### PR TITLE
fix: URL-encode keys in joinPublicUrl and Vercel Blob fast-path

### DIFF
--- a/.changeset/eager-jokes-like.md
+++ b/.changeset/eager-jokes-like.md
@@ -1,5 +1,5 @@
 ---
-"files-sdk": minor
+"files-sdk": patch
 ---
 
 URL-encode keys in `joinPublicUrl` to prevent injection attacks via special characters (`?`, `#`, spaces) in file keys. Uses segment-by-segment encoding to preserve `/` as a path separator.

--- a/.changeset/eager-jokes-like.md
+++ b/.changeset/eager-jokes-like.md
@@ -1,0 +1,5 @@
+---
+"files-sdk": patch
+---
+
+fix: URL-encode keys in joinPublicUrl and Vercel Blob fast-path to prevent URL injection

--- a/.changeset/eager-jokes-like.md
+++ b/.changeset/eager-jokes-like.md
@@ -1,5 +1,7 @@
 ---
-"files-sdk": patch
+"files-sdk": minor
 ---
 
-fix: URL-encode keys in joinPublicUrl and Vercel Blob fast-path to prevent URL injection
+URL-encode keys in `joinPublicUrl` to prevent injection attacks via special characters (`?`, `#`, spaces) in file keys. Uses segment-by-segment encoding to preserve `/` as a path separator.
+
+**Note:** Pass raw keys — this function handles encoding. Pre-encoded keys will be double-encoded (e.g. `%20` becomes `%2520`).

