### PR TITLE
fix(fs): reject keys ending in .meta.json sidecar suffix

### DIFF
--- a/.changeset/fs-reject-meta-json-suffix.md
+++ b/.changeset/fs-reject-meta-json-suffix.md
@@ -2,4 +2,4 @@
 "files-sdk": patch
 ---
 
-fs adapter: reject keys ending in `.meta.json` — the adapter reserves that suffix for its per-object metadata sidecar, and accepting it as a regular key let a same-root caller silently overwrite, hide, or delete another key's sidecar (flipping the served `Content-Type`, mutating arbitrary `metadata` fields, or stripping the etag).
+fs adapter: reject keys that resolve to a `.meta.json` sidecar path — the adapter reserves that suffix for its per-object metadata sidecar, and accepting it as a regular key let a same-root caller silently overwrite, hide, or delete another key's sidecar (flipping the served `Content-Type`, mutating arbitrary `metadata` fields, or stripping the etag). The check runs on the resolved basename and folds case plus Windows trailing dots/spaces, so re-cased or normalized variants (`x.META.JSON`, `x.meta.json.`, `x.meta.json/`) that alias the sidecar on case-insensitive (APFS/NTFS) or Windows volumes are rejected too.

--- a/.changeset/fs-reject-meta-json-suffix.md
+++ b/.changeset/fs-reject-meta-json-suffix.md
@@ -1,0 +1,5 @@
+---
+"files-sdk": patch
+---
+
+fs adapter: reject keys ending in `.meta.json` — the adapter reserves that suffix for its per-object metadata sidecar, and accepting it as a regular key let a same-root caller silently overwrite, hide, or delete another key's sidecar (flipping the served `Content-Type`, mutating arbitrary `metadata` fields, or stripping the etag).

--- a/packages/files-sdk/src/fs/index.ts
+++ b/packages/files-sdk/src/fs/index.ts
@@ -146,25 +146,31 @@ const sha1Etag = (bytes: Uint8Array): string => {
   return `"${hex.slice(0, ETAG_HEX_LEN)}"`;
 };
 
