### PR TITLE
feat: add unlink alias to Files API

### DIFF
--- a/apps/web/components/sections/api-reference.tsx
+++ b/apps/web/components/sections/api-reference.tsx
@@ -21,6 +21,9 @@ const HEAD_EXAMPLE = `const info = await files.head("avatars/abc.png");
 
 const DELETE_EXAMPLE = `await files.delete("avatars/abc.png");`;
 
+const UNLINK_EXAMPLE = `await files.unlink("avatars/abc.png");
+// exact alias of files.delete("avatars/abc.png")`;
+
 const COPY_EXAMPLE = `await files.copy("avatars/abc.png", "avatars/abc.bak.png");`;
 
 const LIST_EXAMPLE = `const { items, cursor } = await files.list({
@@ -165,9 +168,23 @@ export const ApiReference = () => (
         Removes an object. No-op friendly: a missing key resolves successfully
         on providers that treat delete as idempotent, and throws{" "}
         <code>FilesError</code> with <code>code: "NotFound"</code> on ones that
-        don't.
+        don't. If you prefer filesystem-style naming,{" "}
+        <code>files.unlink(key)</code> is an exact alias.
       </p>
       <CodeBlock code={DELETE_EXAMPLE} lang="ts" />
+    </section>
+
+    <section>
+      <Heading as="h3" id="files-unlink">
+        files.unlink(key)
+      </Heading>
+      <p>
+        Exact alias of <code>files.delete(key)</code>. Exists for callers coming
+        from Node.js / POSIX filesystem APIs. Adapters do not implement a
+        separate <code>unlink</code> method; the alias lives on the public{" "}
+        <code>Files</code> wrapper.
+      </p>
+      <CodeBlock code={UNLINK_EXAMPLE} lang="ts" />
     </section>
 
     <section>

--- a/packages/files-sdk/README.md
+++ b/packages/files-sdk/README.md
@@ -24,12 +24,25 @@ const got = await files.download("avatars/abc.png");
 
 Swap the adapter import (`files-sdk/r2`, `files-sdk/gcs`, `files-sdk/azure`, …) and the rest of your code stays the same.
 
+```ts
+await files.delete("avatars/abc.png");
+await files.unlink("avatars/abc.png"); // exact alias of delete()
+```
+
 ## What you get
 
-- **One API across providers** — `upload`, `download`, `head`, `delete`, `copy`, `list`, `url`, `signedUploadUrl`. The shape is the same on S3, GCS, Azure, Vercel Blob, the local filesystem, and consumer providers like Dropbox.
+- **One API across providers** — `upload`, `download`, `head`, `delete`, `unlink`, `copy`, `list`, `url`, `signedUploadUrl`. `unlink()` is an alias of `delete()`. The shape is the same on S3, GCS, Azure, Vercel Blob, the local filesystem, and consumer providers like Dropbox.
 - **Web-standard I/O** — bodies are `Blob`, `File`, `ReadableStream`, `Uint8Array`, `ArrayBuffer`, or `string`. No provider-specific types leak into your code.
 - **Escape hatch** — every adapter exposes its native client at `files.raw`, so provider-specific features are one property access away.
 - **Tree-shakeable** — each adapter is a separate entry point. You only bundle what you import.
+
+## Delete vs unlink
+
+`files.unlink(key)` is a convenience alias for `files.delete(key)`.
+
+- Use `delete()` if you want the storage/object-store wording.
+- Use `unlink()` if your codebase already uses filesystem-style naming.
+- Adapter authors do not implement `unlink()`; the alias exists only on the public `Files` wrapper.
 
 ## Adapters
 

--- a/packages/files-sdk/src/index.ts
+++ b/packages/files-sdk/src/index.ts
@@ -150,6 +150,13 @@ export interface Adapter<Raw = unknown> {
    * the body accessors. They are not free.
    */
   head(key: string): Promise<StoredFile>;
+  /**
+   * Remove the object stored at `key`.
+   *
+   * Adapter authors only implement `delete()`. The public `Files` class also
+   * exposes `unlink()` as a convenience alias for callers coming from
+   * filesystem-style APIs.
+   */
   delete(key: string): Promise<void>;
   copy(from: string, to: string): Promise<void>;
   list(opts?: ListOptions): Promise<ListResult>;
@@ -246,9 +253,26 @@ export class Files<A extends Adapter = Adapter> {
     return run(() => this.#adapter.head(key));
   }
 
+  /**
+   * Remove the object stored at `key`.
+   *
+   * This is the canonical delete method on the unified API surface. For
+   * filesystem-style call sites, {@link Files.unlink} is an exact alias.
+   */
   delete(key: string): Promise<void> {
     assertValidKey(key);
     return run(() => this.#adapter.delete(key));
+  }
+
+  /**
+   * Alias of {@link Files.delete}.
+   *
+   * Exists for parity with filesystem-style APIs (`fs.unlink`, POSIX
+   * `unlink(2)`, etc.). Adapters do not implement this method separately;
+   * the alias lives entirely on the public `Files` wrapper.
+   */
+  unlink(key: string): Promise<void> {
+    return this.delete(key);
   }
 
   copy(from: string, to: string): Promise<void> {

--- a/packages/files-sdk/test/files.test.ts
+++ b/packages/files-sdk/test/files.test.ts
@@ -67,6 +67,15 @@ describe("Files class", () => {
     expect(adapter.has("d.txt")).toBe(false);
   });
 
+  test("unlink is an alias of delete", async () => {
+    const adapter = fakeAdapter();
+    const files = new Files({ adapter });
+    await files.upload("u.txt", "x");
+    expect(adapter.has("u.txt")).toBe(true);
+    await files.unlink("u.txt");
+    expect(adapter.has("u.txt")).toBe(false);
+  });
+
   test("copy duplicates an object", async () => {
     const files = new Files({ adapter: fakeAdapter() });
     await files.upload("from.txt", "payload");


### PR DESCRIPTION
## Summary

- add `files.unlink(key)` as an alias of `files.delete(key)` on the public `Files` wrapper
- document the alias in the package README and the web API reference
- add coverage proving `unlink()` removes the same object as `delete()`

## Why

Some callers come from filesystem-style APIs and naturally reach for `unlink()`. This keeps that ergonomics without expanding the adapter contract, since adapters still only implement `delete()`.

## Validation

- `bun test test/files.test.ts` in `packages/files-sdk`
- `bun run types` in `packages/files-sdk`
- `bun test` in `packages/files-sdk`
- pre-commit hook: `bun run check`, `turbo run types`, `turbo run test`, `turbo run build --filter files-sdk`