--- a/bun.lock
+++ b/bun.lock
@@ -48,7 +48,7 @@
     },
     "packages/files-sdk": {
       "name": "files-sdk",
-      "version": "1.1.2",
+      "version": "1.2.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.700.0",
         "@aws-sdk/s3-presigned-post": "^3.700.0",

--- a/packages/files-sdk/src/internal/core.ts
+++ b/packages/files-sdk/src/internal/core.ts
@@ -25,12 +25,11 @@ export const DEFAULT_URL_EXPIRES_IN = 3600;
 
 /**
  * Concatenate a public base URL with a key. Tolerates a single trailing
- * slash on the base. The key is embedded literally — the adapter's caller
- * is responsible for URL-encoding any untrusted segments.
+ * slash on the base. The key is URL-encoded so it's safe to embed in a URL path.
  */
 export const joinPublicUrl = (base: string, key: string): string => {
   const trimmed = base.endsWith("/") ? base.slice(0, -1) : base;
-  return `${trimmed}/${key}`;
+  return `${trimmed}/${key.split("/").map(encodeURIComponent).join("/")}`;
 };
 
 export interface UrlStrategyInput {

--- a/packages/files-sdk/src/internal/core.ts
+++ b/packages/files-sdk/src/internal/core.ts
@@ -26,6 +26,8 @@ export const DEFAULT_URL_EXPIRES_IN = 3600;
 /**
  * Concatenate a public base URL with a key. Tolerates a single trailing
  * slash on the base. The key is URL-encoded so it's safe to embed in a URL path.
+ * Pass raw keys — this function handles encoding. Passing a pre-encoded key
+ * causes double-encoding (e.g. `%20` becomes `%2520`).
  */
 export const joinPublicUrl = (base: string, key: string): string => {
   const trimmed = base.endsWith("/") ? base.slice(0, -1) : base;

--- a/packages/files-sdk/src/supabase/index.ts
+++ b/packages/files-sdk/src/supabase/index.ts
@@ -481,7 +481,7 @@ export const supabase = (opts: SupabaseAdapterOptions): SupabaseAdapter => {
         // here so callers get a key that round-trips through the other
         // methods (download/head/delete).
         const fullKey = options?.prefix
-          ? joinPublicUrl(options.prefix, item.name)
+          ? `${options.prefix.replace(/\/$/u, "")}/${item.name}`
           : item.name;
         return createStoredFile(
           {

--- a/packages/files-sdk/src/vercel-blob/index.ts
+++ b/packages/files-sdk/src/vercel-blob/index.ts
@@ -435,7 +435,7 @@ export const vercelBlob = (
       // URL without an API call. `addRandomSuffix: true` makes the actual
       // pathname unknowable in advance, so we have to head() in that case.
       if (storeId && !addRandomSuffix) {
-        return `https://${storeId}.public.blob.vercel-storage.com/${key}`;
+        return `https://${storeId}.public.blob.vercel-storage.com/${key.split("/").map(encodeURIComponent).join("/")}`;
       }
       const result = await headRaw(key);
       if (!result.url) {

--- a/packages/files-sdk/src/vercel-blob/index.ts
+++ b/packages/files-sdk/src/vercel-blob/index.ts
@@ -8,6 +8,7 @@ import type {
   StoredFile,
   UploadResult,
 } from "../index.js";
+import { joinPublicUrl } from "../internal/core.js";
 import { readEnv } from "../internal/env.js";
 import { FilesError } from "../internal/errors.js";
 import type { FilesErrorCode } from "../internal/errors.js";
@@ -435,7 +436,10 @@ export const vercelBlob = (
       // URL without an API call. `addRandomSuffix: true` makes the actual
       // pathname unknowable in advance, so we have to head() in that case.
       if (storeId && !addRandomSuffix) {
-        return `https://${storeId}.public.blob.vercel-storage.com/${key.split("/").map(encodeURIComponent).join("/")}`;
+        return joinPublicUrl(
+          `https://${storeId}.public.blob.vercel-storage.com`,
+          key
+        );
       }
       const result = await headRaw(key);
       if (!result.url) {

--- a/packages/files-sdk/test/s3.test.ts
+++ b/packages/files-sdk/test/s3.test.ts
@@ -204,6 +204,17 @@ describe("s3 adapter", () => {
     expect(await adapter.url("a.txt")).toBe("https://cdn.example.com/a.txt");
   });
 
+  test("url() URL-encodes special characters in the key but preserves / as path separator", async () => {
+    const adapter = s3({
+      bucket: "b",
+      credentials: { accessKeyId: "AKID", secretAccessKey: "SECRET" },
+      publicBaseUrl: "https://cdn.example.com",
+      region: "us-east-1",
+    });
+    const url = await adapter.url("foo bar?baz#qux/a&b");
+    expect(url).toBe("https://cdn.example.com/foo%20bar%3Fbaz%23qux/a%26b");
+  });
+
   test("NoSuchKey is mapped to NotFound", async () => {
     s3Mock.on(GetObjectCommand).rejects(
       Object.assign(new Error("nope"), {

--- a/packages/files-sdk/test/supabase.test.ts
+++ b/packages/files-sdk/test/supabase.test.ts
@@ -495,6 +495,18 @@ describe("supabase adapter", () => {
       expect(listCall[1]).toEqual({ limit: 10, offset: 0 });
     });
 
+    test("keys from list prefix join correctly and round-trip through head/download", async () => {
+      const files = new Files({ adapter: makeAdapter() });
+      const out = await files.list({ limit: 10, prefix: "a/" });
+      const [item] = out.items;
+      if (!item) {
+        throw new Error("expected at least one item");
+      }
+      expect(item.key).toBe("a/a/1.txt");
+      await expect(files.head(item.key)).resolves.toBeDefined();
+      await expect(files.download(item.key)).resolves.toBeDefined();
+    });
+
     test("encodes next offset as cursor when page is full", async () => {
       // Two items returned, limit 2 → full page → cursor "2".
       const out = await makeAdapter().list({ limit: 2 });

--- a/packages/files-sdk/test/vercel-blob.test.ts
+++ b/packages/files-sdk/test/vercel-blob.test.ts
@@ -228,6 +228,18 @@ describe("vercel-blob adapter", () => {
     process.env.BLOB_READ_WRITE_TOKEN = "test-token";
   });
 
+  test("url encodes special characters in the key on the storeId fast path", async () => {
+    process.env.BLOB_READ_WRITE_TOKEN = "vercel_blob_rw_abc123store_random";
+    const files = new Files({ adapter: vercelBlob() });
+    headMock.mockClear();
+    const url = await files.url("my file?q#frag");
+    expect(url).toBe(
+      "https://abc123store.public.blob.vercel-storage.com/my%20file%3Fq%23frag"
+    );
+    expect(headMock).not.toHaveBeenCalled();
+    process.env.BLOB_READ_WRITE_TOKEN = "test-token";
+  });
+
   test("url falls back to head() when token format is unfamiliar (e.g. version segment added)", async () => {
     // Hypothetical future token shape with a version prefix segment after
     // `vercel_blob_rw_`. Old code naively grabbed split('_')[3] and would


### PR DESCRIPTION
## Description
URL-encode each path segment of the file key in joinPublicUrl and the Vercel Blob fast-path to prevent URL injection attacks via special characters (?, #, spaces) in file keys. Uses segment-by-segment encoding to preserve / as a path separator.
## Related Issues
N/A
## Checklist
- [x] I've reviewed my code
- [x] I've written tests
- [x] I've generated a change set file
- [ ] I've updated the docs, if necessary