+// Windows ignores trailing dots and spaces in a path segment, so
+// `x.meta.json.` and `x.meta.json ` open the same file as `x.meta.json`.
+const FS_TRAILING_NOISE = /[. ]+$/u;
+
+// True when `resolved`'s final segment lands on a reserved sidecar path.
+// We compare the basename the way the filesystem resolves names — folded
+// to lower case for case-insensitive volumes (APFS, NTFS — the macOS /
+// Windows machines this dev-oriented adapter mostly runs on) and with
+// trailing dots/spaces stripped for Windows — so re-cased or dot-padded
+// variants like `x.META.JSON` or `x.meta.json.` can't slip a body onto
+// another key's sidecar. Operating on the resolved basename (not the raw
+// key) also folds away `..` and trailing-slash dodges like `x.meta.json/`.
+const aliasesSidecarPath = (resolved: string): boolean =>
+  path
+    .basename(resolved)
+    .replace(FS_TRAILING_NOISE, "")
+    .toLowerCase()
+    .endsWith(SIDECAR_SUFFIX);
+
 // `path.resolve` collapses `..` segments, so a key like
 // `../../etc/passwd` resolves outside `root`. We compare the resolved path
 // against `root` to reject those before any fs operation runs. Without
 // this check, `download("../../../etc/passwd")` would happily exfiltrate
 // from the host filesystem.
 const resolveKeyPath = (root: string, key: string): string => {
-  // The adapter stores per-object metadata in a sidecar at
-  // `${bodyPath}${SIDECAR_SUFFIX}`. A key ending in `SIDECAR_SUFFIX`
-  // therefore resolves to the sidecar path of another key — uploading it
-  // silently rewrites that key's stored contentType / etag / metadata,
-  // deleting it wipes them, and the key itself never surfaces in
-  // `list()` because `walk()` filters the suffix. Reject the suffix at
-  // the boundary so the namespace stays unambiguous.
-  if (key.endsWith(SIDECAR_SUFFIX)) {
-    throw new FilesError(
-      "Provider",
-      `fs: keys ending in ${SIDECAR_SUFFIX} are reserved for adapter sidecars: ${JSON.stringify(key)}`
-    );
-  }
   const resolved = path.resolve(root, key);
   const rootWithSep = root.endsWith(path.sep) ? root : root + path.sep;
   if (resolved !== root && !resolved.startsWith(rootWithSep)) {
@@ -179,6 +185,18 @@ const resolveKeyPath = (root: string, key: string): string => {
     throw new FilesError(
       "Provider",
       "fs: key resolves to the adapter root directory"
+    );
+  }
+  // The adapter stores per-object metadata in a sidecar at
+  // `${bodyPath}${SIDECAR_SUFFIX}`. A key whose body path lands on another
+  // key's sidecar lets a same-root caller silently rewrite that key's
+  // stored contentType / etag / metadata (upload), wipe them (delete), or
+  // hide bytes from `list()` (walk() filters the suffix). Reject anything
+  // that resolves to a sidecar path so the namespace stays unambiguous.
+  if (aliasesSidecarPath(resolved)) {
+    throw new FilesError(
+      "Provider",
+      `fs: keys ending in ${SIDECAR_SUFFIX} are reserved for adapter sidecars: ${JSON.stringify(key)}`
     );
   }
   return resolved;

--- a/packages/files-sdk/src/fs/index.ts
+++ b/packages/files-sdk/src/fs/index.ts
@@ -152,6 +152,19 @@ const sha1Etag = (bytes: Uint8Array): string => {
 // this check, `download("../../../etc/passwd")` would happily exfiltrate
 // from the host filesystem.
 const resolveKeyPath = (root: string, key: string): string => {
+  // The adapter stores per-object metadata in a sidecar at
+  // `${bodyPath}${SIDECAR_SUFFIX}`. A key ending in `SIDECAR_SUFFIX`
+  // therefore resolves to the sidecar path of another key — uploading it
+  // silently rewrites that key's stored contentType / etag / metadata,
+  // deleting it wipes them, and the key itself never surfaces in
+  // `list()` because `walk()` filters the suffix. Reject the suffix at
+  // the boundary so the namespace stays unambiguous.
+  if (key.endsWith(SIDECAR_SUFFIX)) {
+    throw new FilesError(
+      "Provider",
+      `fs: keys ending in ${SIDECAR_SUFFIX} are reserved for adapter sidecars: ${JSON.stringify(key)}`
+    );
+  }
   const resolved = path.resolve(root, key);
   const rootWithSep = root.endsWith(path.sep) ? root : root + path.sep;
   if (resolved !== root && !resolved.startsWith(rootWithSep)) {

--- a/packages/files-sdk/test/fs.test.ts
+++ b/packages/files-sdk/test/fs.test.ts
@@ -506,9 +506,9 @@ describe("fs adapter", () => {
       // would be hidden from list() because walk() filters .meta.json,
       // and delete("x.txt.meta.json") would wipe x.txt's sidecar. Reject
       // at the boundary instead.
-      await expect(
-        files.upload("x.txt.meta.json", "x")
-      ).rejects.toMatchObject({ code: "Provider" });
+      await expect(files.upload("x.txt.meta.json", "x")).rejects.toMatchObject({
+        code: "Provider",
+      });
       await expect(files.download("x.txt.meta.json")).rejects.toMatchObject({
         code: "Provider",
       });

--- a/packages/files-sdk/test/fs.test.ts
+++ b/packages/files-sdk/test/fs.test.ts
@@ -497,6 +497,51 @@ describe("fs adapter", () => {
         code: "Provider",
       });
     });
+
+    test("rejects keys ending in the reserved sidecar suffix", async () => {
+      const root = await makeRoot();
+      const files = new Files({ adapter: fsAdapter({ root }) });
+      // Otherwise upload("x.txt.meta.json", ...) would silently overwrite the
+      // sidecar of "x.txt" (its contentType / etag / metadata), the key
+      // would be hidden from list() because walk() filters .meta.json,
+      // and delete("x.txt.meta.json") would wipe x.txt's sidecar. Reject
+      // at the boundary instead.
+      await expect(
+        files.upload("x.txt.meta.json", "x")
+      ).rejects.toMatchObject({ code: "Provider" });
+      await expect(files.download("x.txt.meta.json")).rejects.toMatchObject({
+        code: "Provider",
+      });
+      await expect(files.head("x.txt.meta.json")).rejects.toMatchObject({
+        code: "Provider",
+      });
+      await expect(files.exists("x.txt.meta.json")).rejects.toMatchObject({
+        code: "Provider",
+      });
+      await expect(files.delete("x.txt.meta.json")).rejects.toMatchObject({
+        code: "Provider",
+      });
+      await expect(
+        files.copy("a.txt", "a.txt.meta.json")
+      ).rejects.toMatchObject({ code: "Provider" });
+      await expect(files.url("x.txt.meta.json")).rejects.toMatchObject({
+        code: "Provider",
+      });
+      await expect(
+        files.signedUploadUrl("x.txt.meta.json", { expiresIn: 60 })
+      ).rejects.toMatchObject({ code: "Provider" });
+    });
+
+    test("keys with .meta.json elsewhere in the path are allowed", async () => {
+      // The collision is at the sidecar path only — a key whose final
+      // segment is not `*.meta.json` is safe. e.g. a folder named
+      // `drafts.meta.json/` containing `note.txt` round-trips fine.
+      const root = await makeRoot();
+      const files = new Files({ adapter: fsAdapter({ root }) });
+      await files.upload("drafts.meta.json/note.txt", "hi");
+      const got = await files.download("drafts.meta.json/note.txt");
+      expect(await got.text()).toBe("hi");
+    });
   });
 
   describe("url", () => {

--- a/packages/files-sdk/test/fs.test.ts
+++ b/packages/files-sdk/test/fs.test.ts
@@ -532,6 +532,33 @@ describe("fs adapter", () => {
       ).rejects.toMatchObject({ code: "Provider" });
     });
 
+    test("rejects sidecar-suffix variants that alias on the host filesystem", async () => {
+      const root = await makeRoot();
+      const files = new Files({ adapter: fsAdapter({ root }) });
+      // A literal `endsWith(".meta.json")` check leaves the namespace open
+      // on the platforms this dev adapter mostly runs on: case-insensitive
+      // volumes (APFS/NTFS) alias `x.txt.META.JSON` onto `x.txt.meta.json`,
+      // Windows strips trailing dots/spaces (`x.txt.meta.json.`), and
+      // path.resolve folds a trailing slash (`x.txt.meta.json/`) back onto
+      // the sidecar. All of these would let an upload overwrite another
+      // key's sidecar, so every variant must reject.
+      const variants = [
+        "x.txt.META.JSON",
+        "x.txt.Meta.Json",
+        "x.txt.meta.json.",
+        "x.txt.meta.json ",
+        "x.txt.meta.json/",
+      ];
+      for (const variant of variants) {
+        await expect(files.upload(variant, "x")).rejects.toMatchObject({
+          code: "Provider",
+        });
+        await expect(files.delete(variant)).rejects.toMatchObject({
+          code: "Provider",
+        });
+      }
+    });
+
     test("keys with .meta.json elsewhere in the path are allowed", async () => {
       // The collision is at the sidecar path only — a key whose final
       // segment is not `*.meta.json` is safe. e.g. a folder named


### PR DESCRIPTION
## Summary

The `fs` adapter stores per-object metadata in a sibling file at `${bodyPath}.meta.json`. Keys are validated for non-emptiness, NUL bytes, and root escape — but not against the sidecar suffix itself. A caller able to pick keys under the same root can upload a key shaped like another key's sidecar and silently rewrite that key's stored `contentType`, `etag`, and `metadata`.

## Impact

For a victim key `K` under the adapter root, an attacker key `K.meta.json` provides three primitives:

1. **Sidecar overwrite.** `upload("K.meta.json", attackerJSON)` overwrites `K`'s sidecar with attacker-controlled JSON. `download("K")` / `head("K")` / `list({ prefix: ... })` then return the attacker's `contentType`, `etag`, and `metadata` fields. Flipping `contentType` from `text/plain` to `text/html` upgrades any `urlBaseUrl` deployment that trusts the adapter's reported type into a stored-XSS path — the same class the `responseContentDisposition` override in `Adapter.url` already exists to defend.
2. **Hidden upload.** `walk()` filters `.meta.json` files out of `list()`, so the attacker's bytes never appear in enumeration. Useful for squatting / anti-forensics under another key's name.
3. **Sidecar wipe.** `delete("K.meta.json")` removes both `K.meta.json` (= K's sidecar) and `K.meta.json.meta.json`. `K`'s recorded contentType collapses to `application/octet-stream` on next `head()` and the etag goes `undefined`.

The `assertValidKey` in `packages/files-sdk/src/index.ts` is intentionally minimal and cross-adapter, so the fix lives in the fs adapter where the suffix is reserved.

## Location

`packages/files-sdk/src/fs/index.ts` — `resolveKeyPath` (called from every key-touching entry point in the fs adapter: `upload`, `download`, `head`, `exists`, `delete`, `copy`, `url`, `signedUploadUrl`).

## Fix

Add a single guard at the top of `resolveKeyPath`:

```ts
if (key.endsWith(SIDECAR_SUFFIX)) {
  throw new FilesError(
    "Provider",
    `fs: keys ending in ${SIDECAR_SUFFIX} are reserved for adapter sidecars: ${JSON.stringify(key)}`
  );
}
```

The check is syntactic, the same shape as the existing `!== root` and `startsWith(root)` checks, and applies uniformly because every fs adapter method calls `resolveKeyPath` before touching the filesystem. Keys whose final segment isn't a sidecar collision (e.g. `drafts.meta.json/note.txt`) round-trip fine — the rule is "ends in `.meta.json`," not "contains."

## Detected by

Aeon (manual review prompted by reading `fs/index.ts` after semgrep + trufflehog + osv-scanner returned no SAST/secret hits on the package).

- Severity: medium
- CWE-73 (External Control of File Name) / CWE-345 (insufficient verification of data authenticity)
- No CVE/GHSA yet

## Verification

- New tests added in `packages/files-sdk/test/fs.test.ts` under `describe("path safety")`:
  - All eight key-taking entry points reject `x.txt.meta.json` with `code: "Provider"`.
  - `drafts.meta.json/note.txt` (suffix mid-path) still round-trips.
- Could not run the full `bun test` suite from this scanning environment (no `bun` in the sandbox). Maintainer CI will exercise.
- Independent harness reproduced both pre-fix exploit and post-fix rejection against the in-tree source: 9 entry points rejected, benign + mid-path keys preserved.

## Notes

- Existing on-disk data with `.meta.json` keys will become unreadable through the adapter after this lands. None of the existing tests, fixtures, or examples relied on a key ending in `.meta.json` (the only test references to that string are intentional sidecar-resilience tests that write the sidecar through raw `fsp.writeFile`, not through `files.upload`). Patch release.
- Sidecar reading already validates field types before trusting the JSON, so non-malicious-but-malformed sidecars still gracefully fall back to defaults — that behavior is preserved.

---
Filed by [Aeon](https://github.com/aaronjmars/aeon-aaron). Happy to adjust the rejection message or move the guard if you prefer a different layering.
