### PR TITLE
docs(adapters): add per-adapter AGENTS.md for storage adapters

### DIFF
--- a/packages/files-sdk/src/akamai/AGENTS.md
+++ b/packages/files-sdk/src/akamai/AGENTS.md
@@ -1,0 +1,220 @@
+# AGENTS.md — `files-sdk/akamai`
+
+Guidance for coding agents working on the Akamai adapter. The unified
+`Files` contract every adapter implements lives in
+[`../index.ts`](../index.ts) — read it first so the wording here
+(`upload`, `download`, `url`, `signedUploadUrl`, …) maps onto the
+shared method shapes. The user-facing intro is in
+[README.md](../../README.md); the agent-oriented integration guide is
+in [SKILL.md](../../../../skills/files-sdk/SKILL.md).
+
+`akamai` is the adapter for Akamai Cloud Object Storage — the
+S3-compatible service that used to ship as Linode Object Storage before
+the Akamai acquisition. It is a thin wrapper around
+[`s3()`](../s3/index.ts) that hands the inner adapter a region-derived
+endpoint, a relabelled error message, and otherwise lets it do the work.
+
+## Overview
+
+What the adapter actually owns:
+
+- Defaulting the endpoint to `https://${region}.linodeobjects.com`.
+  The `linodeobjects.com` domain is unchanged from the Linode era —
+  only the product branding moved to Akamai, so the "wrong-looking"
+  hostname is correct.
+- Treating region/cluster codes (`us-iad-1`, `nl-ams-1`, `fr-par-1`,
+  `gb-lon-1`, `jp-osa-1`, plus the older `us-east-1` /
+  `eu-central-1` / `ap-south-1` clusters) as the single source of
+  truth for both the endpoint host and the SigV4 signing region.
+- Reading credentials from `AKAMAI_ACCESS_KEY_ID` /
+  `AKAMAI_SECRET_ACCESS_KEY` (not the AWS chain — that would silently
+  pick up the wrong account on a dev laptop).
+- Relabelling the fallback `Provider`-code error message to
+  `"Akamai error"` so users don't see `"S3 error"` from a stack they
+  never imported S3 into.
+
+Everything else — the S3 commands, presigned GET URLs, presigned POST
+forms, stream sizing, the `NotFound`/`Unauthorized`/`Conflict`/
+`Provider` mapping — is inherited verbatim from the S3 adapter.
+
+## Directory layout
+
+```
+packages/files-sdk/src/akamai/
+├── index.ts        # AkamaiAdapterOptions + akamai() factory
+├── AGENTS.md       # this file
+└── CLAUDE.md       # @AGENTS.md pointer
+```
+
+Tests live at
+[`../../test/akamai.test.ts`](../../test/akamai.test.ts); the
+user-facing doc page is
+[`../../../../apps/web/content/docs/adapters/akamai.mdx`](../../../../apps/web/content/docs/adapters/akamai.mdx).
+
+## Build, test, typecheck
+
+```bash
+bun test test/akamai.test.ts
+bun test
+bun run build
+bun run types
+```
+
+Run from `packages/files-sdk/`. First is the iteration loop; the rest are what CI runs.
+
+## Public surface
+
+Exports from [`index.ts`](index.ts):
+
+- `akamai(opts: AkamaiAdapterOptions): AkamaiAdapter` — the factory.
+  Returns an `Adapter<S3Client>` whose `name` is `"akamai"` and whose
+  `raw` is the underlying `@aws-sdk/client-s3` `S3Client`. Every other
+  method is forwarded from the inner `s3()` adapter.
+- `AkamaiAdapterOptions` — the constructor options. Rendered into
+  [`akamai.mdx`](../../../../apps/web/content/docs/adapters/akamai.mdx)
+  via `<AutoTypeTable>`, so keep the JSDoc useful — it is the docs.
+- `AkamaiAdapter` — `Adapter<S3Client>` re-exported as a named alias.
+
+The catalog entry that drives the docs landing and CLI lives in
+[`../providers/index.ts`](../providers/index.ts) under
+`slug: "akamai"`. Update it when env vars, peer deps, or the one-line
+description change.
+
+## Authentication / configuration
+
+Required:
+
+- `bucket` — Akamai bucket name. Scopes every operation.
+- `region` — Akamai cluster code (e.g. `"us-iad-1"`). Drives the
+  endpoint host **and** the SigV4 region. No env fallback — missing
+  `region` throws `FilesError("Provider", …)` at construction.
+- `accessKeyId` + `secretAccessKey` — option-first, env-fallback to
+  `AKAMAI_ACCESS_KEY_ID` / `AKAMAI_SECRET_ACCESS_KEY` via
+  [`readEnv`](../internal/env.ts) (safe on Workers without
+  `nodejs_compat`). If both option and env are absent, the factory
+  throws.
+
+Optional:
+
+- `endpoint` — override the region-derived host (staging, regional
+  CNAME).
+- `forcePathStyle` — defaults to the AWS SDK default (`false`).
+  Virtual-hosted is canonical for Akamai; leave it alone unless
+  tooling requires path-style.
+- `publicBaseUrl` — CDN/public origin for `url(key)`. When set,
+  unsigned `${publicBaseUrl}/${key}` is returned instead of a
+  presigned GET. The natural value for a public-ACL bucket is
+  `https://${bucket}.${region}.linodeobjects.com`.
+- `defaultUrlExpiresIn` — default presigned-GET expiry in seconds.
+  Defaults to 3600 via `DEFAULT_URL_EXPIRES_IN` in
+  [`../internal/core.ts`](../internal/core.ts).
+
+## Operation map
+
+Every method on the returned adapter is forwarded from
+[`s3()`](../s3/index.ts). The wrapper only:
+
+1. Builds `endpoint` from `region` when absent.
+2. Threads `defaultProviderMessage: "Akamai error"` into the inner
+   adapter so [`mapS3Error`](../s3/index.ts) emits that label
+   instead of `"S3 error"` for thrown values with no message.
+3. Overrides `name` from `"s3"` to `"akamai"` for telemetry and
+   adapter-routing.
+
+For per-method semantics — `upload` body normalization, the
+`download` buffer-vs-stream branch, `head`'s lazy GET on the returned
+`StoredFile`, `deleteMany`'s 1000-key chunking, `signedUploadUrl`'s
+POST-with-`content-length-range` vs PUT precedence, and the
+`existsByProbe` `HeadObject` fast path — read
+[`../s3/AGENTS.md`](../s3/AGENTS.md).
+
+## URL behavior
+
+`url(key, opts?)` defers to the inner S3 adapter and inherits its
+[`resolveUrlStrategy`](../internal/core.ts) precedence:
+
+- `publicBaseUrl` set, no `responseContentDisposition` → unsigned
+  `${publicBaseUrl}/${key}`, no expiry.
+- Otherwise → presigned `GetObject` with
+  `expiresIn ?? defaultUrlExpiresIn ?? 3600` seconds.
+
+`responseContentDisposition` always forces signing, even when
+`publicBaseUrl` is configured. A permanent CDN URL has no signature to
+bind the override to, and dropping it silently would be a stored-XSS
+regression on user-uploaded HTML/SVG.
+
+`signedUploadUrl` follows the same S3 rules: passing `maxSize` returns
+a presigned `POST` form (with `content-length-range`), omitting it
+returns a presigned `PUT` with no server-side size limit. Always pass
+`maxSize` for browser uploads.
+
+## Provider quirks worth remembering
+
+- **Linode-era hostnames are correct.** Endpoints are
+  `https://${region}.linodeobjects.com`; the marketing rename did not
+  move the domain. Don't rewrite hosts to anything Akamai-branded.
+- **Region is the endpoint.** Unlike AWS, the region string isn't just
+  metadata — it is the literal subdomain. Pass the exact cluster code
+  from the Akamai console.
+- **No `AKAMAI_REGION` / `AKAMAI_BUCKET` / `AKAMAI_ENDPOINT` env
+  fallbacks.** Only credentials are env-driven; bucket, region, and
+  the optional endpoint are constructor-only.
+- **Access keys are scoped per cluster** in the Akamai Cloud Manager
+  under Object Storage → Access Keys.
+- **Errors carry the `"Akamai error"` label** when the underlying SDK
+  error has no message — see the relabel test for the exact wiring.
+
+## Testing approach
+
+Unit tests in [`../../test/akamai.test.ts`](../../test/akamai.test.ts)
+cover endpoint derivation, the virtual-hosted default, region/endpoint
+overrides, explicit `forcePathStyle: true`, missing-region and
+missing-credentials throwing at construction, the
+`AKAMAI_ACCESS_KEY_ID` / `AKAMAI_SECRET_ACCESS_KEY` env fallback,
+`url()` returning a presigned GET by default and the `publicBaseUrl`
+short-circuit, delegation to the inner S3 client via
+`aws-sdk-client-mock` for `upload` and `exists`, and the `mapS3Error`
+relabel that turns the default `"S3 error"` Provider fallback into
+`"Akamai error"`.
+
+When adding behavior, extend these tests instead of fabricating new mock setup.
+
+## Coding conventions
+
+- Match the existing factory shape: option-first, env-fallback,
+  explicit `FilesError("Provider", …)` for misconfiguration at
+  construction.
+- Conditional-spread option forwarding (`...(opts.x !== undefined && {
+  x: opts.x })`) so the inner `s3()` adapter sees only the keys the
+  caller actually set — matters for booleans like `forcePathStyle`
+  where `undefined` and `false` mean different things to the SDK.
+- Don't reach for `process.env` directly — go through
+  [`readEnv`](../internal/env.ts) so the adapter stays usable on
+  Cloudflare Workers without `nodejs_compat`.
+- Keep the wrapper thin. Behavior shared with the rest of the S3
+  family (R2 HTTP, MinIO, DigitalOcean Spaces, Storj, Hetzner,
+  Backblaze B2, Wasabi, Tigris, …) belongs in
+  [`../s3/index.ts`](../s3/index.ts) or
+  [`../internal/core.ts`](../internal/core.ts), not here.
+- No emojis in source, tests, or docs.
+
+## Releases
+
+Ships with the monorepo; see [README.md](../../README.md). Adapter
+changes need a changeset noting the behavioral delta. Docs-only
+changes (this file, MDX edits) don't.
+
+## Where to look next
+
+- User-facing docs:
+  [`../../../../apps/web/content/docs/adapters/akamai.mdx`](../../../../apps/web/content/docs/adapters/akamai.mdx)
+- Inner adapter wrapped here: [`../s3/index.ts`](../s3/index.ts) (and
+  its AGENTS.md once added)
+- Unified contract: [`../index.ts`](../index.ts)
+- Shared helpers (URL strategy, body normalization, error mapper
+  factory): [`../internal/core.ts`](../internal/core.ts)
+- Error type: [`../internal/errors.ts`](../internal/errors.ts)
+- Env-fallback helper: [`../internal/env.ts`](../internal/env.ts)
+- Catalog entry: [`../providers/index.ts`](../providers/index.ts)
+  (search `slug: "akamai"`)
+- Tests: [`../../test/akamai.test.ts`](../../test/akamai.test.ts)

--- a/packages/files-sdk/src/akamai/CLAUDE.md
+++ b/packages/files-sdk/src/akamai/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/packages/files-sdk/src/alibaba/AGENTS.md
+++ b/packages/files-sdk/src/alibaba/AGENTS.md
@@ -1,0 +1,224 @@
+# AGENTS.md — `files-sdk/alibaba`
+
+Guidance for coding agents working on the `alibaba` adapter. The
+unified `Adapter<Raw>` contract — call shapes, `FilesError`,
+`UrlOptions`, `SignUploadOptions`, body normalization — lives in
+[`../index.ts`](../index.ts); this file documents only the
+alibaba-specific deviations. `alibaba()` wraps [`s3()`](../s3/index.ts)
+for [Alibaba Cloud OSS](https://www.alibabacloud.com/product/oss)'s
+S3-compatible API, so operation semantics, error mapping, and presign
+mechanics live in [`../s3/AGENTS.md`](../s3/AGENTS.md) — read it for
+the primitives. Cross-refs: [`README.md`](../../README.md),
+[`SKILL.md`](../../../../skills/files-sdk/SKILL.md).
+
+## Overview
+
+A thin shim. `alibaba()` calls `s3()` with an OSS endpoint, Alibaba
+credentials, and a `defaultProviderMessage` of `"Alibaba Cloud error"`
+so callers never see `"S3 error"` from an Alibaba-typed adapter. No
+per-method code lives here — every operation is forwarded by spread.
+The only alibaba-specific knobs are endpoint derivation from the
+region, the credential env-var pair, and the error-message relabel.
+`raw` is the underlying `@aws-sdk/client-s3` `S3Client`, so any OSS
+feature the AWS SDK can drive (multipart, lifecycle, SSE headers,
+image processing) is one property access away.
+
+## Directory layout
+
+```text
+packages/files-sdk/src/alibaba/
+├── index.ts         # alibaba() factory + AlibabaAdapterOptions
+├── AGENTS.md        # this file
+└── CLAUDE.md        # @AGENTS.md — Claude-Code re-export
+```
+
+Tests at [`../../test/alibaba.test.ts`](../../test/alibaba.test.ts);
+user docs at
+[`../../../../apps/web/content/docs/adapters/alibaba.mdx`](../../../../apps/web/content/docs/adapters/alibaba.mdx).
+
+## Build, test, typecheck
+
+Run from `packages/files-sdk`:
+
+```bash
+bun test test/alibaba.test.ts   # adapter unit tests only
+bun test                        # full SDK suite
+bun run build                   # tsup → dist/, incl. dist/alibaba/
+bun run types                   # tsgo --noEmit
+```
+
+The `alibaba` subpath is enumerated in
+[`../../package.json`](../../package.json)'s `exports` map — keep it
+in sync if the file layout changes.
+
+## Public surface
+
+Exports from [`index.ts`](./index.ts):
+
+- `alibaba(opts: AlibabaAdapterOptions): AlibabaAdapter` — primary
+  factory. The adapter's `name` is `"alibaba"`, overriding `"s3"`.
+- `AlibabaAdapter` — type alias for `Adapter<S3Client>`; `raw` is the
+  underlying AWS SDK client.
+- `AlibabaAdapterOptions` — config interface. JSDoc on every field is
+  the source of truth; the docs MDX renders it via `AutoTypeTable`.
+
+## Authentication / configuration
+
+Required:
+
+- `bucket` — string. **No env fallback**; pass it explicitly.
+- `region` — OSS region code (`cn-hangzhou`, `cn-shanghai`,
+  `cn-beijing`, `ap-southeast-1`, `us-east-1`, `eu-central-1`, …).
+  **No env fallback** — missing region throws
+  `FilesError("Provider", …)` at construction. Pass the **bare** code
+  (`"cn-hangzhou"`), not the `oss-`-prefixed DNS form: the same value
+  doubles as the SigV4 region, and `"oss-cn-hangzhou"` produces
+  signatures OSS rejects.
+- Credentials — `accessKeyId` + `secretAccessKey`, passed in or
+  sourced from `ALIBABA_ACCESS_KEY_ID` / `ALIBABA_ACCESS_KEY_SECRET`.
+  Missing either throws `FilesError("Provider", …)`. Generate the
+  AccessKey pair in the Alibaba Cloud console under *RAM → Users* —
+  the S3-compatible surface has no IAM-role equivalent.
+
+Optional:
+
+- `endpoint` — overrides the derived
+  `https://oss-${region}.aliyuncs.com`. Use for VPC-internal endpoints
+  (`oss-${region}-internal.aliyuncs.com`), acceleration endpoints, or
+  test doubles.
+- `forcePathStyle` — defaults to `false`. Virtual-hosted is canonical
+  for OSS; flip only for proxies that demand path-style.
+- `publicBaseUrl` — origin used by `url()` when set; skips signing.
+  Natural value is `https://${bucket}.oss-${region}.aliyuncs.com`, or
+  a custom domain CNAME'd to the bucket.
+- `defaultUrlExpiresIn` — default presigned-URL expiry in seconds.
+  Falls back to `DEFAULT_URL_EXPIRES_IN` (3600) from
+  [`../internal/core.ts`](../internal/core.ts).
+
+No `ALIBABA_REGION` / `ALIBABA_BUCKET` / `ALIBABA_ENDPOINT` env
+fallback — the provider catalog at
+[`../providers/index.ts`](../providers/index.ts) declares only the two
+credential env vars. Env lookups go through
+[`readEnv`](../internal/env.ts) so the adapter stays safe on runtimes
+without `process` (Cloudflare Workers without `nodejs_compat`).
+
+## Operation map
+
+`alibaba()` calls `s3()` with the resolved config and spreads the
+returned adapter, overriding only `name`. `upload`, `download`,
+`head`, `exists`, `delete`, `deleteMany`, `copy`, `list`, `url`, and
+`signedUploadUrl` all live in [`../s3/index.ts`](../s3/index.ts) and
+are inherited unchanged — `deleteMany`'s 1000-key chunking,
+`signedUploadUrl`'s PUT-vs-presigned-POST split on `maxSize`,
+`exists` 404-as-`false`, and the stream-upload follow-up `head()` for
+authoritative size / `lastModified` all carry over. Errors flow
+through `mapS3Error` with the Alibaba fallback table — `Provider`
+messages read `"Alibaba Cloud error"`, and the server-side message
+wins when present.
+
+## URL behavior
+
+`url(key, opts?)` follows the standard signing-adapter rules:
+
+- Default: presigned `GetObject`, expiring after
+  `opts.expiresIn ?? defaultUrlExpiresIn` seconds, against the
+  configured (or derived) OSS endpoint with the bucket subdomain
+  prepended.
+- With `publicBaseUrl`: returns `${publicBaseUrl}/${key}` unsigned via
+  `joinPublicUrl` (URL-encodes path segments).
+- With `opts.responseContentDisposition`: always signs, even when
+  `publicBaseUrl` is set — a permanent URL has no signature in which
+  to bind the override, and silently dropping it would be a stored-XSS
+  regression on user-uploaded HTML/SVG. See `resolveUrlStrategy` in
+  [`../internal/core.ts`](../internal/core.ts).
+
+## Provider quirks worth remembering
+
+- **Region is part of the hostname *and* the signature.** Buckets
+  live in exactly one region; the endpoint host
+  (`oss-<region>.aliyuncs.com`) and the SigV4 region must both match
+  where the bucket was created. A mismatch surfaces as a `301`/`400`
+  from OSS with a frequently-empty body — re-check the bucket's
+  region first when signatures suddenly stop working.
+- **Public vs internal endpoints.** Intra-region ECS/VPC traffic
+  should use `oss-<region>-internal.aliyuncs.com` (free, lower
+  latency, unreachable from outside). The adapter does not auto-
+  switch — set `endpoint` explicitly when running in Alibaba Cloud.
+- **Region naming overlaps with AWS; endpoints don't.** A bucket in
+  `us-east-1` lives at `oss-us-east-1.aliyuncs.com`, not on the AWS
+  origin. Treat the region string as opaque OSS shorthand.
+- **Env-var spelling is `_ACCESS_KEY_SECRET`**, not the
+  `_SECRET_ACCESS_KEY` suffix the AWS-derived adapters use. The
+  adapter follows Alibaba's own naming so users can paste from
+  Alibaba docs — don't "fix" without a coordinated breaking change.
+- **Custom domains need both halves**: bound to the bucket in the OSS
+  console *and* a matching DNS CNAME, before `publicBaseUrl` resolves.
+- **OSS-only features** (storage-class transitions, image processing,
+  symlinks, PUT callbacks) live on the AWS SDK client — reach for
+  `files.raw`; none ride on the unified surface.
+
+## Testing approach
+
+Unit tests at
+[`../../test/alibaba.test.ts`](../../test/alibaba.test.ts) cover:
+
+- Endpoint derivation from `region` (`cn-hangzhou`, `ap-southeast-1`),
+  default `forcePathStyle: false`, and explicit `endpoint` /
+  `forcePathStyle` overrides reaching the inner `S3Client` config.
+- Missing-region and missing-credential errors at construction.
+- `ALIBABA_ACCESS_KEY_ID` / `ALIBABA_ACCESS_KEY_SECRET` env-var
+  fallbacks (with save/restore around `process.env` mutation).
+- `url()` presign default (`X-Amz-Signature`, `X-Amz-Expires=3600`,
+  OSS hostname) and the `publicBaseUrl` short-circuit.
+- Operation delegation via `aws-sdk-client-mock` — `upload` reaches
+  the underlying client; `exists` returns `false` on a synthetic 404.
+- Error relabeling: `mapS3Error` with the Alibaba messages table
+  returns `"Alibaba Cloud error"` for `Provider`.
+
+Add fixtures here when behavior depends on alibaba-specific config;
+shared S3 semantics belong in
+[`../../test/s3.test.ts`](../../test/s3.test.ts).
+
+## Coding conventions
+
+- Named exports only — `alibaba`, `AlibabaAdapter`,
+  `AlibabaAdapterOptions`.
+- Construction-time errors use
+  [`FilesError("Provider", …)`](../internal/errors.ts); operation
+  errors are the inner S3 adapter's responsibility — don't try-catch
+  here.
+- Read env via [`readEnv`](../internal/env.ts); direct `process.env`
+  breaks Cloudflare Workers without `nodejs_compat`.
+- Forward optional knobs with
+  `...(opts.x !== undefined && { x: opts.x })` so unset values fall
+  through to AWS-SDK defaults; `publicBaseUrl` is gated on truthiness
+  — an empty string is never a valid base URL.
+- Spread the inner adapter, then override only `name` — preserves any
+  future `Adapter` additions `s3()` picks up automatically.
+- Top-level regex literals only.
+
+## Releases
+
+Ships with the monorepo from
+[`../../package.json`](../../package.json). Behavioral changes bump
+the `files-sdk` version and need a
+[`../../CHANGELOG.md`](../../CHANGELOG.md) entry; docs / test-only
+additions don't. The `alibaba` subpath is already in `exports` —
+layout changes inside this directory don't ripple to consumers unless
+`index.ts` moves.
+
+## Where to look next
+
+- Unified contract: [`../index.ts`](../index.ts).
+- Inner S3 adapter: [`../s3/index.ts`](../s3/index.ts) +
+  [`../s3/AGENTS.md`](../s3/AGENTS.md).
+- Shared helpers: [`../internal/core.ts`](../internal/core.ts),
+  [`../internal/errors.ts`](../internal/errors.ts),
+  [`../internal/env.ts`](../internal/env.ts).
+- Provider catalog (`slug: "alibaba"`):
+  [`../providers/index.ts`](../providers/index.ts).
+- User docs:
+  [`../../../../apps/web/content/docs/adapters/alibaba.mdx`](../../../../apps/web/content/docs/adapters/alibaba.mdx).
+- README: [`../../README.md`](../../README.md). SKILL:
+  [`../../../../skills/files-sdk/SKILL.md`](../../../../skills/files-sdk/SKILL.md).
+- Tests: [`../../test/alibaba.test.ts`](../../test/alibaba.test.ts).

--- a/packages/files-sdk/src/alibaba/CLAUDE.md
+++ b/packages/files-sdk/src/alibaba/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/packages/files-sdk/src/appwrite/AGENTS.md
+++ b/packages/files-sdk/src/appwrite/AGENTS.md
@@ -1,0 +1,236 @@
+# AGENTS.md — `files-sdk/appwrite`
+
+Guidance for coding agents working inside the `files-sdk/appwrite`
+adapter. The unified `Adapter` contract — call shapes, `FilesError`,
+`UrlOptions`, `SignUploadOptions`, body normalization — lives in
+[`../index.ts`](../index.ts); this file documents only Appwrite-specific
+behavior. Cross-references: [`../../README.md`](../../README.md),
+[`../../../../skills/files-sdk/SKILL.md`](../../../../skills/files-sdk/SKILL.md).
+
+Appwrite is a **native** adapter on `node-appwrite` `Storage` (not
+`s3()`). Typical bugs: file-ID validation, upload-option strictness
+(`metadata` / `cacheControl` throw; `contentType` dropped), or
+`url()` / `signedUploadUrl()` unsupported paths.
+
+## Overview
+
+[Appwrite Storage](https://appwrite.io/docs/products/storage) via
+`node-appwrite`. **BaaS object storage** — bucket + file ID, API key
+auth. Keys are Appwrite file IDs (`$id`), not paths; slashes are
+invalid. Operations map to `createFile`, `getFile`, `getFileDownload`,
+`deleteFile`, `listFiles`. `signedUploadUrl()` always throws. Peer:
+`node-appwrite`.
+
+## Directory layout
+
+```text
+packages/files-sdk/src/appwrite/
+├── index.ts                # appwrite() factory + mapAppwriteError
+├── AGENTS.md               # this file
+└── CLAUDE.md               # `@AGENTS.md`
+```
+
+Sibling files outside this directory:
+
+- Tests: [`../../test/appwrite.test.ts`](../../test/appwrite.test.ts).
+- User docs:
+  [`../../../../apps/web/content/docs/adapters/appwrite.mdx`](../../../../apps/web/content/docs/adapters/appwrite.mdx).
+- Provider catalog entry (search `slug: "appwrite"`):
+  [`../providers/index.ts`](../providers/index.ts).
+
+## Build, test, typecheck
+
+Run from `packages/files-sdk/`:
+
+```bash
+bun test test/appwrite.test.ts   # adapter unit tests only
+bun test                         # full SDK suite
+bun run build                    # tsup ESM bundle -> dist/appwrite/
+bun run types                    # tsgo --noEmit (typecheck only)
+```
+
+This package uses **`bun test`** (not vitest) and **`tsgo`** (not
+`tsc`). The per-subpath bundle output is `dist/appwrite/index.{js,d.ts}`
+per the `exports` map in [`../../package.json`](../../package.json).
+
+## Public surface
+
+Defined in [`./index.ts`](./index.ts):
+
+- `appwrite(opts: AppwriteAdapterOptions): AppwriteAdapter` — primary
+  factory.
+- `AppwriteAdapter` — `Adapter<Storage> & { readonly bucket: string }`.
+  `raw` is the underlying `node-appwrite` `Storage` instance.
+- `AppwriteAdapterOptions` — config interface; JSDoc on every field is
+  the source of truth (the docs MDX pulls it via `AutoTypeTable`).
+- `mapAppwriteError(err): FilesError` — exported for tests.
+
+`name` is `"appwrite"`.
+
+## Authentication / configuration
+
+Required:
+
+- `bucket` — Appwrite storage bucket ID (`bucketId` on every Storage
+  call). **No env fallback**; pass it explicitly. The provider catalog
+  lists `bucket` under `config`, not credential env vars.
+
+Construction without `client` also requires `projectId` (option or
+`APPWRITE_PROJECT_ID` / `NEXT_PUBLIC_APPWRITE_PROJECT_ID`). Missing
+`projectId` throws `FilesError("Provider", "Appwrite adapter requires
+a projectId or an existing client")`.
+
+Optional / env-backed:
+
+- `endpoint` — defaults to `https://cloud.appwrite.io/v1`, overridable
+  via `APPWRITE_ENDPOINT` or `NEXT_PUBLIC_APPWRITE_ENDPOINT`.
+- `key` — API key for `client.setKey()`. Falls back to
+  `APPWRITE_API_KEY` or `APPWRITE_KEY`. Server-side Storage operations
+  need a key with appropriate scopes; the adapter does not validate
+  scopes at construction.
+- `client` — highest precedence. Accepts a `Client` or `Storage`
+  instance you already configured. When a `Storage` is passed,
+  `endpoint` / `projectId` are inferred from `storage.client.config`
+  when present (needed for `url()` when `public: true`).
+- `public` — when `true`, `url()` returns a permanent unsigned view URL
+  for a **public** bucket; otherwise `url()` rejects.
+
+Env lookups use [`readEnv`](../internal/env.ts) so the adapter is safe
+to import on runtimes without `process` (Cloudflare Workers without
+`nodejs_compat`).
+
+## Operation map
+
+Every SDK call passes `bucketId: opts.bucket`. Errors are caught and
+rethrown through `mapAppwriteError`.
+
+- `upload` — validates the key with `assertAppwriteKey`, rejects
+  non-empty `metadata` and any `cacheControl` (see Provider quirks),
+  buffers the body via shared [`normalizeBody`](../internal/core.ts)
+  and [`collectStream`](../internal/core.ts) into
+  `InputFile.fromBuffer`, then `storage.createFile({ fileId: key, … })`.
+  `UploadOptions.contentType` is **silently ignored** — Appwrite
+  auto-detects MIME from the payload. Returns `{ key: $id, size,
+  contentType: mimeType }`.
+- `download` — parallel `getFile` + `getFileDownload`; eager
+  `StoredFile` with buffer body.
+- `head` — `getFile` only; lazy `StoredFile` that calls
+  `getFileDownload` on first body read.
+- `exists` — [`existsByProbe`](../internal/core.ts) on `getFile`;
+  `NotFound` → `false`, other errors propagate.
+- `delete` — `deleteFile`. No adapter-level `deleteMany`; `Files`
+  falls back to per-key deletes via [`deleteManyWithFallback`](../internal/core.ts).
+- `copy` — **read-then-write**: `getFileDownload` from `from`, then
+  `createFile` with `fileId: to` (no native server-side copy). Uses `to`
+  as the `InputFile` filename to avoid an extra metadata roundtrip.
+  Destination key is validated with `assertAppwriteKey`.
+- `list` — `listFiles` with `Query.limit` (default **100**),
+  optional `Query.startsWith("$id", prefix)`, and
+  `Query.cursorAfter(cursor)`. Items are lazy `StoredFile`s keyed by
+  `$id`. `nextCursor` is the last item's `$id` when the page is full
+  (`files.length === limit`); otherwise `cursor` is omitted.
+- `url` — see URL behavior.
+- `signedUploadUrl` — always rejects with `Provider` and guidance to
+  use a JWT or the client SDK for direct uploads.
+
+Supported upload body shapes: `string`, `Uint8Array`, `ArrayBuffer`,
+`ArrayBufferView`, `Blob`, `ReadableStream`. Other types throw
+`Provider` before the SDK is called.
+
+## URL behavior
+
+Two states only — no presigned read URLs with API keys:
+
+1. **`public` unset / false (default)** — `url()` rejects:
+   `appwrite: url() is not supported. … set { public: true } …`
+2. **`public: true`** — returns
+   `${endpoint}/storage/buckets/${bucket}/files/${key}/view?project=${projectId}`.
+   Requires `endpoint` and `projectId` to be known; if both are missing
+   after client inference, rejects with `missing endpoint or projectId`.
+
+There is no `publicBaseUrl`, no `defaultUrlExpiresIn`, and no
+`responseContentDisposition` support on this adapter. Unsigned URLs are
+permanent for public buckets — not suitable for private objects.
+
+## Error mapping
+
+`mapAppwriteError` uses [`makeErrorMapper`](../internal/core.ts) with
+empty code sets — classification is HTTP-only. `AppwriteException.code`
+is hoisted to `status` for the shared classifier (404/401/403/409/412
+buckets). Fallback label: `"Appwrite error"`. `FilesError` passthrough.
+Local validation throws `Provider` before the SDK runs.
+
+## Provider quirks worth remembering
+
+- **File IDs are not paths.** Regex
+  `^[a-zA-Z0-9][a-zA-Z0-9._-]{0,35}$` — max 36 chars, must start
+  alphanumeric, no `/`. Invalid keys fail locally with a clear message.
+- **`metadata` throws; empty `{}` is allowed.** Non-empty
+  `UploadOptions.metadata` rejects before `createFile` (dropbox/box
+  pattern — don't swallow explicit caller intent). Use `adapter.raw` if
+  you need Appwrite-specific metadata elsewhere.
+- **`cacheControl` throws.** Appwrite has no HTTP cache header on file
+  content.
+- **`contentType` is silently dropped.** MIME comes from Appwrite's
+  detection on upload; returned `contentType` on the upload result is
+  whatever Appwrite stored.
+- **No presigned upload.** `signedUploadUrl()` always throws. Direct
+  browser uploads typically need Appwrite's client SDK + JWT/session,
+  not this server adapter.
+- **No presigned read with API keys.** Private buckets need
+  `getFileDownload` (what `download` / lazy bodies use), not `url()`.
+- **`copy()` costs egress + ingress.** Full object is downloaded then
+  re-uploaded; large files are expensive.
+- **Streams are buffered.** `InputFile.fromBuffer` has no streaming
+  form — `ReadableStream` bodies are fully collected first.
+- **`list({ prefix })` filters `$id`, not display `name`.** Files
+  created in the console where `name` ≠ `$id` won't match prefix queries
+  keyed the way this adapter uploads (`fileId` and filename both set to
+  the virtual key).
+- **SDK typing vs runtime.** `createFile` types `file` as DOM `File`;
+  Node passes `InputFile` from `node-appwrite/file` via cast — required
+  at runtime, not a bug to "fix" with a real `File` polyfill unless
+  tests prove otherwise.
+
+## Testing approach
+
+[`../../test/appwrite.test.ts`](../../test/appwrite.test.ts) mocks
+`node-appwrite` and covers construction/env, every operation (lazy
+bodies, list cursor/prefix, copy args), upload bodies and option
+throws, `url`/`signedUploadUrl`, and HTTP error mapping. Use
+`bun test`; keep Appwrite-specific cases here.
+
+## Coding conventions
+
+- Named exports only — `appwrite`, `AppwriteAdapter`,
+  `AppwriteAdapterOptions`, `mapAppwriteError`.
+- Use [`readEnv`](../internal/env.ts) — never `process.env` directly.
+- Use [`createStoredFile`](../internal/stored-file.ts) for every
+  `StoredFile` returned.
+- Throw unsupported upload options at the boundary (don't no-op
+  `metadata` / `cacheControl`). Silently ignore only `contentType`.
+- Validate keys with `assertAppwriteKey` before upload/copy destination.
+- Top-level regex only (`APPWRITE_KEY_RE`) — keep it that way.
+- Preserve `AppwriteException.code` → `status` hoisting in
+  `mapAppwriteError.extract`; Appwrite does not use AWS-style string
+  error codes in the empty code sets.
+
+## Releases
+
+Ships with the monorepo from
+[`../../package.json`](../../package.json). Behavioral changes need a
+changeset on `files-sdk`. README / AGENTS.md / test-only edits do not.
+The `./appwrite` export is already wired in `exports` and
+[`../../tsup.config.ts`](../../tsup.config.ts).
+
+## Where to look next
+
+- Contract: [`../index.ts`](../index.ts); source: [`./index.ts`](./index.ts);
+  tests: [`../../test/appwrite.test.ts`](../../test/appwrite.test.ts).
+- Internals: [`../internal/core.ts`](../internal/core.ts),
+  [`../internal/errors.ts`](../internal/errors.ts),
+  [`../internal/env.ts`](../internal/env.ts).
+- Catalog (`slug: "appwrite"`): [`../providers/index.ts`](../providers/index.ts).
+- Docs: [`../../../../apps/web/content/docs/adapters/appwrite.mdx`](../../../../apps/web/content/docs/adapters/appwrite.mdx),
+  [`../../README.md`](../../README.md),
+  [`../../../../skills/files-sdk/SKILL.md`](../../../../skills/files-sdk/SKILL.md).

--- a/packages/files-sdk/src/appwrite/CLAUDE.md
+++ b/packages/files-sdk/src/appwrite/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/packages/files-sdk/src/azure/AGENTS.md
+++ b/packages/files-sdk/src/azure/AGENTS.md
@@ -1,0 +1,308 @@
+# AGENTS.md — `files-sdk/azure`
+
+Guidance for coding agents working on the `azure` adapter. The unified
+`Adapter<Raw>` contract — methods, body shapes, `FilesError`,
+`UrlOptions`, `SignUploadOptions` — lives in
+[`../index.ts`](../index.ts); this file only documents azure-specific
+deviations. Native adapter built on `@azure/storage-blob` plus
+`@azure/core-auth` (`TokenCredential` type) and `@azure/identity`
+(pre-built credentials). Cross-references:
+[`README.md`](../../README.md),
+[`SKILL.md`](../../../../skills/files-sdk/SKILL.md),
+[user-facing docs](../../../../apps/web/content/docs/adapters/azure.mdx).
+
+## Overview
+
+`azure(opts)` returns `Adapter<BlobServiceClient> & { readonly bucket: string }`.
+Operations dispatch directly against the Azure SDK — no inner adapter
+forwarding.
+
+- **Container is the bucket; blob is the object.** Azure's "container"
+  surfaces as `adapter.bucket` for cross-adapter consistency
+  (s3/r2/gcs/minio).
+- **Four credential modes** — connection string, shared account key,
+  `TokenCredential` (Azure AD / Managed Identity), SAS token; plus
+  anonymous (account name only) for public-read containers. Mutually
+  exclusive per the provider catalog
+  ([`../providers/index.ts`](../providers/index.ts) → `slug: "azure"`).
+- **SAS URLs everywhere `url()` signs.** Presigning hands
+  `generateBlobSASQueryParameters` (shared key) or
+  `BlobClient.generateUserDelegationSasUrl` (token credential) a
+  permissions string, expiry, and optional content-disposition.
+- **Token credentials sign via User Delegation Keys** —
+  `BlobServiceClient.getUserDelegationKey` mints account-scoped signing
+  material the adapter caches across SAS URLs (see
+  [URL behavior](#url-behavior)). Support landed via
+  [`../../../../.changeset/azure-token-credentials.md`](../../../../.changeset/azure-token-credentials.md);
+  follow the same pattern for future auth additions.
+
+## Directory layout
+
+```text
+packages/files-sdk/src/azure/
+├── index.ts        # azure() factory + mapAzureError + types
+├── AGENTS.md       # this file
+└── CLAUDE.md       # @AGENTS.md — Claude Code re-export
+```
+
+Tests at [`../../test/azure.test.ts`](../../test/azure.test.ts);
+user-facing docs at
+[`../../../../apps/web/content/docs/adapters/azure.mdx`](../../../../apps/web/content/docs/adapters/azure.mdx);
+the `azure` subpath is enumerated in
+[`../../package.json`](../../package.json)'s `exports` map.
+
+## Build, test, typecheck
+
+Run from `packages/files-sdk/`:
+
+```bash
+bun test test/azure.test.ts   # adapter-only suite
+bun test                       # full SDK test suite
+bun run build                  # tsup ESM bundle → dist/azure/index.{js,d.ts}
+bun run types                  # tsgo --noEmit
+```
+
+Tests use `bun test` with `mock.module("@azure/storage-blob", …)` to
+stub `BlobServiceClient`, `StorageSharedKeyCredential`, and
+`generateBlobSASQueryParameters` — no real network or Azurite needed.
+Read the mock-module setup at the top of the test file before touching
+the SDK boundary.
+
+## Public surface
+
+Exports from [`./index.ts`](./index.ts):
+
+- `azure(opts: AzureAdapterOptions): AzureAdapter` — primary factory;
+  the adapter's `name` is `"azure"`.
+- `AzureAdapter` — `Adapter<BlobServiceClient> & { readonly bucket: string }`;
+  `.raw` is the underlying `BlobServiceClient`.
+- `AzureAdapterOptions` — config interface. JSDoc on every field is the
+  source of truth; the docs MDX pulls it via `AutoTypeTable`.
+- `mapAzureError(err): FilesError` — exported for direct testing.
+
+Optional peer deps (in [`../../package.json`](../../package.json)):
+`@azure/storage-blob` (runtime), `@azure/core-auth` (`TokenCredential`,
+type-only), and `@azure/identity` (`DefaultAzureCredential`,
+`ManagedIdentityCredential`, `ClientSecretCredential`, … — the adapter
+never imports it; callers pass `credential` from their own import).
+
+## Authentication / configuration
+
+Credential modes, picked by precedence:
+
+1. **Connection string** — `opts.connectionString` or
+   `AZURE_STORAGE_CONNECTION_STRING`. `parseConnectionString` recovers
+   `AccountName`, `AccountKey`, `BlobEndpoint`; the recovered key feeds
+   a `StorageSharedKeyCredential` so `url()` and `signedUploadUrl()`
+   keep working without a second credential.
+2. **Account key** — `opts.accountKey` (or `AZURE_STORAGE_ACCOUNT_KEY`
+   / `AZURE_STORAGE_KEY`) plus `opts.accountName` (or
+   `AZURE_STORAGE_ACCOUNT_NAME` / `AZURE_STORAGE_ACCOUNT`). Builds
+   `StorageSharedKeyCredential(accountName, accountKey)` →
+   `BlobServiceClient(endpoint, sharedKey)`.
+3. **Token credential** — `opts.credential` plus `accountName`. SDK
+   calls authenticate against Azure AD; signed URLs use User Delegation
+   SAS via `getUserDelegationKey` + `generateUserDelegationSasUrl`. Set
+   `useUserDelegationSas: false` to keep token-authenticated I/O but
+   disable SAS signing.
+4. **SAS token** — `opts.sasToken` (or `AZURE_STORAGE_SAS_TOKEN`) plus
+   `accountName`. Appended to the endpoint. Reads/writes/listing work
+   as the SAS allows; `url()` and `signedUploadUrl()` throw — the SAS
+   is the credential, not a re-signable key. **Anonymous** (account
+   name only) shares the caveat and only works for public-read
+   containers.
+
+Required: `opts.container` (missing throws `FilesError("Provider",
+"missing container")`). Optional:
+
+- `endpoint` — defaults to `https://${accountName}.blob.core.windows.net`.
+  Override for Azurite (`http://127.0.0.1:10000/devstoreaccount1`) or
+  sovereign clouds (`*.blob.core.usgovcloudapi.net`,
+  `*.blob.core.chinacloudapi.cn`).
+- `publicBaseUrl` — switches `url()` to `${publicBaseUrl}/${key}`
+  unsigned, for `Blob` / `Container` access levels or a CDN
+  (`*.azureedge.net`, Front Door) in front.
+- `defaultUrlExpiresIn` — default SAS read-URL expiry, seconds.
+  Defaults to `DEFAULT_URL_EXPIRES_IN` (3600) from
+  [`../internal/core.ts`](../internal/core.ts).
+
+Env reads go through [`readEnv`](../internal/env.ts) so the adapter is
+import-safe on Cloudflare Workers without `nodejs_compat`. The catalog
+entry (`slug: "azure"`) in
+[`../providers/index.ts`](../providers/index.ts) is the canonical env
+spec — keep it aligned with the JSDoc fallbacks.
+
+## Operation map
+
+Errors funnel through `mapAzureError`, which prefers
+`RestError.details.errorCode` over the top-level `code` (which is
+sometimes an SDK class name). Code sets:
+`BlobNotFound`/`ContainerNotFound`/`ResourceNotFound` → `NotFound`;
+`AuthenticationFailed`/`AuthorizationFailure`/`AuthorizationPermissionMismatch`/`InvalidAuthenticationInfo`/`InsufficientAccountPermissions`
+→ `Unauthorized`;
+`BlobAlreadyExists`/`ContainerAlreadyExists`/`ConditionNotMet`/`LeaseIdMismatchWithBlobOperation`/`LeaseAlreadyPresent`
+→ `Conflict`.
+
+| Method            | Underlying SDK call                                                                                  |
+| ----------------- | ---------------------------------------------------------------------------------------------------- |
+| `upload`          | `BlockBlobClient.uploadData` (buffered) or `BlockBlobClient.uploadStream` (`ReadableStream`)         |
+| `download`        | `BlobClient.download` (stream) or `BlobClient.downloadToBuffer` (buffered, parallel range requests)  |
+| `head`            | `BlobClient.getProperties` + lazy `downloadToBuffer` factory for `text()` / `blob()` etc.            |
+| `exists`          | `BlobClient.exists`; a thrown `NotFound` is caught and reported as `false`                           |
+| `delete`          | `BlobClient.deleteIfExists` — idempotent (matches s3; divergent from gcs)                            |
+| `copy`            | `BlobClient.syncCopyFromURL`, source signed by `buildCopySource` (see quirks)                        |
+| `list`            | `ContainerClient.listBlobsFlat().byPage()`; cursor round-trips `continuationToken`                   |
+| `url`             | `publicBaseUrl` join or SAS via `buildSasUrl` — see [URL behavior](#url-behavior)                    |
+| `signedUploadUrl` | SAS with `cw` (create + write); PUT with `x-ms-blob-type: BlockBlob`                                 |
+
+Body normalization runs through [`normalizeBody`](../internal/core.ts).
+Stream bodies bridge to Node `Readable` via `Readable.fromWeb`;
+buffered bodies become `Buffer` via a zero-copy
+`Buffer.from(u8.buffer, u8.byteOffset, u8.byteLength)` so a `DataView`
+at an offset doesn't over-read. Stream uploads do a follow-up
+`getProperties` for an authoritative `UploadResult.size`. ETags are
+unwrapped via `stripEtag`; `AbortSignal` flows through
+`abortOpts(signal)` (the SDK's `AbortSignalLike` is satisfied by a web
+`AbortSignal`). `signedUploadUrl` rejects `maxSize` — Azure SAS has no
+`content-length-range`; enforce caps at the gateway.
+
+## URL behavior
+
+`url(key, opts?)` follows the two-state strategy from
+[`resolveUrlStrategy`](../internal/core.ts):
+
+- **`publicBaseUrl` set, no `responseContentDisposition`** →
+  `${publicBaseUrl}/${encoded key}`, unsigned.
+- **Otherwise** → SAS via `buildSasUrl`: shared-key mode uses
+  `generateBlobSASQueryParameters`; token-credential mode uses
+  `BlobClient.generateUserDelegationSasUrl` with a cached
+  `UserDelegationKey`. Permissions `r`, expiry
+  `opts.expiresIn ?? defaultUrlExpiresIn` seconds, HTTPS;
+  `responseContentDisposition` flows into
+  `BlobSASSignatureValues.contentDisposition`.
+- **`responseContentDisposition` always forces signing**, even with
+  `publicBaseUrl` set — a permanent CDN URL has no signature to bind
+  the override to, and silently dropping it would regress stored-XSS
+  protections on user-uploaded HTML/SVG.
+
+`url()` and `signedUploadUrl()` throw `FilesError("Provider", …)` in
+**SAS-only**, **anonymous**, and **token-credential mode with
+`useUserDelegationSas: false`** — the message lists recovery paths.
+
+**User Delegation Key rotation.** Token-credential signing caches one
+`UserDelegationKey` per signer as
+`signer.cachedKey: { key, expiresOn }`. Reused while
+`expiresOn > sasExpiresOn + 5 min` (`USER_DELEGATION_KEY_SLACK_MS`); on
+refetch, requested expiry is `requiredUntil + 1 h`
+(`USER_DELEGATION_KEY_TTL_MS`), capped at `startsOn + 7 d`
+(`USER_DELEGATION_KEY_MAX_MS`; Azure rejects keys older than 7 days).
+Default-expiry `url()` calls share the cache — back-to-back `url("a")`
++ `url("b")` does one `getUserDelegationKey` round-trip and two
+`generateUserDelegationSasUrl` calls; a dedicated test pins this, so
+preserve it when changing the cache window. The principal needs blob
+data access **plus** permission to call
+`…/generateUserDelegationKey/action` (the *Storage Blob Delegator*
+role at account scope fits).
+
+## Provider quirks worth remembering
+
+- **Metadata keys force lowercase on the wire.** Azure returns keys
+  lowercase, so `{ Author: "me" }` round-trips as `{ author: "me" }`.
+  Azure also restricts keys to C# identifier characters (no dashes, no
+  non-ASCII); the adapter doesn't normalize, so lowercase at the
+  caller if you compare across writes.
+- **`syncCopyFromURL` caps at 256 MB source.** Larger blobs need
+  `adapter.raw.getContainerClient(c).getBlobClient(to).beginCopyFromURL(sourceUrl)`
+  via the escape hatch.
+- **`delete()` is idempotent** (`deleteIfExists`); matches s3,
+  diverges from gcs.
+- **HTTP headers live in `blobHTTPHeaders`.** `Cache-Control` →
+  `blobCacheControl`, `Content-Type` → `blobContentType`.
+- **Copy source URLs need their own signature.** `syncCopyFromURL` has
+  the destination fetch the source over HTTPS, so `buildCopySource`
+  mints a 5-minute SAS (`COPY_SOURCE_SAS_SECONDS = 300`) in shared-key
+  and token-credential modes, appends the existing SAS in SAS-only
+  mode, and uses the bare URL in anonymous mode.
+- **`x-ms-blob-type: BlockBlob` is required on the upload PUT** —
+  without it Azure returns `400 InvalidHeaderValue`. `signedUploadUrl`
+  emits the header.
+- **Env-var aliases.** Both `AZURE_STORAGE_ACCOUNT_NAME` /
+  `AZURE_STORAGE_ACCOUNT` and `AZURE_STORAGE_ACCOUNT_KEY` /
+  `AZURE_STORAGE_KEY` work (the Azure CLI uses both); first populated
+  wins.
+- **Sovereign clouds and Azurite go through `endpoint`** — no separate
+  flag. Azurite has a baked-in account segment (`…/devstoreaccount1`);
+  pass it literally.
+- **`exists()` swallows thrown 404s** — some configurations throw 404
+  rather than returning `false`; the adapter normalizes both.
+
+## Testing approach
+
+[`../../test/azure.test.ts`](../../test/azure.test.ts) is one
+`describe("azure adapter")` block with a sub-block per surface
+(`construction`, `upload`, `download`, `head`, `exists`, `delete`,
+`copy`, `list`, `url`, `signedUploadUrl`, `error mapping`,
+`signal forwarding`). Coverage worth preserving:
+
+- Every credential mode picks the right primitive
+  (`fromConnectionString` vs `new BlobServiceClient(endpoint, …)`).
+- `upload` body shapes (`Uint8Array`, `ArrayBuffer`, `ArrayBufferView`
+  at offset, `Blob`, `ReadableStream` with stream-size follow-up);
+  `download` buffered + lazy stream + empty-stream fallback.
+- `exists` native true/false plus thrown 404 → `false`, 403 →
+  `Unauthorized`; `copy` in all four credential modes.
+- `url`: `publicBaseUrl` short-circuit, signed default, `expiresIn`
+  honored, `responseContentDisposition` forces signing, no-signer
+  modes throw, token mode reuses the cached UDK across default and
+  explicit expiries. `signedUploadUrl`: PUT shape, `Content-Type`
+  propagation, `maxSize` rejection, no-signer throw.
+- `mapAzureError` covers every code class, HTTP status bucket, and
+  `FilesError` pass-through; every op forwards `AbortSignal`.
+
+Extend an existing sub-block rather than adding a new top-level
+`describe` — keeps the `beforeEach` mock reset working.
+
+## Coding conventions
+
+- Named exports only — `azure`, `mapAzureError`, `AzureAdapter`,
+  `AzureAdapterOptions`. No default exports.
+- Construction errors use
+  [`FilesError("Provider", …)`](../internal/errors.ts) with messages
+  that list recovery paths. Operation errors funnel through
+  `mapAzureError`; don't `instanceof RestError` directly — the mapper's
+  `extract` already knows the SDK's shape.
+- Read env via [`readEnv`](../internal/env.ts), never `process.env`.
+- Propagate optional fields with `...(value && { key: value })` so
+  unset values fall through to SDK defaults rather than explicit
+  `undefined`.
+- Top-level constants only (`COPY_SOURCE_SAS_SECONDS`,
+  `USER_DELEGATION_KEY_TTL_MS`, the `AZURE_*_CODES` sets); keep
+  SAS-builder branching inside `buildSasUrl` so callers stay agnostic
+  about shared-key vs UDK.
+
+## Releases
+
+Ships from [`../../package.json`](../../package.json). Behavioral
+changes (new options, default changes, error-shape changes, new
+credential modes) need a changeset — `bun changeset`, pick `files-sdk`.
+Follow the
+[token-credentials changeset](../../../../.changeset/azure-token-credentials.md)
+pattern for auth additions: changeset + MDX update + a `describe`
+exercising both SDK-call and SAS-signing paths. Docs-only edits don't.
+
+## Where to look next
+
+- Unified `Adapter` contract: [`../index.ts`](../index.ts); shared
+  helpers (URL strategy, body normalization, error-mapper factory,
+  `DEFAULT_URL_EXPIRES_IN`):
+  [`../internal/core.ts`](../internal/core.ts); `FilesError`:
+  [`../internal/errors.ts`](../internal/errors.ts); env reader:
+  [`../internal/env.ts`](../internal/env.ts); provider catalog:
+  [`../providers/index.ts`](../providers/index.ts) (`slug: "azure"`).
+- Tests: [`../../test/azure.test.ts`](../../test/azure.test.ts);
+  user-facing docs:
+  [`../../../../apps/web/content/docs/adapters/azure.mdx`](../../../../apps/web/content/docs/adapters/azure.mdx);
+  package [README](../../README.md); SKILL:
+  [`../../../../skills/files-sdk/SKILL.md`](../../../../skills/files-sdk/SKILL.md);
+  changeset:
+  [`../../../../.changeset/azure-token-credentials.md`](../../../../.changeset/azure-token-credentials.md).

--- a/packages/files-sdk/src/azure/CLAUDE.md
+++ b/packages/files-sdk/src/azure/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/packages/files-sdk/src/backblaze-b2/AGENTS.md
+++ b/packages/files-sdk/src/backblaze-b2/AGENTS.md
@@ -1,0 +1,223 @@
+# AGENTS.md — `files-sdk/backblaze-b2`
+
+Guidance for coding agents working on the `backblaze-b2` adapter. The unified
+`Adapter<Raw>` contract every adapter implements lives in
+[../index.ts](../index.ts); this file documents only what is specific to
+Backblaze B2. The adapter targets B2's **S3-compatible API** (not the legacy
+native B2 API at `api.backblazeb2.com/b2api/v3/…`) and is a thin wrapper around
+[`s3()`](../s3/index.ts). For the unified surface and high-level mental model
+see [../../README.md](../../README.md) and
+[../../../../skills/files-sdk/SKILL.md](../../../../skills/files-sdk/SKILL.md).
+
+## Overview
+
+`backblaze-b2` constructs an internal `s3()` adapter, points it at a B2 cluster
+endpoint, relabels the unknown-error fallback message, and re-exports it with
+`name: "backblaze-b2"`. Every operation (`upload`, `download`, `head`,
+`exists`, `delete`, `deleteMany`, `copy`, `list`, `url`, `signedUploadUrl`)
+flows through the inner S3 client. The B2-specific work is:
+
+- Deriving the endpoint host from a cluster code (e.g. `us-west-002`).
+- Auto-loading credentials from `B2_APPLICATION_KEY_ID` / `B2_APPLICATION_KEY`.
+- Keeping virtual-hosted-style addressing on, which B2 expects.
+- Relabeling the generic `Provider`-code fallback to `"Backblaze B2 error"` so
+  callers don't see `"S3 error"`.
+
+If you reach for S3 internals (presigners, `mapS3Error`, `S3AdapterOptions`),
+edit [../s3/index.ts](../s3/index.ts) and let the change flow through; do not
+fork S3 logic into this file.
+
+## Directory layout
+
+```text
+packages/files-sdk/src/backblaze-b2/
+├── AGENTS.md   # this file
+├── CLAUDE.md   # @AGENTS.md indirection
+└── index.ts    # backblazeB2() factory + BackblazeB2AdapterOptions
+```
+
+Tests: [../../test/backblaze-b2.test.ts](../../test/backblaze-b2.test.ts).
+User docs:
+[../../../../apps/web/content/docs/adapters/backblaze-b2.mdx](../../../../apps/web/content/docs/adapters/backblaze-b2.mdx).
+Provider catalog: [../providers/index.ts](../providers/index.ts) under
+`slug: "backblaze-b2"`.
+
+## Build, test, typecheck
+
+```bash
+bun test test/backblaze-b2.test.ts
+bun test
+bun run build
+bun run types
+```
+
+The first is the fast inner loop. Run the full suite before pushing — changes
+to [../s3/index.ts](../s3/index.ts) ripple here. `bun run build` (tsup)
+confirms the `./backblaze-b2` subpath export in
+[../../package.json](../../package.json) still resolves; `bun run types` runs
+`tsgo --noEmit`.
+
+## Public surface
+
+Two exports:
+
+- `backblazeB2(opts: BackblazeB2AdapterOptions): BackblazeB2Adapter` — factory
+  returning `Adapter<S3Client>` with `name: "backblaze-b2"`.
+- `BackblazeB2AdapterOptions` — constructor options.
+
+`files.raw` is the underlying `@aws-sdk/client-s3` `S3Client` for escape-hatch
+access to B2 features outside the unified API:
+
+```ts
+import { backblazeB2 } from "files-sdk/backblaze-b2";
+```
+
+## Authentication / configuration
+
+Required: `bucket`, `region`, and `accessKeyId` + `secretAccessKey` (or the env
+vars below). `region` is the B2 cluster code (`"us-west-000"`, `"us-west-001"`,
+`"us-west-002"`, `"us-east-004"`, `"us-east-005"`, `"eu-central-003"`, …) and
+has **no env-var fallback**. It drives both the endpoint host
+(`https://s3.<region>.backblazeb2.com`) and the SigV4 region; the bucket's
+cluster shows in the B2 console next to the endpoint, and the wrong code
+returns a `301`. Application keys come from **Account → Application Keys** —
+prefer bucket-scoped keys with the minimum capabilities over the master key.
+
+Optional: `endpoint` overrides the derived host (private link, proxy);
+`forcePathStyle` defaults to `false` (virtual-hosted is canonical for B2 — only
+flip when a proxy demands path-style); `publicBaseUrl` is the origin for
+unsigned `url()` reads (see [URL behavior](#url-behavior));
+`defaultUrlExpiresIn` is the default `expiresIn` (seconds) for presigned
+`url()`, defaulting to `3600` and honored only when `publicBaseUrl` is unset.
+
+Env-var fallbacks (via [../internal/env.ts](../internal/env.ts)):
+
+| Option            | Env var                 |
+| ----------------- | ----------------------- |
+| `accessKeyId`     | `B2_APPLICATION_KEY_ID` |
+| `secretAccessKey` | `B2_APPLICATION_KEY`    |
+
+The factory throws `FilesError("Provider", …)` (from
+[../internal/errors.ts](../internal/errors.ts)) when `region` is missing or
+when neither explicit credentials nor both env vars are set. Those messages
+are part of the public contract — grep before renaming.
+
+## Operation map
+
+Every operation forwards to the inner `s3()` adapter unchanged:
+
+| Files SDK method  | S3 wire call (via `s3()`)                                   |
+| ----------------- | ----------------------------------------------------------- |
+| `upload`          | `PutObjectCommand` (+ follow-up `HeadObject` for streams)   |
+| `download`        | `GetObjectCommand`                                          |
+| `head`            | `HeadObjectCommand`                                         |
+| `exists`          | `HeadObjectCommand` via `existsByProbe`                     |
+| `delete`          | `DeleteObjectCommand`                                       |
+| `deleteMany`      | `DeleteObjectsCommand` (chunked at 1000 keys/request)       |
+| `copy`            | `CopyObjectCommand` (`CopySource` URL-encoded)              |
+| `list`            | `ListObjectsV2Command`                                      |
+| `url`             | `getSignedUrl(GetObjectCommand)` or `publicBaseUrl` concat  |
+| `signedUploadUrl` | `createPresignedPost` if `maxSize`, else signed `PutObject` |
+
+For per-method details and error classification, see
+[../s3/index.ts](../s3/index.ts). For nuance beyond "it does what S3 does,"
+update that file and add a regression test in
+[../../test/backblaze-b2.test.ts](../../test/backblaze-b2.test.ts).
+
+## URL behavior
+
+`url(key, opts?)` follows the signing-adapter rules in
+[../internal/core.ts](../internal/core.ts) `resolveUrlStrategy`:
+
+- **`publicBaseUrl` unset:** SigV4-presigned `GetObject` URL against the
+  cluster endpoint, expiring after
+  `opts.expiresIn ?? defaultUrlExpiresIn ?? 3600` seconds.
+- **`publicBaseUrl` set:** `${publicBaseUrl}/${key}` unsigned and permanent.
+  For public-read buckets the natural value is the **B2 Friendly URL** prefix
+  `https://f<NNN>.backblazeb2.com/file/<bucket>` (the `f<NNN>` host varies per
+  cluster; look it up under the bucket's "Endpoint" in the B2 console). A
+  Cloudflare-fronted custom domain also works.
+- **`responseContentDisposition` set:** always forces signing, even with
+  `publicBaseUrl` configured. A permanent CDN URL has no signature to bind the
+  override to; dropping it silently would be a stored-XSS regression on
+  user-uploaded HTML/SVG. This invariant lives in `resolveUrlStrategy`, not
+  here — don't reimplement it.
+
+Keys passed through `joinPublicUrl` are URL-encoded by segment; presigned URLs
+are encoded by the AWS SDK.
+
+## Provider quirks worth remembering
+
+- **Cluster code matters.** A bucket lives in exactly one cluster. The wrong
+  `region` returns a `301` surfaced as a generic `Provider`-code `FilesError`
+  reading "Backblaze B2 error" — not a pointer back to the cluster mistake.
+  If a user reports mysterious 301s, ask which cluster their bucket is in.
+- **Friendly URLs are the only public-read URL B2 exposes**
+  (`https://f<NNN>.backblazeb2.com/file/<bucket>/<key>`); path-style on
+  `s3.<region>.backblazeb2.com` does not bypass auth. Keep
+  `forcePathStyle: false` unless the network path forces otherwise.
+- **No native object-lock or list-versions** in the unified API. Reach for
+  `files.raw` for B2 features outside it.
+- **Errors are labeled `"Backblaze B2 error"`** via `defaultProviderMessage`
+  on the inner `s3()` call. Tests assert this string — do not change without
+  updating the test and adding a changeset.
+
+## Testing approach
+
+Tests in [../../test/backblaze-b2.test.ts](../../test/backblaze-b2.test.ts)
+cover three layers:
+
+1. **Config plumbing.** Region → derived endpoint, explicit endpoint override,
+   `forcePathStyle: true` pass-through, missing-region and missing-credentials
+   throws, env-var credential fallback. These read `client.config.region()`,
+   `client.config.endpoint?.()`, and `client.config.credentials()` directly
+   off the inner `S3Client`.
+2. **Delegation.** `upload` and `exists` exercised through a `Files` wrapper
+   with `aws-sdk-client-mock` (`mockClient(S3Client)`) and the relevant
+   `*Command` resolutions stubbed. Guard against accidental method-renaming
+   when `s3()` changes.
+3. **Error relabeling.** A direct call into `mapS3Error` confirms the
+   `Provider`-code fallback is `"Backblaze B2 error"`.
+
+When adding behavior, extend an existing test rather than spawning a new file.
+Mock the SDK and reset between assertions; never hit real B2.
+
+## Coding conventions
+
+- Named exports only.
+- The factory is a pure function: no module-level mutable state, no I/O at
+  import. Env reads happen inside the factory via `readEnv`
+  ([../internal/env.ts](../internal/env.ts)) so Cloudflare Workers (no
+  `process`) can still import the module.
+- Construction-time validation throws `FilesError("Provider", …)` with a
+  message starting with the adapter slug ("backblaze-b2 adapter: …") so
+  sibling S3-compatible adapters stay distinguishable.
+- Keep the option set a strict subset of `S3AdapterOptions`; thread any new
+  knob through `s3()` rather than splitting the implementation.
+- Type-only imports from `@aws-sdk/client-s3` — it is an **optional** peer dep
+  (see [../../package.json](../../package.json)); a runtime
+  `import { S3Client }` here would break consumers who install `files-sdk`
+  without it. The runtime client is constructed inside `s3()`.
+
+## Releases
+
+The package ships as `files-sdk` on a single version line. Behavioral changes
+— `defaultProviderMessage` string, error message text, env-var names, option
+renames — need a Changesets entry against `files-sdk`. AGENTS.md / CLAUDE.md
+and comment-only edits don't.
+
+## Where to look next
+
+- Unified contract: [../index.ts](../index.ts).
+- Inner adapter: [../s3/index.ts](../s3/index.ts) — every operation here
+  ultimately runs through it.
+- Shared helpers: [../internal/core.ts](../internal/core.ts),
+  [../internal/errors.ts](../internal/errors.ts),
+  [../internal/env.ts](../internal/env.ts).
+- Provider catalog: [../providers/index.ts](../providers/index.ts)
+  (`slug: "backblaze-b2"`).
+- Tests: [../../test/backblaze-b2.test.ts](../../test/backblaze-b2.test.ts).
+- User docs:
+  [../../../../apps/web/content/docs/adapters/backblaze-b2.mdx](../../../../apps/web/content/docs/adapters/backblaze-b2.mdx).
+- Package overview: [../../README.md](../../README.md) and
+  [../../../../skills/files-sdk/SKILL.md](../../../../skills/files-sdk/SKILL.md).

--- a/packages/files-sdk/src/backblaze-b2/CLAUDE.md
+++ b/packages/files-sdk/src/backblaze-b2/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/packages/files-sdk/src/box/AGENTS.md
+++ b/packages/files-sdk/src/box/AGENTS.md
@@ -1,0 +1,252 @@
+# AGENTS.md — `files-sdk/box`
+
+Guidance for coding agents working on the `box` adapter. The unified
+`Adapter` contract — call shapes, `FilesError`, `UrlOptions`,
+`SignUploadOptions`, body normalization — lives in
+[`../index.ts`](../index.ts); this file only documents box-specific
+behavior. `box()` is a native adapter over
+[`box-typescript-sdk-gen`](https://github.com/box/box-typescript-sdk-gen)
+for [Box](https://www.box.com) cloud content. Box files are addressed by
+stable IDs, not paths, so the adapter maps virtual slash-separated keys
+onto a folder tree rooted at `rootFolderId`. Cross-references:
+[`README.md`](../../README.md),
+[`SKILL.md`](../../../../skills/files-sdk/SKILL.md).
+
+## Overview
+
+A full native implementation (~1000 lines) that wires the unified API to
+Box's REST surface via the generated SDK. Virtual keys like `docs/a.txt`
+are split into path segments, walked under `rootFolderId` (default `"0"` —
+the account root folder), and resolved to Box file/folder IDs with
+per-instance caches. Upload auto-creates missing intermediate folders;
+read/delete/copy resolve existing paths only. Five auth shapes plus a
+pre-built `client` escape hatch cover developer scripts, user OAuth apps,
+Client Credentials Grant (enterprise or app-user), and JWT server auth —
+token refresh and exchange are delegated to the SDK's `Authentication`
+classes. The returned adapter's `raw` is the underlying `BoxClient`; anything
+the SDK exposes (metadata templates, retention, workflows) is one property
+access away. `BoxAdapter` also exposes `rootFolderId` for callers that need
+the configured anchor.
+
+## Directory layout
+
+```
+packages/files-sdk/src/box/
+├── index.ts                   # box() factory + BoxAdapterOptions
+├── AGENTS.md                  # this file
+└── CLAUDE.md                  # @AGENTS.md — Claude-Code re-export
+```
+
+Tests at [`../../test/box.test.ts`](../../test/box.test.ts);
+user-facing docs at
+[`../../../../apps/web/content/docs/adapters/box.mdx`](../../../../apps/web/content/docs/adapters/box.mdx).
+
+## Build, test, typecheck
+
+Run from `packages/files-sdk`:
+
+```bash
+bun test test/box.test.ts   # adapter unit tests only
+bun test                     # full SDK suite
+bun run build                # tsup → dist/, including dist/box/
+bun run types                # tsgo --noEmit (typecheck only)
+```
+
+The `box` subpath is enumerated in
+[`../../package.json`](../../package.json)'s `exports` map — keep that
+entry in sync if the file layout changes. Peer dependency:
+`box-typescript-sdk-gen`.
+
+## Public surface
+
+Exports from [`index.ts`](./index.ts):
+
+- `box(opts?: BoxAdapterOptions): BoxAdapter` — primary factory.
+- `BoxAdapter` — `Adapter<BoxClient>` plus `readonly rootFolderId: string`.
+  `raw` is the underlying `BoxClient`.
+- `BoxAdapterOptions`, `BoxOAuthOptions`, `BoxCcgOptions`, `BoxJwtOptions`
+  — config interfaces (JSDoc on every field is the source of truth; the
+  docs MDX pulls it via `AutoTypeTable`).
+- `mapBoxError(err: unknown): FilesError` — exported for tests and
+  callers that invoke `raw` directly.
+- `BoxClient` — re-exported type alias from `box-typescript-sdk-gen`.
+
+The adapter's `name` is `"box"`.
+
+## Authentication / configuration
+
+Pass **exactly one** auth method (or `client`). More than one throws
+`FilesError("Provider", …)` at construction.
+
+| Mode | Option | Notes |
+| ---- | ------ | ----- |
+| Escape hatch | `client?: BoxClient` | Caller wires auth, `NetworkSession`, proxies, downscoped tokens. |
+| Developer token | `developerToken?: string` | Short-lived console token. Env fallback: `BOX_DEVELOPER_TOKEN` via [`readEnv`](../internal/env.ts). |
+| OAuth (user app) | `oauth?: BoxOAuthOptions` | `clientId`, `clientSecret`, `refreshToken`. Seeds SDK token storage on first API call; SDK refreshes access tokens. |
+| CCG (server) | `ccg?: BoxCcgOptions` | `clientId`, `clientSecret`, plus **`enterpriseId` or `userId`** (required). `enterpriseId` → service account; `userId` → managed/app user. |
+| JWT (server) | `jwt?: BoxJwtOptions` | `configJsonString` or `configFilePath` → `JwtConfig` from Box developer console JSON. |
+
+Production auth (OAuth, CCG, JWT) is configured via constructor options,
+not env vars — only `BOX_DEVELOPER_TOKEN` has an env fallback. The
+provider catalog entry in [`../providers/index.ts`](../providers/index.ts)
+(search `slug: "box"`) documents the same.
+
+Optional knobs:
+
+- `rootFolderId` — logical bucket root (default `"0"`). Virtual keys live
+  under this folder; it must already exist. Intermediate subfolders are
+  auto-created on `upload()` only.
+- `publicByDefault` — when `true`, `upload()` calls `addShareLinkToFile`
+  (`access: "open"`) and `url()` returns the shared link's
+  `download_url` (or `url`). Default `false`.
+- `publicBaseUrl` — when set, `url(key)` returns
+  `${publicBaseUrl}/${key}` via [`joinPublicUrl`](../internal/core.ts)
+  and skips signing and shared-link resolution. No API calls.
+- `defaultUrlExpiresIn` — accepted for API symmetry on `url()`; Box's
+  `getDownloadFileUrl` does not take an expiry parameter (TTL is
+  server-controlled). Defaults to `DEFAULT_URL_EXPIRES_IN` (3600) from
+  [`../internal/core.ts`](../internal/core.ts).
+
+## Operation map
+
+All methods call `authHandle.ensureReady()` first (OAuth seeds the refresh
+token lazily). Errors pass through `mapBoxError`.
+
+| Method | Implementation |
+| ------ | -------------- |
+| `upload(key, body, opts?)` | `splitKey` → `resolveFolderId({ create: true })` → `resolveExistingFileForUpload` → `uploadFile` / `uploadFileVersion` (≤ 50 MB) or `chunkedUploads.uploadBigFile` (> 50 MB). Bodies normalized to `Buffer` then `Readable`. Rejects non-empty `metadata` and `cacheControl`. Optional `ensureSharedLink` when `publicByDefault`. |
+| `download(key, opts?)` | Resolve file ID → `getFileById` for metadata → `getDownloadFileUrl` → `fetch` (forwards `signal`). Default buffer; `opts.as: "stream"` returns a `ReadableStream`. |
+| `head(key)` | `getFileById` metadata + lazy body factory (`lazyDownload`). |
+| `exists(key)` | [`existsByProbe`](../internal/core.ts) around `resolveFileId` + lightweight `getFileById`. |
+| `delete(key)` | Idempotent: missing key is a no-op. Resolves ID, `deleteFileById`, drops cache entry. Swallows `NotFound` from delete (out-of-band removal). |
+| `copy(from, to)` | `copyFile` with destination folder resolved (`create: true`). |
+| `list(opts?)` | Paginated `getFolderItems` on **`rootFolderId` only** — immediate file children, no subfolder recursion. `prefix` filtered client-side on `name`. Cursor is numeric offset string. Subfolders and web links skipped. |
+| `url(key, opts?)` | `publicBaseUrl` short-circuit, else shared link (`publicByDefault`) or `getDownloadFileUrl`. Rejects `responseContentDisposition`. |
+| `signedUploadUrl` | **Throws** — Box multipart upload shape does not fit the SDK's PUT/POST-form contract. |
+
+`deleteMany` is **not** implemented; `Files.deleteMany()` fans out to
+`delete()` with bounded concurrency via
+[`deleteManyWithFallback`](../internal/core.ts).
+
+## URL behavior
+
+Three paths, in precedence order:
+
+1. **`publicBaseUrl` set** — `${publicBaseUrl}/${key}` unsigned. Path
+   segments URL-encoded by `joinPublicUrl`. No Box API call; file need not
+   exist.
+2. **`publicByDefault: true`** — `addShareLinkToFile` (`access: "open"`)
+   on upload; `url()` returns `download_url` ?? `url` from the shared
+   link. Idempotent on conflict (re-fetches existing link). Enterprise
+   plans may block open links (`access_denied_insufficient_permissions`).
+3. **Default** — `getDownloadFileUrl(fileId)`. Short-lived; `expiresIn`
+   is accepted for API symmetry but not passed to Box.
+
+`responseContentDisposition` always throws — Box download URLs and shared
+links have no Content-Disposition override.
+
+## Provider quirks worth remembering
+
+- **IDs vs paths.** Box's API is ID-centric. The adapter hides this with
+  virtual keys and caches (`folderIdCache`, `fileIdCache`). On `NotFound`,
+  cache entries are dropped so out-of-band moves/deletes are picked up on
+  the next call. Keys are **not** Box file IDs — do not pass `"12345"` as a
+  key unless a file is literally named that at the resolved folder.
+- **`rootFolderId` is not created for you.** Point it at an existing folder
+  (e.g. a dedicated "SDK Storage" folder). `"0"` is the user's root — on
+  enterprise accounts this is the service account's root, on personal
+  accounts the personal root.
+- **CCG `enterpriseId` vs `userId`.** Enterprise installs authenticate as
+  the service account (`enterpriseId`). App-user / managed-user flows use
+  `userId`. At least one is required.
+- **OAuth refresh seeding.** The adapter stores `{ accessToken: "", refreshToken }`
+  before the first call; the SDK's interceptor exchanges on 401. Tests
+  reach `_authHandle` (non-enumerable) — do not document as public API.
+- **50 MB upload threshold.** `SIMPLE_UPLOAD_LIMIT_BYTES` — above that,
+  `chunkedUploads.uploadBigFile`. Stream bodies are fully buffered first
+  because the SDK expects a Node `Readable`.
+- **`list()` is shallow.** Only files directly under `rootFolderId`; keys
+  in the result are **bare filenames** (`a.txt`), not full virtual paths.
+  Deep enumeration requires `raw.folders.getFolderItems` and manual
+  recursion.
+- **Content types are inferred.** Box does not persist caller-supplied
+  `contentType` on file content. `head()` / `list()` infer MIME from the
+  filename extension (`TYPE_BY_EXT` table).
+- **`signedUploadUrl` unsupported.** Box requires multipart POST with an
+  `attributes` JSON part plus file bytes — incompatible with the SDK's
+  PUT-with-headers or POST-form `SignedUpload` shapes. Use server-side
+  `upload()` or Box UI Elements for browser flows.
+- **Folder walk races.** `createFolder` conflicts (`item_name_in_use`) trigger
+  a re-resolve — another writer may have created the folder between find
+  and create.
+- **Pagination in `findChildByName`.** Folder listings paginate at 1000;
+  large folders need multiple `getFolderItems` calls during path resolution.
+
+## Testing approach
+
+Unit tests at [`../../test/box.test.ts`](../../test/box.test.ts) use a
+fully mocked `BoxClient` (in-memory `Map` store) — no live Box API calls.
+Coverage includes:
+
+- Auth validation (missing auth, multiple auth, CCG without
+  `enterpriseId`/`userId`, env `BOX_DEVELOPER_TOKEN`, OAuth/JWT/CCG
+  construction paths).
+- Upload (root default, nested folder auto-create, overwrite via
+  `uploadFileVersion`, chunked > 50 MB, body shapes, metadata/cacheControl
+  rejection, `publicByDefault` shared links).
+- Download (buffer + stream, `signal` forwarding, fetch error paths).
+- `head` lazy download, `exists`, idempotent `delete`, `copy` with nested
+  destination, shallow `list` with prefix and cursor pagination.
+- `url()` (signed default, shared link, `publicBaseUrl`, disposition throw).
+- `signedUploadUrl` throw, `rootFolderId` scoping, `mapBoxError`
+  classification table, folder/file cache behavior, path-segment conflicts,
+  createFolder race recovery, OAuth `ensureReady` seeding.
+
+Add box-specific fixtures here rather than elsewhere. When mocking, match
+the duck-typed `BoxApiError` shape (`responseInfo.statusCode` /
+`responseInfo.code`) that `mapBoxError` expects.
+
+## Coding conventions
+
+- Named exports only — `box`, `BoxAdapter`, `BoxAdapterOptions`,
+  `mapBoxError`, type aliases.
+- Construction-time validation throws
+  [`FilesError("Provider", …)`](../internal/errors.ts); operation errors
+  are caught and rethrown via `mapBoxError`.
+- Environment variables via [`readEnv`](../internal/env.ts) — never
+  `process.env` directly (Cloudflare Workers without `nodejs_compat`).
+- Path helpers (`trimSlashes`, `splitKey`, `folderCacheKey`) are module-level
+  pure functions. Folder walks and pagination loops intentionally use
+  sequential `await` (eslint `no-await-in-loop` suppressed with comments).
+- `mapBoxError` uses `||` (not `??`) for message fallback so empty-string
+  Box messages still get the default table.
+- Cache invalidation: `dropFileFromCache` on successful delete; implicit
+  invalidation on resolve `NotFound` is not implemented for folders — folder
+  cache persists until adapter instance is discarded.
+- Top-level regex in tests only; [`index.ts`](./index.ts) has none.
+
+## Releases
+
+Ships with the rest of the monorepo from
+[`../../package.json`](../../package.json). Behavioral changes (new
+options, default changes, error-shape changes) bump the `files-sdk`
+version and add an entry to [`../../CHANGELOG.md`](../../CHANGELOG.md);
+pure docs / test-only additions don't. The `box` subpath is already
+declared in `exports` — no further wiring needed for new options.
+
+## Where to look next
+
+- Unified contract & `Adapter` interface: [`../index.ts`](../index.ts).
+- Shared helpers (`joinPublicUrl`, `existsByProbe`, `DEFAULT_URL_EXPIRES_IN`):
+  [`../internal/core.ts`](../internal/core.ts).
+- `FilesError` and codes: [`../internal/errors.ts`](../internal/errors.ts).
+- Env-var reader: [`../internal/env.ts`](../internal/env.ts).
+- `StoredFile` factory: [`../internal/stored-file.ts`](../internal/stored-file.ts).
+- Provider catalog entry (search `slug: "box"`):
+  [`../providers/index.ts`](../providers/index.ts).
+- User-facing docs:
+  [`../../../../apps/web/content/docs/adapters/box.mdx`](../../../../apps/web/content/docs/adapters/box.mdx).
+- Package README: [`../../README.md`](../../README.md).
+- SKILL doc:
+  [`../../../../skills/files-sdk/SKILL.md`](../../../../skills/files-sdk/SKILL.md).
+- Tests: [`../../test/box.test.ts`](../../test/box.test.ts).

--- a/packages/files-sdk/src/box/CLAUDE.md
+++ b/packages/files-sdk/src/box/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/packages/files-sdk/src/bun-s3/AGENTS.md
+++ b/packages/files-sdk/src/bun-s3/AGENTS.md
@@ -1,0 +1,150 @@
+# AGENTS.md — `files-sdk/bun-s3`
+
+Guidance for coding agents working inside the `bun-s3` adapter. Every files-sdk adapter implements the same unified `Adapter<Raw>` contract from [`../index.ts`](../index.ts); this file only documents what is specific to `bun-s3`. Read [`README.md`](../../README.md) for the user-facing surface and [`SKILL.md`](../../../../skills/files-sdk/SKILL.md) for the cross-adapter mental model first. The sibling AWS-SDK adapter at [`../s3/index.ts`](../s3/index.ts) is a separate implementation, not a parent — they share no code, target different runtimes, and use different underlying SDKs.
+
+## Overview
+
+`bun-s3` talks to S3 (and any S3-compatible bucket) through Bun's native `Bun.S3Client` instead of `@aws-sdk/client-s3`. It is **Bun-only** — the factory throws at construction on Node, Workers, or any runtime where `globalThis.Bun.S3Client` is missing. The trade-off: a single-file adapter with zero peer dependencies that piggy-backs on Bun's built-in S3 implementation, at the cost of a few primitives that Bun's API does not expose (server-side copy, presigned POST forms with size policy, per-object cache and metadata headers).
+
+The intended audience is users whose entire stack runs on Bun — for them, the `@aws-sdk/client-s3` install (≈3 MB across `client-s3`, `s3-presigned-post`, and `s3-request-presigner`) is pure overhead because Bun ships its own implementation. When any of the missing primitives are non-negotiable on a given bucket, the right answer is to point a parallel `s3()` adapter at it from a Node process and keep `bun-s3` for the Bun-side workloads.
+
+`endpoint` and `virtualHostedStyle` are the knobs for non-AWS S3-compatible providers (Cloudflare R2, DigitalOcean Spaces, MinIO, Wasabi, Backblaze B2, …). Bun's S3 client speaks the same wire protocol; if a bucket works against AWS, it works against this adapter with the same options shape.
+
+## Directory layout
+
+```text
+packages/files-sdk/src/bun-s3/
+├── AGENTS.md          # this file
+├── CLAUDE.md          # `@AGENTS.md` shim
+└── index.ts           # adapter, types, and `mapBunS3Error`
+```
+
+Tests live one level up at [`../../test/bun-s3.test.ts`](../../test/bun-s3.test.ts) (the package keeps tests in a sibling `test/` tree, not colocated). The provider catalog entry sits at [`../providers/index.ts`](../providers/index.ts) under `slug: "bun-s3"`.
+
+## Build, test, typecheck
+
+```bash
+bun test test/bun-s3.test.ts   # this adapter's tests only
+bun test                        # the whole files-sdk test suite
+bun run build                   # tsup ESM bundle → dist/bun-s3/
+bun run types                   # tsgo --noEmit (typecheck)
+bun run test:coverage           # bun test --coverage
+```
+
+Note: the package uses **`bun test`** (not Vitest) and **`tsgo`** (the TypeScript native preview, not `tsc`). Don't introduce Vitest configs or `tsc` invocations here.
+
+## Public surface
+
+`index.ts` exports:
+
+- `bunS3(opts?)` — adapter factory. Returns `BunS3Adapter`.
+- `BunS3Adapter` — `Adapter<BunS3ClientLike> & { readonly bucket?: string }`.
+- `BunS3AdapterOptions` — construction options.
+- `mapBunS3Error(err)` — error mapper, exposed for callers that drop into `files.raw` and want to translate provider errors back into `FilesError`.
+- `BunS3ClientLike`, `BunS3FileLike`, `BunS3OperationOptions`, `BunS3PresignOptions`, `BunS3Stats`, `BunS3WritableBody`, `BunS3ListObjectsOptions`, `BunS3ListObjectsResponse` — the duck-typed `Bun.S3Client` surface area, exported so tests and host apps can implement compatible fakes without depending on `@types/bun`.
+
+The duck-typed `BunS3ClientLike` exists so the adapter doesn't take a hard build-time dependency on `@types/bun`. Anything implementing the shape (the real `Bun.S3Client`, a test fake, a sandbox shim) plugs in. Keep this surface minimal — every method added here becomes part of the public type contract.
+
+## Authentication / configuration
+
+Two construction modes, mutually exclusive:
+
+1. **Caller-supplied client.** Pass `{ client: Bun.s3 }` (or any `Bun.S3Client` instance constructed elsewhere). The adapter uses it as-is and **rejects** any of `bucket`, `region`, `endpoint`, `virtualHostedStyle`, `accessKeyId`, `secretAccessKey`, `sessionToken` at construction. The mismatch is surfaced loudly because the alternative — silently ignoring them while `adapter.bucket` reports a value the client never sees — is the kind of bug that survives review.
+2. **Self-constructed client.** Omit `client` and pass any subset of those options; the adapter calls `new Bun.S3Client({...})` itself.
+
+Env-var resolution is **Bun's job, not the adapter's**. Bun reads `S3_*` first, then `AWS_*` as aliases for `ACCESS_KEY_ID`, `SECRET_ACCESS_KEY`, `SESSION_TOKEN`, `REGION`, `BUCKET`. The adapter never touches `process.env`; if you're on a sandbox that strips it, pass values explicitly. The provider catalog notes (`readBy: "sdk-chain"`) reflect this — files-sdk does not own this resolution path.
+
+`virtualHostedStyle` defaults to `false` (path-style). Flip it on for endpoints that demand virtual-hosted addressing. `defaultUrlExpiresIn` defaults to `DEFAULT_URL_EXPIRES_IN` (3600 s) from [`../internal/core.ts`](../internal/core.ts).
+
+## Operation map
+
+Deviations from the unified `Adapter<Raw>` contract in [`../index.ts`](../index.ts):
+
+- **`upload(key, body, opts?)`** — rejects `cacheControl` and `metadata` (Bun.S3Client.write has no equivalents) with a `Provider` `FilesError`. The body union is forwarded to Bun's `write()` directly; only `ReadableStream` bodies are wrapped in `new Response(body)` to match Bun's accepted shapes. Content type follows the unified rule (`opts.contentType` wins, then `Blob.type`, then `text/plain; charset=utf-8` for strings, then `application/octet-stream`). After the write, the adapter does a follow-up `stat()` to surface authoritative `size`, `lastModified`, and `etag`; if that probe fails, it returns a thin `{ contentType, key, size }` rather than throwing.
+- **`download(key, opts?)`** — supports `as: "stream"` (delegates to `Bun.S3File.stream()`). Buffer mode prefers `bytes()` and falls back to `arrayBuffer()` for older Bun versions. Both modes pre-fetch `stat()` to populate metadata; that's one extra round trip versus the `s3()` adapter, which reads metadata from the `GetObject` response. The cost is small in practice and lets the adapter share a single `storedFromStat` factory across `download()`, `head()`, and the post-write probe in `upload()`.
+- **`head(key)`** — calls `client.stat(key)` for metadata; body accessors lazy-GET via `client.file(key).bytes()` on first use, in line with the unified `head()` contract.
+- **`exists(key)`** — uses Bun's native `client.exists()` primitive (no probe scaffold). Maps `NotFound` to `false` and rethrows everything else.
+- **`delete(key)`** — standard.
+- **`deleteMany(keys, opts?)`** — **not implemented**. The SDK falls through to `deleteManyWithFallback` from [`../internal/core.ts`](../internal/core.ts), which fans out to `delete()` with bounded concurrency (default 8). Bun.s3 has no bulk-delete primitive to wire up.
+- **`copy(from, to)`** — **client-side stream copy**. Bun.S3Client has no server-side `CopyObject`, so the adapter reads the source through this process and writes it to the destination. Doubled bandwidth, no atomicity, only the source `Content-Type` is preserved (no Content-Disposition, cache headers, custom user metadata, or ACL). For server-side copy on the same bucket, route to the `s3()` adapter.
+- **`list(opts?)`** — maps `prefix` / `limit` / `cursor` to Bun's `prefix` / `maxKeys` / `continuationToken`. Items expose lazy bodies via `client.file(key).bytes()`. `lastModified` is parsed from a string or `Date`; invalid timestamps are dropped rather than surfaced as `NaN`.
+- **`url(key, opts?)`** — presigned `GET` via `client.presign(key, { method: "GET", expiresIn, contentDisposition? })`. `publicBaseUrl` opts in to unsigned `${publicBaseUrl}/${encoded(key)}` via `joinPublicUrl`. `responseContentDisposition` forces signing even when `publicBaseUrl` is set (see URL behavior below).
+- **`signedUploadUrl(key, opts)`** — **PUT only**. Throws a `Provider` `FilesError` on `maxSize` because Bun exposes presigned URLs, not S3 POST policy fields. Returns `{ method: "PUT", url, headers: { "Content-Type": opts.contentType }? }` — `headers` is omitted entirely when no `contentType` was requested. The browser-side `PUT` must echo the bound `Content-Type` exactly, or S3 rejects the upload at request time.
+
+Body shapes accepted by `upload()` end up in `BunS3WritableBody` after the `ReadableStream` wrap: `string`, `ArrayBuffer`, `ArrayBufferView`, `Blob`, `Request`, `Response`. Bun's `write()` handles these natively, which is why this adapter skips the central `normalizeBody` helper.
+
+## URL behavior
+
+`url()` resolves via `resolveUrlStrategy` from [`../internal/core.ts`](../internal/core.ts):
+
+- `publicBaseUrl` set, no `responseContentDisposition` → `joinPublicUrl(publicBaseUrl, key)` (unsigned, permanent, **URL-encoded**). `joinPublicUrl` encodes each path segment, so pass raw keys; pre-encoded keys double-encode.
+- Otherwise → presigned `GET` with `expiresIn` (per-call, then `defaultUrlExpiresIn`, then 3600).
+
+`responseContentDisposition` always forces signing — even with `publicBaseUrl` set — because a permanent CDN URL has no signature in which to bind the override. Silently dropping it would be a stored-XSS regression on user-uploaded HTML/SVG. The override wins, intentionally.
+
+## Provider quirks worth remembering
+
+- **Bun-only at construction.** `bunS3()` throws `"only available in the Bun runtime"` if `globalThis.Bun.S3Client` is missing. There is no graceful fallback to `@aws-sdk/client-s3`.
+- **`client` and standalone options are mutually exclusive.** Passing both throws at construction with the offending keys named, so the mismatch can't sneak into production. Pick one mode.
+- **`copy()` round-trips bytes through your process.** Same-bucket copy on a 5 GB object will move 5 GB through your network twice. Reach for `s3()` when this matters.
+- **`upload()` rejects `cacheControl` / `metadata`.** Loud throw rather than silent drop. If Bun adds support, drop the guards and add the pass-through.
+- **`signedUploadUrl()` rejects `maxSize`.** Bun has no S3 POST policy primitive. Without `maxSize`, S3 presigned PUTs have **no server-side size limit**; document this for callers and prefer `s3()` when size enforcement matters.
+- **Post-write `stat()` is best-effort.** When the probe fails (rare; consistency window or revoked permissions mid-write), `upload()` returns `{ contentType, key, size }` without `etag` or `lastModified` rather than throwing. Don't treat the absence as failure.
+- **`exists()` rethrows non-NotFound.** Auth (`AccessDenied`, `ERR_S3_INVALID_SIGNATURE`, `ERR_S3_INVALID_SESSION_TOKEN`, `ERR_S3_MISSING_CREDENTIALS`) and transport failures still throw. `false` means "the bucket exists, the key doesn't" — never "something else is broken".
+- **ETag stripping.** Bun.S3Client returns ETags wrapped in literal double quotes (`"abc123"`). The adapter strips them via the module-level regex so callers see naked hex on every `head()`, `list()`, and `upload()` result.
+- **`virtualHostedStyle` defaults to path-style.** That's the inverse of some S3-compatible providers' expectations — flip it on for those endpoints.
+- **Bun owns env resolution.** files-sdk doesn't read env vars in this adapter at all. Don't add `readEnv()` calls; pass options explicitly when Bun's resolution doesn't fit the runtime.
+- **`download({ as: "stream" })` is one-shot.** The returned `StoredFile` body is single-use per the rules in [`../internal/stored-file.ts`](../internal/stored-file.ts) — calling `stream()` and then `text()` (or vice versa) throws. Buffer first or stream once.
+- **`presign()` is synchronous on Bun.** Unlike `@aws-sdk/s3-request-presigner` (which returns a `Promise<string>`), `Bun.S3Client.presign()` returns the URL directly and can throw synchronously on bad input. The adapter wraps the call in a `try { return Promise.resolve(...) } catch { return Promise.reject(mapBunS3Error(...)) }` to match the unified async contract — keep that wrapper in place if you refactor.
+- **Bun's `contentDisposition` ≠ unified `responseContentDisposition`.** The user-facing `UrlOptions.responseContentDisposition` maps to Bun's `BunS3PresignOptions.contentDisposition`. Both names are correct in their own scope; the adapter does the rename at the call site. Don't surface Bun's name in the unified API.
+- **`adapter.bucket` is optional.** The type is `readonly bucket?: string`. When Bun resolves the bucket from env (`S3_BUCKET` / `AWS_BUCKET`) and the caller didn't pass an explicit `bucket` option, the adapter can't see Bun's resolved value and `adapter.bucket` is `undefined`. Code that relies on `bucket` for telemetry should either pass it explicitly to `bunS3()` or read it off `Bun.s3` via `files.raw`.
+- **`list()` items report `application/octet-stream` for `type`.** Bun's `list` response doesn't carry per-object content type; that's a protocol-level limitation of `ListObjectsV2`, not something the adapter can synthesize. Call `head(key)` for the real type when it matters per item.
+- **Session tokens pass through.** `sessionToken` is forwarded to `Bun.S3Client` for temporary credentials (STS, IAM Identity Center). Treat it like any other secret — don't log it, don't bake it into images, refresh it before expiry.
+
+### Error mapping
+
+`mapBunS3Error` is built with `makeErrorMapper` from [`../internal/core.ts`](../internal/core.ts). The classification table is:
+
+- `notFound`: `NoSuchKey`, `NotFound`
+- `unauthorized`: `AccessDenied`, `ERR_S3_INVALID_SIGNATURE`, `ERR_S3_INVALID_SESSION_TOKEN`, `ERR_S3_MISSING_CREDENTIALS`
+- `conflict`: `PreconditionFailed`
+
+The extractor reads both the Bun-style `code` field and the AWS-style `Code` field, plus `status` / `statusCode` / `$metadata.httpStatusCode`, so consumers can throw either shape and have it classified consistently. HTTP status fallbacks (404 → NotFound, 401/403 → Unauthorized, 409/412 → Conflict) live in `makeErrorMapper` itself; don't duplicate them here. Existing `FilesError` instances pass through `mapBunS3Error` unchanged so adapters can rethrow their own programmatic errors without re-wrapping — this is exercised by the `pre-wrapped` test at the bottom of the suite.
+
+### Choosing between `bun-s3` and `s3()`
+
+Use `bun-s3` when the runtime is exclusively Bun and the bucket doesn't need server-side copy, presigned POST with a size policy, `cacheControl`, or per-object `metadata`. Use the [`s3()` adapter](../s3/index.ts) when any of those are required, or when the same code has to run on Node. The two adapters can coexist on the same bucket — wrap a `bun-s3` instance for the hot path and reach for `s3()` (or `files.raw`) only for the operations Bun's API can't express.
+
+## Testing approach
+
+Tests in [`../../test/bun-s3.test.ts`](../../test/bun-s3.test.ts) run under `bun:test` (`import { describe, expect, test } from "bun:test"`). Don't add `aws-sdk-client-mock` here — Bun.s3 doesn't go through the AWS SDK, and the AWS mocking helpers won't intercept its calls.
+
+The fixture is a hand-rolled `FakeBunS3Client` implementing `BunS3ClientLike` end-to-end: an in-memory `Map<string, Entry>` for objects, a deterministic `presign()` that reflects its options into a query string against a fixed `signingOrigin = "https://signed.example.com"`, and a recorded `writes` log for asserting pass-through. URL assertions use that origin as a marker; `publicBaseUrl` tests use `"https://cdn.example.com/"` so signed-vs-public paths are distinguishable in `expect(url).toContain(...)`. Provider errors are fabricated with `Object.assign(new Error(...), { code, status })` to exercise both the Bun-style `code` and AWS-style `Code` paths through `mapBunS3Error`.
+
+The default-client construction tests stub `globalThis.Bun.S3Client` with a fake constructor to verify option pass-through and the runtime-not-Bun guard, then restore the original in a `try / finally`. When you add a behavioral test that depends on `globalThis.Bun`, follow the same save-and-restore pattern so test ordering stays insensitive.
+
+## Coding conventions
+
+- **Named exports only.** No default exports; every public symbol is `export interface`, `export type`, `export const`, or `export function`. Public types live in `index.ts` next to the implementation.
+- **All errors flow through `FilesError`.** Wrap underlying SDK errors with `mapBunS3Error`; throw programmatic errors directly with `new FilesError("Provider", ...)`. The mapper returns `FilesError` instances unchanged, so re-wrapping is safe.
+- **Body normalization.** This adapter forwards bodies to `Bun.S3Client.write` directly because Bun's signature accepts the full union. If you ever need to inspect body bytes pre-write, route through `normalizeBody` from [`../internal/core.ts`](../internal/core.ts) instead of branching on the body union manually.
+- **No `process.env` outside `readEnv`.** [`../internal/env.ts`](../internal/env.ts) is the only place env reads are allowed. This adapter currently doesn't read env at all (Bun does), so don't introduce one.
+- **Top-level regex literals only.** The adapter has a single regex (`/^"+|"+$/gu` for ETag stripping) at module scope. Keep it that way — inline regex inside hot loops is a ReDoS risk and harms readability.
+- **Spread-only optional fields.** When constructing options for Bun's API, use the `...(opts.x && { x: opts.x })` pattern (already pervasive in this file) rather than mutating an object after creation. Keeps the call site readable and avoids leaking `undefined` into Bun's option parsers.
+
+## Releases
+
+Behavioral changes ship via Changesets. Run `bunx changeset`, choose `files-sdk` as the bumped package, and describe the user-visible change. Pure documentation edits (this file, [`../../README.md`](../../README.md), the docs MDX, the provider catalog `description`) do not need a changeset — `AGENTS.md` and `CLAUDE.md` updates are for agents, not consumers.
+
+## Where to look next
+
+- [User-facing docs](../../../../apps/web/content/docs/adapters/bun-s3.mdx)
+- [Adapter implementation](index.ts)
+- [Tests](../../test/bun-s3.test.ts)
+- [Provider catalog entry](../providers/index.ts) — search for `slug: "bun-s3"`
+- [Unified `Adapter<Raw>` contract](../index.ts) — option and result shapes
+- [Shared adapter helpers](../internal/core.ts) — `makeErrorMapper`, `joinPublicUrl`, `resolveUrlStrategy`, `DEFAULT_URL_EXPIRES_IN`, `normalizeBody`, `existsByProbe`, `collectStream`, `deleteManyWithFallback`
+- [`StoredFile` factory](../internal/stored-file.ts) — body-source kinds and the one-shot stream rule
+- [`FilesError` and codes](../internal/errors.ts)
+- [Sibling AWS-SDK adapter](../s3/index.ts) — route here when you need server-side copy, presigned POST with size policy, `cacheControl`, or `metadata`
+- [Package manifest](../../package.json) — exports map and peer-dep matrix

--- a/packages/files-sdk/src/bun-s3/CLAUDE.md
+++ b/packages/files-sdk/src/bun-s3/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/packages/files-sdk/src/bunny-storage/AGENTS.md
+++ b/packages/files-sdk/src/bunny-storage/AGENTS.md
@@ -1,0 +1,260 @@
+# AGENTS.md — `files-sdk/bunny-storage`
+
+Guidance for coding agents working on the `bunny-storage` adapter. The
+unified `Adapter` contract — call shapes, `FilesError`, `UrlOptions`,
+`SignUploadOptions`, body normalization — lives in
+[`../index.ts`](../index.ts); this file documents only bunny-storage
+deviations. `bunnyStorage()` is a **native** adapter: it talks directly to
+[Bunny Storage](https://bunny.net/storage) through
+[`@bunny.net/storage-sdk`](https://www.npmjs.com/package/@bunny.net/storage-sdk),
+not through an S3-compatible endpoint. Cross-references:
+[`../../README.md`](../../README.md),
+[`../../../../skills/files-sdk/SKILL.md`](../../../../skills/files-sdk/SKILL.md).
+
+## Overview
+
+One connected storage zone per adapter instance (`zone.connect_with_accesskey`).
+Every method calls a Bunny primitive (`file.upload`, `file.get`,
+`file.list`, `file.remove`). There is no server-side copy, no presigned
+read URL, and no presigned upload URL in the Bunny Storage API — the
+adapter surfaces those gaps honestly (`copy` read-then-writes,
+`signedUploadUrl` throws, `url` needs a CDN origin). Upload metadata
+round-trips via a post-PUT `file.get` because Bunny's PUT response carries
+no body. Listing is directory-scoped (one `file.list` per parent path),
+with client-side prefix filtering and numeric cursor pagination layered
+on top. The returned adapter exposes `name: "bunny-storage"`, a readonly
+`zone` string, and `raw` as the connected `StorageZone` client.
+
+Peer dependency (optional, in
+[`../../package.json`](../../package.json)): `@bunny.net/storage-sdk`.
+
+## Directory layout
+
+```text
+packages/files-sdk/src/bunny-storage/
+├── index.ts     # bunnyStorage() factory + mapBunnyStorageError + keyFromStorageFile
+├── AGENTS.md    # this file
+└── CLAUDE.md    # @AGENTS.md indirection
+```
+
+Tests: [`../../test/bunny-storage.test.ts`](../../test/bunny-storage.test.ts).
+User docs:
+[`../../../../apps/web/content/docs/adapters/bunny-storage.mdx`](../../../../apps/web/content/docs/adapters/bunny-storage.mdx).
+Provider catalog:
+[`../providers/index.ts`](../providers/index.ts) under `slug: "bunny-storage"`.
+
+## Build, test, typecheck
+
+```bash
+# from packages/files-sdk/
+bun test test/bunny-storage.test.ts   # this adapter's tests
+bun test                               # full suite
+bun run build                          # tsup → dist/bunny-storage/
+bun run types                          # tsgo --noEmit
+```
+
+`bun test` (not vitest) and `tsgo` (not `tsc`) are pinned. The
+`bunny-storage` subpath is in [`../../package.json`](../../package.json)'s
+`exports` map — keep it in sync if the layout changes.
+
+## Public surface
+
+Exports from [`./index.ts`](./index.ts):
+
+- `bunnyStorage(opts?: BunnyStorageAdapterOptions): BunnyStorageAdapter` —
+  factory. Throws `FilesError("Provider", …)` when `zone` + `accessKey` +
+  `region` cannot be resolved (unless `client` is passed).
+- `BunnyStorageAdapterOptions` — `zone`, `accessKey`, `region`, `client`,
+  `publicBaseUrl`. JSDoc on every field is the source of truth; the docs
+  MDX pulls it via `<AutoTypeTable>`.
+- `BunnyStorageAdapter` — `Adapter<BunnyStorageClient> & { readonly zone }`.
+  `BunnyStorageClient` is `ReturnType<typeof zone.connect_with_accesskey>`.
+- `BunnyStorageRegion` — template type over
+  `BunnyStorageSDK.regions.StorageRegion` (`"de"`, `"ny"`, `"syd"`, …).
+- `mapBunnyStorageError(err): FilesError` — exported for callers reusing
+  the same classification on errors from `raw`.
+
+## Authentication / configuration
+
+Three resolution paths, in precedence order:
+
+1. **`opts.client`** — an already-connected storage zone from
+   `@bunny.net/storage-sdk`. When set, `zone`, `accessKey`, and `region`
+   are ignored and no env vars are read. `adapter.zone` comes from
+   `zone.name(client)`.
+2. **Explicit options** — `zone` + `accessKey` + `region`, passed to
+   `zone.connect_with_accesskey(region, zone, accessKey)`. `accessKey` is
+   the Storage Zone **password** (Bunny's console label), not an account
+   API key.
+3. **Env fallbacks** — via [`readEnv`](../internal/env.ts):
+   - Zone: `BUNNY_STORAGE_ZONE`, then `STORAGE_ZONE`.
+   - Access key: `BUNNY_STORAGE_ACCESS_KEY`, then `STORAGE_ACCESS_KEY`.
+   - Region: `BUNNY_STORAGE_REGION`, then `STORAGE_REGION`.
+
+Missing any of the trio throws at construction with a message naming both
+the `BUNNY_STORAGE_*` and `STORAGE_*` aliases. Invalid `region` strings
+throw before connect — valid codes are whatever
+`Object.values(BunnyStorageSDK.regions.StorageRegion)` contains today
+(`de`, `jh`, `uk`, `la`, `ny`, `br`, `sg`, `se`, `syd`, …).
+
+Optional:
+
+- **`publicBaseUrl`** — origin for `url()` (typically a Bunny **Pull
+  Zone** or custom CDN hostname in front of the Storage Zone). Without it,
+  `url()` throws: the raw Storage API URL requires an `AccessKey` header
+  and cannot be handed out as a public link.
+
+The provider catalog entry under `slug: "bunny-storage"` in
+[`../providers/index.ts`](../providers/index.ts) mirrors the env layout:
+required zone, credential-mode access key, optional region.
+
+## Operation map
+
+All operations route errors through `mapBunnyStorageError`. Keys are
+zone-relative strings; the adapter prefixes Bunny paths with `/` via
+`toBunnyPath` / `fromBunnyPath`.
+
+- **`upload`** — `file.upload` then `file.get` for authoritative
+  `etag` / `lastModified` / `size` (streamed uploads may not know size
+  upfront). Body goes through shared
+  [`normalizeBody`](../internal/core.ts). `assertSupportedUploadOptions`
+  runs first (see quirks). If the post-upload `get` fails, returns a
+  fallback `UploadResult` from the normalized body.
+- **`download`** — `file.get` → `entry.data()`. `as: "stream"` returns a
+  lazy stream `StoredFile`; default buffers via `bytesFromStream`.
+- **`head`** — `file.get` without eagerly fetching bytes; body accessors
+  lazy-call `entry.data()`.
+- **`exists`** — [`existsByProbe`](../internal/core.ts) wrapping
+  `file.get`; `NotFound` → `false`.
+- **`delete`** — `file.remove`. The Bunny SDK returns `response.ok` and
+  does **not** throw on 4xx — missing keys delete idempotently. Only
+  network-layer failures reach the catch.
+- **`copy`** — `file.get(from)` → stream → `file.upload(to, …)` with the
+  source `contentType`. Not atomic; no server-side copy in the SDK.
+- **`list`** — `file.list(client, listDirectoryForPrefix(prefix))`,
+  filters out `isDirectory` entries, maps via `keyFromStorageFile`, then
+  client-side `prefix` filter and numeric `cursor`/`limit` slicing.
+  Emits `cursor` only when more items remain. **Shallow only:** a prefix
+  like `docs/` lists immediate children of `/docs/`, not recursive
+  descendants — nested keys under `docs/2024/` do not appear when listing
+  `docs/`.
+- **`signedUploadUrl`** — always rejects with `FilesError("Provider", …)`.
+  Bunny writes require the Storage API `AccessKey` header; proxy uploads
+  through your app or call `raw` directly.
+
+## URL behavior
+
+Bunny Storage has **no signed-read primitive**. `url(key, opts?)` does not
+call the Storage API and does not honor `expiresIn` (there is nothing to
+expire).
+
+- **`publicBaseUrl` required** — returns
+  [`joinPublicUrl(publicBaseUrl, key)`](../internal/core.ts) (URL-encodes
+  path segments). Permanent CDN URL; configure TTL and cache on the Pull
+  Zone, not in this adapter.
+- **`publicBaseUrl` absent** — throws `Provider` with guidance to set a
+  Pull Zone / CDN origin.
+- **`opts.responseContentDisposition`** — throws `Provider`. Unlike S3
+  adapters, there is no signature to bind a Content-Disposition override;
+  silently ignoring it would be a stored-XSS regression on user-uploaded
+  HTML/SVG.
+
+There is no `defaultUrlExpiresIn` option — nothing to sign.
+
+## Provider quirks worth remembering
+
+- **Storage Zone password auth.** `accessKey` is the zone password from
+  the Bunny dashboard (*FTP & API Access* → *Password*). Every Storage API
+  request carries it; treat it like a secret.
+- **Region picks the Storage API host.** Must match where the zone was
+  created. Wrong region → auth or routing failures before object I/O.
+- **CDN is separate from Storage.** Reads for end users almost always go
+  through a Pull Zone (`publicBaseUrl`). The Storage hostname itself is
+  not a public URL.
+- **Custom `metadata` throws.** Non-empty `UploadOptions.metadata` →
+  `FilesError("Provider", …)`. Bunny has no arbitrary metadata primitive.
+  An empty `{}` is allowed (no keys → no throw).
+- **`cacheControl` throws.** Configure cache behavior on the Pull Zone /
+  CDN, not per-object via Storage API.
+- **`copy` is read-then-write.** Large objects stream through your runtime;
+  not atomic; concurrent writes to the source between get and put are not
+  detected.
+- **`keyFromStorageFile` is the fragile center.** Bunny returns `Path`
+  (directory, zone-prefixed, usually trailing `/`) and `ObjectName`
+  (filename). The adapter strips the zone segment and joins carefully —
+  including defensive branches when `Path` already contains the full key
+  or when a filename equals its parent directory name. The trailing-slash
+  detector uses `(?<!\/)\/+$` to avoid ReDoS on long slash runs. Touch this
+  only with regression tests from
+  [`../../test/bunny-storage.test.ts`](../../test/bunny-storage.test.ts).
+- **Error mapping is message-regex based.** `@bunny.net/storage-sdk` throws
+  plain `Error` with English text, not structured codes. `mapBunnyStorageError`
+  regex-matches `not found`, `unauthor|access key|forbidden`, and
+  `conflict|precondition`, plus explicit `code` when present. Localization
+  or rephrasing would silently degrade to `Provider`.
+- **`etag` comes from Bunny `checksum`.** May be null; surfaced when present.
+
+## Testing approach
+
+[`../../test/bunny-storage.test.ts`](../../test/bunny-storage.test.ts)
+mocks `@bunny.net/storage-sdk` with an in-memory `Map` backing store and
+hand-built `StorageFile` shapes that mirror real Bunny semantics
+(`Path: "/<zone>/<dir>/"`, `ObjectName: "<file>"`). Coverage includes:
+
+- Construction: missing credentials, env fallbacks (`BUNNY_STORAGE_*` and
+  `STORAGE_*`), explicit options overriding env, `client` bypass, invalid
+  region.
+- Upload: round-trip metadata, head fallback on transient `get` failure,
+  `cacheControl` / metadata throws, empty metadata allowed, all `Body`
+  variants including unknown-length streams.
+- Download / head / exists / list (prefix, limit, cursor, shallow listing,
+  zone-prefix stripping, `keyFromStorageFile` edge cases).
+- Copy (content-type preservation, missing source → `NotFound`), delete
+  idempotency, `url` / `signedUploadUrl` throws, `mapBunnyStorageError`
+  classification.
+
+Add fixtures here, not in a generic storage test, whenever behavior
+depends on Bunny path semantics or SDK message shapes.
+
+## Coding conventions
+
+- Named exports only — `bunnyStorage`, `mapBunnyStorageError`, types.
+- Construction-time and capability gaps throw
+  [`FilesError("Provider", …)`](../internal/errors.ts) with the
+  `bunnyStorage:` prefix so logs stay grep-friendly. Operation errors wrap
+  via `mapBunnyStorageError`; existing `FilesError` instances pass through.
+- Read env via [`readEnv`](../internal/env.ts); never `process.env`
+  directly (Workers without `nodejs_compat`).
+- Use shared [`normalizeBody`](../internal/core.ts) and
+  [`createStoredFile`](../internal/stored-file.ts) — don't hand-roll
+  `StoredFile` bodies.
+- Top-level regex literals only (`toBunnyPath`, `keyFromStorageFile`). Keep
+  the `(?<!\/)` anchor when trimming trailing slashes.
+- Cast Bunny stream types at the boundary (`as unknown as ReadableStream`)
+  — the SDK's stream typing is narrower than WHATWG streams the adapter
+  accepts.
+
+## Releases
+
+Ships on the monorepo Changesets schedule. Behavioral changes need a
+changeset; AGENTS.md / CLAUDE.md / test-only edits do not. Peer dep
+`@bunny.net/storage-sdk` is declared optional — document version bumps in
+CHANGELOG when the adapter starts requiring newer SDK behavior.
+
+## Where to look next
+
+- Source: [`./index.ts`](./index.ts).
+- Tests: [`../../test/bunny-storage.test.ts`](../../test/bunny-storage.test.ts).
+- User docs:
+  [`../../../../apps/web/content/docs/adapters/bunny-storage.mdx`](../../../../apps/web/content/docs/adapters/bunny-storage.mdx).
+- Unified contract: [`../index.ts`](../index.ts).
+- Shared helpers:
+  [`../internal/core.ts`](../internal/core.ts),
+  [`../internal/errors.ts`](../internal/errors.ts),
+  [`../internal/env.ts`](../internal/env.ts),
+  [`../internal/stored-file.ts`](../internal/stored-file.ts).
+- Provider catalog (search `slug: "bunny-storage"`):
+  [`../providers/index.ts`](../providers/index.ts).
+- CLI registry: [`../cli/registry.ts`](../cli/registry.ts).
+- README + SKILL: [`../../README.md`](../../README.md),
+  [`../../../../skills/files-sdk/SKILL.md`](../../../../skills/files-sdk/SKILL.md).

--- a/packages/files-sdk/src/bunny-storage/CLAUDE.md
+++ b/packages/files-sdk/src/bunny-storage/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/packages/files-sdk/src/cloudinary/AGENTS.md
+++ b/packages/files-sdk/src/cloudinary/AGENTS.md
@@ -1,0 +1,274 @@
+# AGENTS.md — `files-sdk/cloudinary`
+
+Guidance for coding agents working on the `cloudinary` adapter
+([Cloudinary](https://cloudinary.com), exposed at the `files-sdk/cloudinary`
+subpath). The unified `Adapter<Raw>` contract — call shapes, `FilesError`,
+`UrlOptions`, `SignUploadOptions`, body normalization — lives in
+[`../index.ts`](../index.ts); read it first. This file documents only
+cloudinary-specific behavior. Cross-references:
+[`../../README.md`](../../README.md),
+[`../../../../skills/files-sdk/SKILL.md`](../../../../skills/files-sdk/SKILL.md).
+
+## Overview
+
+This is a **native** adapter built on the official [`cloudinary`](https://www.npmjs.com/package/cloudinary)
+Node SDK (`cloudinary.v2`). It is **media-focused**, not a drop-in S3
+replacement: assets live in Cloudinary's CDN with `public_id` keys,
+`resource_type` buckets (`image` / `video` / `raw`), and delivery `type`
+(`upload` / `private` / `authenticated`). The unified API maps `key` to
+`public_id` and treats `url()` as a **delivery URL** (transformable on
+`image`/`video` via `files.raw`), while `download()` fetches bytes over
+HTTP from that delivery URL after a metadata probe.
+
+`cloudinary(opts)` returns `CloudinaryAdapter`, which extends
+`Adapter<typeof cloudinary>` with readonly `resourceType`, `type`, and
+`cloudName`. `raw` is the `cloudinary.v2` namespace — use it for
+upload presets, eager transforms, `context`/`metadata` parameters, and
+anything outside the common subset. Peer dep: `cloudinary` (see
+[`../../package.json`](../../package.json) `peerDependencies`).
+
+## Directory layout
+
+```text
+packages/files-sdk/src/cloudinary/
+├── index.ts          # cloudinary() factory + CloudinaryAdapterOptions
+├── AGENTS.md         # this file
+└── CLAUDE.md         # `@AGENTS.md` — Claude-Code re-export
+```
+
+Sibling files: tests at
+[`../../test/cloudinary.test.ts`](../../test/cloudinary.test.ts);
+user-facing docs at
+[`../../../../apps/web/content/docs/adapters/cloudinary.mdx`](../../../../apps/web/content/docs/adapters/cloudinary.mdx);
+subpath export at `exports["./cloudinary"]` in
+[`../../package.json`](../../package.json).
+
+## Build, test, typecheck
+
+Run from `packages/files-sdk/`:
+
+```bash
+bun test test/cloudinary.test.ts   # this adapter only
+bun test                            # full SDK suite
+bun run build                       # tsup ESM → dist/cloudinary/
+bun run types                       # tsgo --noEmit
+```
+
+This package uses **`bun test`** and **`tsgo`** (not vitest/tsc).
+
+## Public surface
+
+Exports from [`./index.ts`](./index.ts):
+
+- `cloudinary(opts?: CloudinaryAdapterOptions): CloudinaryAdapter` —
+  primary factory. Alias: `cloudinaryAdapter`.
+- `CloudinaryAdapter` — `Adapter<typeof cloudinary>` plus
+  `resourceType`, `type`, `cloudName`.
+- `CloudinaryAdapterOptions`, `CloudinaryResourceType`,
+  `CloudinaryDeliveryType`.
+- `mapCloudinaryError` — exported for tests; maps provider errors to
+  `FilesError` via [`makeErrorMapper`](../internal/core.ts).
+
+The adapter's `name` is `"cloudinary"`. There is no `deleteMany` —
+the SDK fans out to `delete()` when callers use bulk delete on `Files`.
+
+## Authentication / configuration
+
+Required:
+
+- `cloudName` — string. Falls back to `CLOUDINARY_CLOUD_NAME` or the
+  cloud segment parsed from `CLOUDINARY_URL`. Missing value throws
+  `FilesError("Provider", …)` at construction.
+
+Optional (needed for `signedUploadUrl()` and for `url()` on
+`private` / `authenticated` assets):
+
+- `apiKey` — `CLOUDINARY_API_KEY` or parsed from `CLOUDINARY_URL`.
+- `apiSecret` — `CLOUDINARY_API_SECRET` or parsed from `CLOUDINARY_URL`.
+
+`CLOUDINARY_URL` format (parsed by top-level regex in
+[`./index.ts`](./index.ts)):
+
+```text
+cloudinary://<api_key>:<api_secret>@<cloud_name>
+```
+
+Malformed URLs are ignored; discrete env vars still apply.
+
+Other knobs:
+
+| Option                 | Default    | Role                                                                 |
+| ---------------------- | ---------- | -------------------------------------------------------------------- |
+| `resourceType`         | `"raw"`    | Cloudinary bucket: arbitrary bytes vs `image`/`video` transforms.      |
+| `type`                 | `"upload"` | Delivery type: public CDN vs access-controlled.                      |
+| `secure`               | `true`     | HTTPS delivery URLs (`sdk.config({ secure })`).                      |
+| `signedUrlExpiresIn`   | `3600`     | Default expiry for signed delivery URLs (`private`/`authenticated`). |
+| `client`               | —          | Pre-configured `cloudinary.v2`; skips `sdk.config()` (see quirks).   |
+
+Env vars are read via [`readEnv`](../internal/env.ts) (Workers-safe).
+Provider catalog: search `slug: "cloudinary"` in
+[`../providers/index.ts`](../providers/index.ts).
+
+## Keys, folders, and the media model
+
+- **`key` ↔ `public_id`.** Every operation passes `key` as Cloudinary's
+  `public_id`. Slashes are folder segments (`user-1/avatar.png`), not
+  a separate bucket name — there is no `bucket` option.
+- **`list({ prefix })`** maps to Admin API `prefix` (folder filter).
+  Pagination uses opaque `cursor` ↔ `next_cursor`.
+- **`resource_type` is fixed per adapter instance.** Pick `"raw"` for
+  S3-style arbitrary files; `"image"` / `"video"` when you want format
+  inference (`image/png`, `video/mp4`) and transformation URLs from
+  `files.raw.url(...)`. The unified adapter does not embed transform
+  parameters in `url()` — that stays on the SDK escape hatch.
+- **Delivery vs storage.** `upload()` ingests via Admin upload API;
+  `url()` returns CDN delivery URLs (`sdk.url` or
+  `sdk.utils.private_download_url`). `download()` GETs the delivery URL
+  (not a separate "raw storage" endpoint). Transformed bytes are
+  whatever the delivery URL serves; for untransformed originals on
+  images, use `raw` resource type or signed admin download via `raw`.
+
+## Operation map
+
+Errors flow through `mapCloudinaryError` — classification is **HTTP
+status only** (`404 → NotFound`, `401/403 → Unauthorized`; empty
+provider code sets). `exists` uses
+[`existsByProbe`](../internal/core.ts) on `sdk.api.resource`.
+
+| Method            | Implementation                                                                                    |
+| ----------------- | ------------------------------------------------------------------------------------------------- |
+| `upload`          | Buffer body → `sdk.uploader.upload_stream` with `public_id: key`, `overwrite: true`, `invalidate: true`. Returns `response.public_id` as `key`. |
+| `download`        | Parallel `sdk.api.resource` + `fetch(sdk.url(key))`. `signal` forwarded to fetch. 404 → `NotFound`. |
+| `head`            | `sdk.api.resource` → `createStoredFile` with lazy body factory (same delivery fetch as download). |
+| `exists`          | Probe `sdk.api.resource`; `NotFound` → `false`.                                                   |
+| `delete`          | `sdk.uploader.destroy` with `invalidate: true`.                                                   |
+| `copy`            | **No native copy.** `sdk.uploader.upload(sourceDeliveryUrl, { public_id: to })` — re-ingest from CDN URL. New `asset_id` / `etag`. |
+| `list`            | `sdk.api.resources` with `prefix`, `next_cursor`, `max_results` (default 100, max 500). Items use `public_id` as `key`, lazy bodies. |
+| `url`             | See [URL behavior](#url-behavior).                                                                |
+| `signedUploadUrl` | Local `sdk.utils.api_sign_request` + POST to `https://api.cloudinary.com/v1_1/{cloud}/{resourceType}/upload`. |
+
+Rejected `UploadOptions`:
+
+- `cacheControl` — throws `Provider` (no per-asset HTTP cache headers).
+- `metadata` with keys — throws `Provider`; empty `{}` is allowed.
+
+Rejected `UrlOptions`:
+
+- `responseContentDisposition` — throws `Provider`.
+
+## URL behavior
+
+Behavior depends on constructor `type`:
+
+- **`type: "upload"` (default).** `url(key)` returns `sdk.url(key, {
+  resource_type, type, secure })` — a **public, non-expiring** delivery
+  URL. `opts.expiresIn` is ignored. This is the normal path for public
+  assets and for `raw` arbitrary-byte storage.
+- **`type: "private"` or `"authenticated"`.** `url()` first calls
+  `sdk.api.resource` to read `format`, then
+  `sdk.utils.private_download_url(key, format, { expires_at, resource_type, type })`.
+  Expiry: `opts.expiresIn ?? signedUrlExpiresIn` (default 3600 via
+  [`DEFAULT_URL_EXPIRES_IN`](../internal/core.ts)). **Raw assets without
+  a stored `format`** cannot be signed — error tells callers to put the
+  extension in `public_id`.
+- **No `publicBaseUrl` knob.** Cloudinary's CDN origin is implicit in
+  `sdk.url`; callers don't configure a separate origin.
+
+Signed upload shape differs from S3-style presigned PUT:
+
+- `method: "POST"`, `url` = Admin upload endpoint, `fields` =
+  `{ api_key, public_id, signature, timestamp, content_type? }`.
+- Requires `apiKey` + `apiSecret` at construction.
+- `SignUploadOptions.expiresIn` / `maxSize` / `minSize` are not enforced
+  by this adapter (Cloudinary signatures are ~1h; size limits need an
+  upload preset via `raw`).
+
+## Provider quirks worth remembering
+
+- **Global SDK config.** Unless `client` is passed, the factory calls
+  `sdk.config({ cloud_name, api_key, api_secret, secure })` on the
+  module-level `cloudinary.v2` namespace. Multiple adapters with
+  different credentials in one process: **last config wins**. Use
+  separate pre-configured `client` instances for isolation.
+- **`upload_stream` is callback-shaped.** Wrapped in a Promise locally;
+  don't expect an upstream promise API.
+- **`copy()` is ingest-by-URL, not byte copy.** Source must be reachable
+  at its delivery URL; duplicates billing/transform pipeline semantics.
+- **`download()` / lazy `head()` / `list()` hit the CDN.** Admin API
+  for metadata only; body transfer is `fetch` on the delivery URL.
+- **Invalidation on write/delete.** `invalidate: true` on upload and
+  destroy busts CDN cache — good for freshness, costly at scale.
+- **List ceiling.** `limit` clamped to 500 (Cloudinary Admin API max).
+- **Image/video transforms** live outside the unified API. With
+  `resourceType: "image"` or `"video"`, callers build transform URLs via
+  `files.raw.url(publicId, { transformation: [...] })` or upload-time
+  `transformation` / `eager` on `files.raw.uploader.upload`.
+- **No `deleteMany`.** Bulk delete fans out in `Files` with bounded
+  concurrency.
+
+## Testing approach
+
+Tests in [`../../test/cloudinary.test.ts`](../../test/cloudinary.test.ts)
+mock `cloudinary` via `mock.module("cloudinary", …)` and stub
+`globalThis.fetch` for download paths. Coverage areas:
+
+- Construction: missing `cloudName`, `CLOUDINARY_URL` parse, discrete
+  env vars, malformed URL fallback, `client` skips `config()`.
+- Defaults: `resourceType: "raw"`, `type: "upload"`.
+- `upload`: `upload_stream` opts (`public_id`, `overwrite`), body shapes
+  (string, `Uint8Array`, `ReadableStream`), `cacheControl`/`metadata`
+  throws, empty metadata allowed, `image`/`video` content-type inference.
+- `download` / `head`: lazy fetch, 404/500 classification, `signal`
+  forwarded.
+- `exists`: true/false/401 rethrow.
+- `delete` / `copy` / `list`: delegation, prefix/cursor, limit clamp 500.
+- `url`: public `sdk.url`, private signed URL + `expiresIn`,
+  `responseContentDisposition` throw, missing `format` on private raw.
+- `signedUploadUrl`: POST shape, signature params, missing secret throw.
+- `mapCloudinaryError`: 404/401 mapping, `FilesError` passthrough.
+
+Add cloudinary-specific cases here; shared `Files` behavior belongs in
+core tests.
+
+## Coding conventions
+
+- Named exports only — `cloudinary`, `cloudinaryAdapter`,
+  `CloudinaryAdapter`, `CloudinaryAdapterOptions`, `mapCloudinaryError`.
+- Construction-time misconfig → `FilesError("Provider", …)`; operations
+  wrap caught errors with `mapCloudinaryError` (preserves existing
+  `FilesError`).
+- Env via [`readEnv`](../internal/env.ts) — never bare `process.env`.
+- Use [`createStoredFile`](../internal/stored-file.ts) for all
+  `StoredFile` returns; lazy download factory matches other adapters.
+- Body normalization via [`normalizeBody` / `collectStream`](../internal/core.ts)
+  in `toBuffer` before `upload_stream`.
+- Top-level regex only (`parseCloudinaryUrl`). Keep upload_stream's
+  `new Promise` wrapper — upstream has no promise API.
+- When adding options, update JSDoc on `CloudinaryAdapterOptions` (MDX
+  `AutoTypeTable` reads it), provider catalog env block, and tests.
+
+## Releases
+
+Ships with the monorepo from [`../../package.json`](../../package.json).
+Behavioral changes bump `files-sdk` version and
+[`../../CHANGELOG.md`](../../CHANGELOG.md); docs/tests-only need no
+version bump. The `./cloudinary` export is already wired in `exports`
+and [`../../tsup.config.ts`](../../tsup.config.ts).
+
+## Where to look next
+
+- Source: [`./index.ts`](./index.ts); tests:
+  [`../../test/cloudinary.test.ts`](../../test/cloudinary.test.ts).
+- User-facing docs:
+  [`../../../../apps/web/content/docs/adapters/cloudinary.mdx`](../../../../apps/web/content/docs/adapters/cloudinary.mdx).
+- Provider catalog (search `slug: "cloudinary"`):
+  [`../providers/index.ts`](../providers/index.ts).
+- Unified contract: [`../index.ts`](../index.ts); shared helpers:
+  [`../internal/core.ts`](../internal/core.ts),
+  [`../internal/stored-file.ts`](../internal/stored-file.ts),
+  [`../internal/errors.ts`](../internal/errors.ts),
+  [`../internal/env.ts`](../internal/env.ts).
+- README: [`../../README.md`](../../README.md); SKILL:
+  [`../../../../skills/files-sdk/SKILL.md`](../../../../skills/files-sdk/SKILL.md).
+- CLI registry entry: [`../cli/registry.ts`](../cli/registry.ts)
+  (`cloudinary` slug).

--- a/packages/files-sdk/src/cloudinary/CLAUDE.md
+++ b/packages/files-sdk/src/cloudinary/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/packages/files-sdk/src/convex/AGENTS.md
+++ b/packages/files-sdk/src/convex/AGENTS.md
@@ -1,0 +1,271 @@
+# AGENTS.md — `files-sdk/convex`
+
+Guidance for coding agents working on the `convex` adapter
+([Convex file storage](https://docs.convex.dev/file-storage), exposed at
+the `files-sdk/convex` subpath). The unified `Adapter<Raw>` contract —
+call shapes, `FilesError`, `UrlOptions`, `SignUploadOptions`, body
+normalization — lives in [`../index.ts`](../index.ts); read it first.
+This file documents only convex-specific behavior. Cross-references:
+[`../../README.md`](../../README.md),
+[`../../../../skills/files-sdk/SKILL.md`](../../../../skills/files-sdk/SKILL.md).
+
+## Overview
+
+This is a **native** adapter — no inner `s3()` shim, no AWS SDK, no HTTP
+client you configure at the edge. Every operation is implemented against
+Convex's in-deployment file storage API: `ctx.storage` for blob I/O and
+URL minting, and `ctx.db.system` for enumerating the built-in `_storage`
+system table. Construct it **per Convex function invocation** with the
+live function context: `convex({ ctx })` inside your `action`, `mutation`,
+or `query` handler.
+
+Convex is **not object storage**. There are no buckets, regions, access
+keys, or a public REST surface you call from outside the deployment.
+Files live in Convex storage scoped to a single deployment; auth is
+implicit in the function context (your deployment URL and Convex's
+runtime), not static credentials in env vars. The unified `key` is
+Convex's opaque storage id (`Id<"_storage">`, typed as `string` here) —
+the caller never chooses it on upload.
+
+`convex(opts)` returns `Adapter<ConvexCtx>`. `raw` is the same `ctx`
+object you passed in (`storage` plus optional `db.system`), so the escape
+hatch is the full Convex context — call `files.raw.storage.store(...)` or
+query `files.raw.db.system` directly when you need primitives outside the
+unified API.
+
+Peer dep: [`convex`](https://www.npmjs.com/package/convex), optional in
+[`../../package.json`](../../package.json). Shared plumbing:
+[`../internal/core.js`](../internal/core.js) (`normalizeBody`,
+`collectStream`), [`../internal/stored-file.js`](../internal/stored-file.js),
+[`../internal/errors.js`](../internal/errors.js).
+
+## How this differs from object storage
+
+Object-storage adapters (S3, R2, GCS, Wasabi, …) share a mental model:
+hierarchical keys under a named bucket, long-lived credentials or IAM,
+presigned URLs with expiry, and often user metadata on the object.
+Convex file storage breaks that model in ways that affect every method:
+
+| Object storage assumption | Convex behavior |
+| ------------------------- | --------------- |
+| Caller chooses the object key | `upload()` **ignores** the key argument; Convex assigns `Id<"_storage">` and returns it as `UploadResult.key`. Persist that id in your own table. |
+| Keys are path-like (`avatars/uuid.png`) | Storage ids are opaque strings (e.g. `kg2abc…`). `list({ prefix })` filters by **literal id prefix**, not folder paths — rarely useful. |
+| Bucket + region + credentials | Single deployment store; **no env vars**. Only `ctx` from the running function. |
+| `metadata` / `cacheControl` on the object | `_storage` is fixed: `contentType`, `sha256`, `size`, `_creationTime`. Custom metadata must live in **your** table keyed by the storage id. |
+| `copy(from, to)` server-side | **Unsupported** — ids are immutable; download then upload and track the new id. |
+| Presigned GET with `expiresIn` | `url()` returns a **permanent** serving URL while the file exists; `expiresIn` is ignored. |
+| Multipart POST signed upload | `signedUploadUrl()` returns `{ method: "POST", url, fields: {} }` — browser sends the **raw body**, response JSON `{ storageId }` is the key. |
+
+Do **not** set `prefix` on `new Files({ adapter, prefix })` with this
+adapter — the SDK would prepend a path segment and corrupt the storage id.
+Use unscoped keys that are exactly the Convex storage id.
+
+## Directory layout
+
+```text
+packages/files-sdk/src/convex/
+├── index.ts          # convex() factory + ConvexAdapterOptions
+├── AGENTS.md         # this file
+└── CLAUDE.md         # `@AGENTS.md` — Claude-Code re-export
+```
+
+Sibling files: tests at
+[`../../test/convex.test.ts`](../../test/convex.test.ts); user-facing docs at
+[`../../../../apps/web/content/docs/adapters/convex.mdx`](../../../../apps/web/content/docs/adapters/convex.mdx);
+subpath export at `exports["./convex"]` in
+[`../../package.json`](../../package.json).
+
+## Build, test, typecheck
+
+Run from `packages/files-sdk/`:
+
+```bash
+bun test test/convex.test.ts   # this adapter only
+bun test                        # full SDK suite
+bun run build                   # tsup ESM → dist/convex/
+bun run types                   # tsgo --noEmit
+```
+
+This package uses **`bun test`** (not vitest) and **`tsgo`** (not `tsc`).
+The type-assignability tests in `convex.test.ts` only compile under
+`bun run types` — they guard that real `GenericActionCtx` /
+`GenericMutationCtx` / `GenericQueryCtx` remain assignable to `ConvexCtx`.
+
+## Public surface
+
+Exports from [`./index.ts`](./index.ts):
+
+- `convex(opts: ConvexAdapterOptions): ConvexAdapter` — primary factory.
+  Requires `opts.ctx` with at least `storage.getUrl`.
+- `ConvexAdapter` — `Adapter<ConvexCtx>`. `raw` is the passed-in `ctx`.
+- `ConvexAdapterOptions` — `{ ctx: ConvexCtx }`; JSDoc on `ctx` documents
+  per-context operation availability (docs MDX pulls via `AutoTypeTable`).
+- `ConvexCtx` — structural type for `storage` + optional `db.system`.
+  Real Convex contexts are assignable without casting (verified in tests).
+
+The adapter's `name` is `"convex"`.
+
+## Authentication / configuration
+
+There is **no** `readEnv` path and no provider env vars. The provider
+catalog entry (`slug: "convex"` in
+[`../providers/index.ts`](../providers/index.ts)) lists config as
+`ctx (Convex function context)` with the note that upload/download need
+an action and list needs a query or mutation.
+
+Required:
+
+- `ctx` — the Convex function context for the current request. Missing
+  or invalid `ctx` throws `FilesError("Provider", …)` at construction.
+
+Which operations work depends on what Convex exposes on that `ctx`
+(feature-detected at runtime, not by function kind enum):
+
+| Context | Typical availability |
+| ------- | -------------------- |
+| **action** / **httpAction** | `upload`, `download`, `delete`, `url`, `head`, `exists`, `signedUploadUrl`. **`list` throws** (no `ctx.db`). |
+| **mutation** | `delete`, `url`, `head`, `exists`, `list`, `signedUploadUrl`. **`upload` / `download` throw** (no `store` / `get`). |
+| **query** | `url`, `head`, `exists`, `list` (read-only). No writes, no signed upload URL. |
+
+The adapter checks `typeof storage.<method> === "function"` (and
+`ctx.db` for `list`) and throws a descriptive `FilesError("Provider", …)`
+when the primitive is missing — do not assume all methods work in every
+handler.
+
+## Operation map
+
+Errors flow through `mapConvexError`: not-found phrasing in the message →
+`NotFound`; everything else → `Provider` with the original error as
+`cause`. Convex often signals absence with `null` returns; those paths
+are handled inline before mapping.
+
+| Method | Behavior |
+| ------ | -------- |
+| `upload` | `storage.store(blob)` after [`normalizeBody`](../internal/core.js). Caller `key` **ignored**; returned `key` is the assigned id. Rejects `metadata` and `cacheControl`. Requires action context. |
+| `download` | `storage.get` → buffer `StoredFile`; `etag` from sha256, `lastModified` from system table when available. Requires action context. |
+| `head` | Metadata via `readMeta` (`ctx.db.system.get("_storage", id)` preferred, else `storage.getMetadata`). Lazy body via `loadBytes` (action only). If metadata missing but `getUrl` succeeds, returns minimal metadata (`size: 0`, empty sha256). |
+| `exists` | `storage.getUrl(key) !== null`. `NotFound` from provider → `false`. |
+| `delete` | `storage.delete`; idempotent when mapped error is `NotFound`. Requires mutation or action. |
+| `list` | `ctx.db.system.query("_storage").paginate({ cursor, numItems })`; default `limit` 1000. Requires query or mutation. Items use lazy `loadBytes` factories. |
+| `url` | `storage.getUrl`; permanent URL. `expiresIn` ignored. `responseContentDisposition` throws — no signature to bind override. |
+| `signedUploadUrl` | `storage.generateUploadUrl()` → POST with empty `fields`. Convex controls ~1h expiry; `expiresIn` / size / content-type opts ignored. Key arg ignored. |
+| `copy` | Always throws — immutable ids, no server-side copy to a chosen key. |
+
+`deleteMany` is not implemented; the `Files` class falls back to
+per-key `delete` via [`deleteManyWithFallback`](../internal/core.js).
+
+`readMeta(key)` centralizes metadata: prefers `ctx.db.system.get("_storage",
+key)` (includes `_creationTime` → `lastModified`); in actions without
+`db`, falls back to deprecated `storage.getMetadata`.
+
+## URL behavior
+
+- **Permanent serving URLs.** `url(key)` returns whatever Convex's
+  `storage.getUrl` provides; valid while the file exists. Do not treat
+  `expiresIn` as meaningful.
+- **`responseContentDisposition` throws `Provider`.** Convex URLs have no
+  signing primitive to bind a Content-Disposition override; silently
+  dropping it would be a stored-XSS regression on user-uploaded HTML/SVG
+  (same rationale as [`resolveUrlStrategy`](../internal/core.js) on
+  signing adapters).
+- **Untrusted downloads.** Serve sensitive or user-uploaded content through
+  your own HTTP action with explicit headers rather than relying on
+  `url()` overrides.
+
+## Signed upload flow
+
+`signedUploadUrl()` is for browser-direct uploads via Convex's upload
+endpoint:
+
+1. Call from a **mutation or action** (writer context).
+2. Client `POST`s the file as the **raw request body** (not multipart
+   form data).
+3. Response body is JSON `{ storageId }` — that string is the file's
+   `key` for subsequent `download` / `head` / `delete` / `url`.
+
+The unified `SignedUpload` shape uses `fields: {}` because Convex does not
+use S3-style POST policies.
+
+## Provider quirks worth remembering
+
+- **Store extra fields in your schema.** Link `storageId` in a `files`
+  table (or similar) for filenames, ownership, ACLs — the adapter cannot
+  attach arbitrary metadata to `_storage`.
+- **`etag` is sha256.** Mapped from Convex's content hash, not a weak
+  HTTP ETag from a CDN.
+- **Lazy list/head bodies need actions.** `head()` from a query returns
+  metadata but `arrayBuffer()` on the `StoredFile` throws until you read
+  from an action context (tests assert this).
+- **Type branding.** Real Convex code uses `Id<"_storage">`; the adapter
+  uses plain `string` so structural typing stays simple. Branded ids are
+  assignable to `string`.
+- **No `readEnv`.** Unlike S3-style adapters, never add env-based config
+  here — it would imply an external API that does not exist.
+- **Convex `null` vs throw.** `get`, `getUrl`, and metadata helpers return
+  `null` for missing files; the adapter translates those to `NotFound` or
+  `false` (`exists`) as appropriate.
+
+## Testing approach
+
+[`../../test/convex.test.ts`](../../test/convex.test.ts) uses an in-memory
+fake that mirrors Convex's context gating (`actionCtx`, `mutationCtx`,
+`queryCtx` from one shared store). Coverage includes:
+
+- Construction without `ctx`, `name` / `raw` exposure.
+- Upload ignoring caller key, body shapes (string, `Uint8Array`, `Blob`,
+  stream), explicit `contentType`, unsupported `metadata` / `cacheControl`.
+- Context gating errors for upload/download/list/signedUploadUrl.
+- `head` lazy body, `lastModified` from system table in query context,
+  `exists`, idempotent `delete`.
+- `url` serving URL and `responseContentDisposition` rejection.
+- `signedUploadUrl` POST shape; `copy` unsupported.
+- `list` pagination and metadata on items.
+- `Files` wrapper integration (`files.raw === ctx`).
+- Type-level assignability of real Convex context types to `ConvexCtx`
+  (compile-only under `bun run types`).
+
+Extend this fake when adding behavior — do not hit a live deployment from
+unit tests.
+
+## Coding conventions
+
+- Named exports only — `convex`, `ConvexAdapter`, `ConvexAdapterOptions`,
+  `ConvexCtx`.
+- Use [`normalizeBody`](../internal/core.js) and [`collectStream`](../internal/core.js)
+  for uploads; [`createStoredFile`](../internal/stored-file.js) for every
+  `StoredFile`.
+- Feature-detect Convex methods with `typeof fn === "function"` — Convex
+  gates APIs by context; do not branch on a hard-coded handler kind string.
+- `ConvexStorageLike` uses method declarations (not arrow properties) so
+  TypeScript's method-parameter bivariance accepts real `StorageReader` /
+  `StorageWriter` types with branded `Id<"_storage">` parameters.
+- Top-level regex only in `mapConvexError` (`/not found|…/iu`) — keep new
+  patterns at module scope.
+- Throw `FilesError("Provider", …)` for unsupported options and missing
+  context; preserve `cause` when re-wrapping caught errors.
+- Do not add bucket/region/credential options — stay aligned with Convex's
+  deployment-scoped storage model.
+
+## Releases
+
+Ships with the rest of the monorepo via Changesets. Behavioral changes
+need a changeset (`bunx changeset`, pick `files-sdk`). Pure docs / test
+additions do not. The `convex` subpath is already in `exports` — new
+options only need JSDoc + MDX `AutoTypeTable` updates unless the export
+map changes.
+
+## Where to look next
+
+- Source: [`./index.ts`](./index.ts); tests:
+  [`../../test/convex.test.ts`](../../test/convex.test.ts).
+- User-facing docs:
+  [`../../../../apps/web/content/docs/adapters/convex.mdx`](../../../../apps/web/content/docs/adapters/convex.mdx).
+- Provider catalog (search `slug: "convex"`):
+  [`../providers/index.ts`](../providers/index.ts).
+- Unified contract: [`../index.ts`](../index.ts); shared helpers:
+  [`../internal/core.js`](../internal/core.js),
+  [`../internal/errors.js`](../internal/errors.js),
+  [`../internal/stored-file.js`](../internal/stored-file.js).
+- Package README: [`../../README.md`](../../README.md); SKILL:
+  [`../../../../skills/files-sdk/SKILL.md`](../../../../skills/files-sdk/SKILL.md).
+- Upstream: [Convex file storage](https://docs.convex.dev/file-storage).

--- a/packages/files-sdk/src/convex/CLAUDE.md
+++ b/packages/files-sdk/src/convex/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/packages/files-sdk/src/digitalocean-spaces/AGENTS.md
+++ b/packages/files-sdk/src/digitalocean-spaces/AGENTS.md
@@ -1,0 +1,219 @@
+# AGENTS.md — `files-sdk/digitalocean-spaces`
+
+Guidance for coding agents working inside the `digitalocean-spaces`
+adapter. This file is scoped to DigitalOcean Spaces only — the unified
+`Adapter<Raw>` contract lives in [`../index.ts`](../index.ts), and the
+package-wide overview and integration skill are in
+[`../../README.md`](../../README.md) and
+[`../../../../skills/files-sdk/SKILL.md`](../../../../skills/files-sdk/SKILL.md).
+The adapter is a thin wrapper around [`../s3/index.ts`](../s3/index.ts)
+with DigitalOcean-friendly defaults — region-derived endpoint,
+virtual-hosted addressing, and a Spaces-CDN-aware `publicBaseUrl`.
+Redirect S3-primitive questions to `../s3/`.
+
+## Overview
+
+`digitaloceanSpaces(opts)` returns an `Adapter<S3Client>`. It builds an
+`S3Client` via the shared `s3()` factory with three Spaces-specific
+overrides:
+
+- Endpoint defaults to `https://${region}.digitaloceanspaces.com` when
+  the caller doesn't pass one.
+- Credential env fallback reads `DO_SPACES_KEY` / `DO_SPACES_SECRET`
+  instead of the AWS chain.
+- Provider-error label is rewritten from `"S3 error"` to
+  `"Spaces error"` so users don't see surprise "S3 error" strings.
+
+Everything else — error mapping, signing, presigned POST forms, bulk
+delete chunking, the `publicBaseUrl` short-circuit — is inherited
+unchanged from `s3()`. The wrapper is ~100 lines because that is all
+it needs to be.
+
+## Directory layout
+
+```
+packages/files-sdk/src/digitalocean-spaces/
+└── index.ts        # digitaloceanSpaces() factory + options type
+```
+
+Tests live at
+[`../../test/digitalocean-spaces.test.ts`](../../test/digitalocean-spaces.test.ts),
+user-facing docs at
+[`../../../../apps/web/content/docs/adapters/digitalocean-spaces.mdx`](../../../../apps/web/content/docs/adapters/digitalocean-spaces.mdx),
+and the provider-catalog entry (env vars, peer deps, description) in
+[`../providers/index.ts`](../providers/index.ts) under
+`slug: "digitalocean-spaces"`.
+
+## Build, test, typecheck
+
+Run from the package root (`packages/files-sdk`):
+
+```bash
+bun test test/digitalocean-spaces.test.ts   # focused
+bun test                                    # whole suite
+bun run build                               # tsup ESM bundle → dist/
+bun run types                               # tsgo --noEmit
+```
+
+The package uses `tsgo` (typescript-go) — not `tsc`. The `build`
+script bumps `--max-old-space-size`, so prefer the package script over
+invoking `tsup` directly. Tests use Bun's `bun:test` and
+`aws-sdk-client-mock` to stub the S3 client.
+
+## Public surface
+
+One factory and its option type, both from `index.ts`:
+
+```ts
+export const digitaloceanSpaces: (
+  opts: DigitalOceanSpacesAdapterOptions,
+) => DigitalOceanSpacesAdapter; // = Adapter<S3Client>
+```
+
+`DigitalOceanSpacesAdapterOptions` carries `bucket` and `region`
+(required), plus optional `endpoint`, `accessKeyId`, `secretAccessKey`,
+`forcePathStyle`, `publicBaseUrl`, and `defaultUrlExpiresIn`. The
+returned adapter sets `name: "digitalocean-spaces"` (overriding the
+inner `s3` adapter's `"s3"`). `raw` is the underlying `S3Client` —
+reach for it for behaviour the unified API doesn't model (CORS,
+lifecycle, bucket policy, …).
+
+## Authentication / configuration
+
+`bucket` and `region` are required and have **no env-var fallback**.
+The factory throws `FilesError("Provider", …)` at construction when
+`region` is empty — intentionally early, before any request hits the
+network.
+
+Credentials come from one of:
+
+| Source                                        | Order                |
+| --------------------------------------------- | -------------------- |
+| `accessKeyId` / `secretAccessKey` options     | explicit values win  |
+| `DO_SPACES_KEY` / `DO_SPACES_SECRET` env vars | fallback             |
+
+Missing credentials throw with a message naming both. The env pair is
+`DO_SPACES_KEY` / `DO_SPACES_SECRET` (matching the DigitalOcean
+dashboard) — not the AWS-style `DO_SPACES_ACCESS_KEY_ID` /
+`DO_SPACES_SECRET_ACCESS_KEY`. The provider catalog mirrors this via
+the shared `s3Compatible(...)` helper. DigitalOcean publishes no
+`DO_REGION` convention, so region is always explicit; `bucket` is
+likewise explicit because Spaces routes by Host header.
+
+## Operation map
+
+Every method on the returned adapter is the inner `s3()` implementation
+unchanged — see [`../s3/index.ts`](../s3/index.ts) for details.
+
+| Method                         | Backed by                                                         |
+| ------------------------------ | ----------------------------------------------------------------- |
+| `upload` / `download`          | `PutObjectCommand` / `GetObjectCommand`                           |
+| `head` / `exists`              | `HeadObjectCommand` (the latter via `existsByProbe`)              |
+| `delete` / `deleteMany`        | `DeleteObjectCommand` / `DeleteObjectsCommand` (1000-key batches) |
+| `copy` / `list`                | `CopyObjectCommand` / `ListObjectsV2Command`                      |
+| `url`                          | `getSignedUrl` over `GetObjectCommand`, or `joinPublicUrl` when `publicBaseUrl` is set |
+| `signedUploadUrl`              | `createPresignedPost` (with `maxSize`), else `getSignedUrl` over `PutObjectCommand` |
+
+If you need to extend behaviour, change the wrapper — not the inner
+`s3()`. The S3 adapter is shared by ~15 wrappers (MinIO, Wasabi,
+Backblaze B2, Storj, Hetzner, Akamai, Tigris, …) and breaking changes
+ripple.
+
+## URL behavior
+
+`url(key, opts?)` follows the standard signing-adapter rules documented
+in `../index.ts` and the SKILL: presigned `GetObject` by default,
+`publicBaseUrl` as the unsigned short-circuit,
+`responseContentDisposition` forcing the signing path even when
+`publicBaseUrl` is set. Default expiry is 3600 s from
+`DEFAULT_URL_EXPIRES_IN`; override via `defaultUrlExpiresIn` or per-call
+`url(key, { expiresIn })`. Two DigitalOcean-specific notes:
+
+- **CDN host.** Spaces ships an opt-in CDN at
+  `https://${bucket}.${region}.cdn.digitaloceanspaces.com`. Pass it as
+  `publicBaseUrl` to return that permanent URL from `url()`; otherwise
+  `url()` signs against the origin (`${region}.digitaloceanspaces.com`).
+- **Custom CNAME.** When a Space is fronted by a custom domain (the
+  CDN is attached to the CNAME), set `publicBaseUrl` to that domain.
+  `joinPublicUrl` URL-encodes path segments — pass raw keys.
+
+## Provider quirks worth remembering
+
+- **Virtual-hosted addressing is canonical.** Spaces routes by Host
+  header — the bucket subdomain is prepended onto
+  `${region}.digitaloceanspaces.com`. The AWS SDK default
+  (`forcePathStyle: false`) is what we want, so the wrapper only
+  forwards `forcePathStyle` when the caller sets it explicitly.
+- **Wire-compatible with S3, not feature-parity.** Versioning, Object
+  Lock, S3 Select, and several replication primitives are absent — a
+  caller reaching through `raw` to send one of those commands fails at
+  the wire.
+- **Error label.** `defaultProviderMessage: "Spaces error"` is threaded
+  into `mapS3Error` so unknown errors get a `FilesError` with
+  `message: "Spaces error"` rather than `"S3 error"`. Known
+  classifications (`NotFound`, `Unauthorized`, `Conflict`) still
+  surface the upstream message when present.
+
+## Testing approach
+
+[`../../test/digitalocean-spaces.test.ts`](../../test/digitalocean-spaces.test.ts)
+covers the four pieces of behaviour specific to this wrapper:
+
+1. **Endpoint derivation.** Region drives the default host; explicit
+   `endpoint` overrides; `forcePathStyle` defaults to `false`.
+2. **Credential resolution.** Explicit options win; `DO_SPACES_KEY` /
+   `DO_SPACES_SECRET` are the fallbacks; missing region or credentials
+   throw at construction.
+3. **URL strategy.** Default `url()` signs against the region host
+   (`X-Amz-Signature=` and `nyc3.digitaloceanspaces.com` in the result);
+   `publicBaseUrl` short-circuits to a plain concatenation.
+4. **Error relabelling.** `mapS3Error` is called directly with the
+   Spaces message table to confirm the provider fallback is
+   `"Spaces error"`.
+
+Delegation tests (`upload`, `exists`) use `aws-sdk-client-mock` to catch
+wrapper-level regressions (e.g. dropping `defaultProviderMessage` or
+`endpoint`). Don't re-test the inner `s3()` adapter — that is covered
+by [`../../test/s3.test.ts`](../../test/s3.test.ts).
+
+## Coding conventions
+
+- One named export per file; no default exports. Factory and option
+  type live together in `index.ts`.
+- **Forward options conditionally** with
+  `...(opts.foo !== undefined && { foo: opts.foo })` so unset fields
+  stay absent in the inner config — the AWS SDK distinguishes
+  `undefined` from "key missing" for some fields.
+- Throw `FilesError` from
+  [`../internal/errors.ts`](../internal/errors.ts) for construction-time
+  validation. Runtime errors go through the inner `s3()` adapter's
+  mapper — don't add a second wrapping layer.
+- No `process.env` access outside
+  [`../internal/env.ts`](../internal/env.ts) — `readEnv` tolerates
+  runtimes where `process` is undefined (Cloudflare Workers without
+  `nodejs_compat`). Keep the factory body flat.
+
+## Releases
+
+The adapter ships with the rest of `files-sdk` from
+[`../../package.json`](../../package.json) on the package's normal
+release cadence. Behavioural changes need a release note; option
+additions and docs-only edits do not. When adding an option: extend
+`DigitalOceanSpacesAdapterOptions` with JSDoc naming any env fallback
+and default, thread it into `s3({...})` using the
+`...(opt !== undefined && { opt })` pattern, mirror user-visible env
+vars in [`../providers/index.ts`](../providers/index.ts), and add a
+wrapper-level test.
+
+## Where to look next
+
+- Source: [`./index.ts`](./index.ts)
+- Tests: [`../../test/digitalocean-spaces.test.ts`](../../test/digitalocean-spaces.test.ts)
+- Inner S3 adapter (almost all behaviour lives here): [`../s3/index.ts`](../s3/index.ts)
+- Unified `Adapter<Raw>` contract: [`../index.ts`](../index.ts)
+- Shared helpers (`joinPublicUrl`, `resolveUrlStrategy`, `makeErrorMapper`, `existsByProbe`): [`../internal/core.ts`](../internal/core.ts)
+- `FilesError` / `FilesErrorCode`: [`../internal/errors.ts`](../internal/errors.ts)
+- Provider-catalog entry: [`../providers/index.ts`](../providers/index.ts)
+- User-facing docs: [`../../../../apps/web/content/docs/adapters/digitalocean-spaces.mdx`](../../../../apps/web/content/docs/adapters/digitalocean-spaces.mdx)
+- Package README: [`../../README.md`](../../README.md)
+- Integration skill: [`../../../../skills/files-sdk/SKILL.md`](../../../../skills/files-sdk/SKILL.md)

--- a/packages/files-sdk/src/digitalocean-spaces/CLAUDE.md
+++ b/packages/files-sdk/src/digitalocean-spaces/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/packages/files-sdk/src/dropbox/AGENTS.md
+++ b/packages/files-sdk/src/dropbox/AGENTS.md
@@ -1,0 +1,320 @@
+# AGENTS.md — `files-sdk/dropbox`
+
+Guidance for coding agents working inside the `files-sdk/dropbox`
+adapter. Every adapter implements the same `Adapter<Raw>` contract from
+[`../index.ts`](../index.ts); this file documents only the
+dropbox-specific deviations. For the unified surface, read
+[`../../README.md`](../../README.md) and
+[`../../../../skills/files-sdk/SKILL.md`](../../../../skills/files-sdk/SKILL.md)
+first.
+
+Dropbox is a NATIVE adapter — it talks to the official `dropbox` SDK
+directly rather than going through `s3()`. Most adapter-level bugs
+land in one of two places: the four-shaped auth resolver (pre-built
+client, static token, callable token, OAuth refresh-token flow) or
+the URL strategy that splits between 4-hour temporary links and
+permanent shared links.
+
+## Overview
+
+Dropbox via the official `dropbox` SDK. Family: **consumer file
+provider** (alongside `google-drive`, `onedrive`, `box`, `sharepoint`).
+Path-addressable like OneDrive — virtual keys map directly to Dropbox
+paths under an optional `rootFolderPath` virtual bucket root, so there
+is no virtual-key cache and no ID resolution.
+
+The unified surface — `upload`, `download`, `head`, `exists`,
+`delete`, `copy`, `list`, `url` — is implemented natively against the
+SDK's `filesUpload` / `filesDownload` / `filesGetMetadata` /
+`filesDeleteV2` / `filesCopyV2` / `filesListFolder` /
+`sharingCreateSharedLinkWithSettings` / `filesGetTemporaryLink`
+primitives. `signedUploadUrl()` throws — see Operation map. Optional
+peer dependency: `dropbox`.
+
+## Directory layout
+
+```text
+packages/files-sdk/src/dropbox/
+├── index.ts                # adapter implementation + auth resolver
+├── AGENTS.md               # this file
+└── CLAUDE.md               # `@AGENTS.md`
+```
+
+Sibling files outside this directory:
+
+- Tests: [`../../test/dropbox.test.ts`](../../test/dropbox.test.ts)
+  (adapter behaviour) and
+  [`../../test/dropbox-auth.test.ts`](../../test/dropbox-auth.test.ts)
+  (auth resolver + refresh flow).
+- User docs:
+  [`../../../../apps/web/content/docs/adapters/dropbox.mdx`](../../../../apps/web/content/docs/adapters/dropbox.mdx).
+- Provider catalog entry (search `slug: "dropbox"`):
+  [`../providers/index.ts`](../providers/index.ts).
+
+## Build, test, typecheck
+
+Run from `packages/files-sdk/`:
+
+```bash
+bun test test/dropbox.test.ts         # adapter unit tests
+bun test test/dropbox-auth.test.ts    # auth resolver + refresh-token flow
+bun test                              # full SDK suite
+bun run build                         # tsup ESM bundle -> dist/dropbox/
+bun run types                         # tsgo --noEmit (typecheck only)
+```
+
+This package uses **`bun test`** (not vitest) and **`tsgo`** (not
+`tsc`). The per-subpath bundle output is `dist/dropbox/index.{js,d.ts}`
+per the `exports` map in [`../../package.json`](../../package.json).
+
+## Public surface
+
+Defined in [`./index.ts`](./index.ts):
+
+- `dropbox(opts: DropboxAdapterOptions): DropboxAdapter` — primary
+  factory.
+- `DropboxAdapter` — `Adapter<DropboxClient> & { readonly rootFolderPath: string }`
+  so callers can read the configured root without re-passing it.
+- `DropboxClient` — type alias for the SDK's `Dropbox` class. `raw` is
+  the underlying client.
+- `DropboxAdapterOptions` — config interface; JSDoc on every field is
+  the source of truth (the docs MDX pulls it via `AutoTypeTable`).
+- `mapDropboxError(err): FilesError` — exported for tests and callers
+  that need to classify an SDK error themselves.
+
+The adapter also hangs a non-enumerable `_authHandle` for the auth
+tests to reach `ensureAccessToken` / `getAccessToken`. Test-only —
+don't promote it to the public type.
+
+## Authentication / configuration
+
+Dropbox's auth is the most distinctive part of this adapter. Four
+shapes are accepted, with a strict "exactly one" rule:
+
+1. **Pre-built `client`** — pass a `Dropbox` instance you already
+   constructed (team-space `pathRoot`, shared `DropboxAuth`, custom
+   headers, …). The adapter never refreshes; you own the token
+   lifecycle. `ensureAccessToken()` is a no-op.
+2. **Static `accessToken: string`** — applied at construction via
+   `DropboxAuth({ accessToken })`. `ensureAccessToken()` is a no-op.
+3. **Callable `accessToken: () => string | Promise<string>`** — the
+   resolver is awaited on **every** call and pushed into the SDK
+   before the request goes out. The adapter does not cache the
+   result; caching/refresh is the caller's responsibility. Pairs
+   naturally with secret managers.
+4. **OAuth2 refresh-token flow** — `refreshToken` plus `appKey`, and
+   optionally `appSecret`. The adapter exchanges credentials at
+   `https://api.dropboxapi.com/oauth2/token` and caches the access
+   token until ~60s before expiry (`REFRESH_LEEWAY_MS = 60_000`).
+   Confidential (server-side) clients pass both `appKey` and
+   `appSecret`; PKCE-only public clients pass `appKey` alone and
+   `client_secret` is omitted from the form body.
+
+Mode selection rules (enforced in `resolveAuth`): `client` wins
+outright; `accessToken` together with any refresh-flow field throws
+`Provider`; refresh flow requires both `refreshToken` and `appKey`.
+The SDK's own auto-refresh is **not** activated — `DropboxAuth({})`
+is constructed without `refreshToken` / `clientId` so the SDK can't
+race the adapter's refresh. The adapter is the sole refresh authority
+and the SDK just sees a fresh token on each call (via `setAccessToken`).
+
+Env-var fallback (read via [`readEnv`](../internal/env.ts), safe on
+Cloudflare Workers without `nodejs_compat`): `DROPBOX_ACCESS_TOKEN`
+for static-token mode, or `DROPBOX_REFRESH_TOKEN` + `DROPBOX_APP_KEY`
+(+ optional `DROPBOX_APP_SECRET`) for the refresh flow. If nothing
+resolves, construction throws `FilesError("Provider", …)` enumerating
+every accepted shape.
+
+## Operation map
+
+Every method awaits `authHandle.ensureAccessToken()` before issuing
+the SDK call and catches with `mapDropboxError`.
+
+- `upload` — `filesUpload` with `mode: { ".tag": "overwrite" }` and
+  `mute: true` for bodies up to `SIMPLE_UPLOAD_LIMIT_BYTES`
+  (`150 * 1024 * 1024`, Dropbox's single-call cap). Larger bodies
+  switch to the chunked path: `filesUploadSessionStart` →
+  N × `filesUploadSessionAppendV2` (8 MiB chunks) →
+  `filesUploadSessionFinish`. `metadata` and `cacheControl` throw
+  `Provider` at the boundary — Dropbox files carry neither field
+  natively. With `publicByDefault: true`, a shared link is also
+  created on upload (idempotent — see URL behavior).
+- `download` — buffer path issues `filesDownload` and extracts bytes
+  from either `fileBinary` (Node) or `fileBlob` (browser/Workers).
+  Stream path is special: the SDK's `filesDownload` buffers the full
+  response, so true streaming falls back to `filesGetTemporaryLink`
+  plus a `fetch()` against the returned URL (which exposes
+  `Response.body` as a real `ReadableStream`). `signal` only flows
+  through on the stream path; the SDK transport has no cancellation
+  primitive.
+- `head` — `filesGetMetadata`. Folder/deleted entries are rejected as
+  `NotFound`. The returned `StoredFile` installs a lazy body factory
+  that re-issues `filesDownload` on first body access — not free.
+- `exists` — `existsByProbe` against `filesGetMetadata` with the same
+  folder/deleted rejection (duplicated because the probe wrapper
+  expects a `NotFound` throw, not a sentinel value).
+- `delete` — `filesDeleteV2`. Idempotent: a mapped `NotFound` returns
+  silently; other errors propagate.
+- `copy` — `filesCopyV2` (server-side; no read+write round-trip).
+- `list` — `filesListFolder` with `recursive: true`;
+  `filesListFolderContinue` when a `cursor` is passed. Folders and
+  any entry whose path equals `rootFolderPath` are dropped. When
+  `has_more` is set, `result.cursor` is surfaced as
+  `ListResult.cursor`.
+- `url` — see URL behavior below.
+- `signedUploadUrl` — throws `Provider`. Dropbox's
+  `files/get_temporary_upload_link` returns a URL that requires
+  `POST` with `Content-Type: application/octet-stream` and the raw
+  bytes as the body. Our `SignedUpload` shape supports
+  PUT-with-raw-body or POST-with-form-fields (S3 policy style); a
+  raw-body POST fits neither. The JSDoc points callers at
+  `adapter.raw.filesGetTemporaryUploadLink(...)`.
+
+Body normalization is local (the dropbox SDK accepts Node `Buffer`,
+which the shared [`normalizeBody`](../internal/core.ts) does not
+preserve). Error mapping (`mapDropboxError`) walks the SDK's
+discriminated `.tag` union with a depth-6 guard, classifies by first
+matching tag, then falls back to HTTP status. Tag sets:
+
+- `NOT_FOUND_TAGS = { not_found, not_file, not_folder, restricted_content }`
+- `UNAUTH_TAGS = { invalid_access_token, expired_access_token, missing_scope, user_suspended, route_access_denied, access_denied }`
+- `CONFLICT_TAGS = { conflict, no_write_permission, shared_link_already_exists }`
+
+HTTP 409 alone is **not** a `Conflict` signal — Dropbox uses 409 as
+the generic envelope for endpoint-specific errors and the actual
+classification lives in the body tags. `FilesError` instances pass
+through untouched.
+
+## URL behavior
+
+`url(key, opts?)` follows a three-state decision tree distinct from
+the signing-adapter precedence:
+
+1. `publicBaseUrl` set → `${publicBaseUrl}/${key}` via
+   [`joinPublicUrl`](../internal/core.ts). No network call, no
+   signing. Useful when a CDN sits in front of pre-shared Dropbox
+   links.
+2. `publicByDefault: true` → creates (or retrieves) a permanent
+   public shared link via `sharingCreateSharedLinkWithSettings`. The
+   result is rewritten so `?dl=0` becomes `?dl=1` (raw bytes instead
+   of the preview page); URLs that already carry a `dl=` parameter
+   are left untouched, and URLs with no `dl=` get `?dl=1` (or `&dl=1`
+   when a query string is already present) appended.
+3. Otherwise → mints a `filesGetTemporaryLink`. The per-call
+   `expiresIn` beats `defaultUrlExpiresIn`, which is clamped at
+   construction to `MAX_TEMPORARY_LINK_DURATION = 14_400` (4 hours,
+   Dropbox's maximum). Per-call values above 14400 throw `Provider`
+   with guidance to switch to `publicByDefault: true` for a permanent
+   link.
+
+`responseContentDisposition` always throws `Provider` — neither
+temporary nor shared links honour a disposition override on Dropbox,
+and silently dropping the override is the kind of stored-XSS
+regression [`resolveUrlStrategy`](../internal/core.ts) explicitly
+guards against elsewhere.
+
+The shared-link creation path handles `shared_link_already_exists`:
+the SDK throws with the existing link's metadata at
+`err.error.shared_link_already_exists.metadata.url`, and the adapter
+reuses that URL (rewriting `dl=0` → `dl=1`). If the embedded
+metadata is empty or missing, the original error is rethrown.
+
+## Provider quirks worth remembering
+
+- **Plan policy can forbid public shared links.** Dropbox Business
+  teams may disable public shared links entirely. The adapter
+  surfaces Dropbox's `access_denied` error unmodified (classified as
+  `Unauthorized`) — don't retry or fall back to a temporary link;
+  the team policy is the answer.
+- **150 MB simple-upload limit.** Bodies above
+  `SIMPLE_UPLOAD_LIMIT_BYTES` switch to `filesUploadSession*` with
+  8 MiB chunks (session ceiling is Dropbox's 350 GB cap). The
+  boundary is inclusive — exactly 150 MiB uses the simple path;
+  150 MiB + 1 byte uses the session path.
+- **Path normalization is case-insensitive.** Dropbox lowercases
+  paths, so `head()` and `list()` results may carry casing different
+  from what the caller uploaded. The adapter prefers `path_display`
+  and falls back to `path_lower`.
+- **No native content-type or arbitrary metadata.** `filesUpload`
+  accepts no Content-Type; `download()` infers a MIME from the
+  filename extension via the local `TYPE_BY_EXT` table.
+  `upload(..., { metadata })` throws — escape hatch is `adapter.raw`
+  plus `property_groups` (requires a registered Dropbox template).
+- **Refresh-flow cache is per-instance.** The cached
+  `{ token, expiresOnMs }` is not shared across processes;
+  multi-process deployments mint independent tokens. Dropbox
+  tolerates this, but OAuth-endpoint log volume scales with process
+  count.
+- **`rootFolderPath` must already exist.** The adapter does not
+  auto-create folders. `keyToPath` joins `rootFolderPath` with the
+  virtual key under a single leading slash; `pathToKey` strips it
+  back off for `list()` so callers see un-prefixed keys.
+
+## Testing approach
+
+Two test files split the surface:
+
+- [`../../test/dropbox.test.ts`](../../test/dropbox.test.ts) — uses a
+  hand-rolled `fakeClient` implementing every Dropbox SDK method as a
+  `mock(...)` returning `{ headers, result, status }` envelopes from
+  an in-memory `Map<string, FakeFile>`. Covers the full operation
+  map, every `mapDropboxError` branch (tag-based and status
+  fallback), simple-vs-session upload, body shapes (`string`,
+  `Uint8Array`, `Blob`, `ArrayBuffer`, `ArrayBufferView`,
+  `ReadableStream`), stream-mode download via the temporary-link
+  fetch, the `publicByDefault` flow including
+  `shared_link_already_exists` recovery and rethrow, `rootFolderPath`
+  nesting, and the chunked-upload offset math.
+- [`../../test/dropbox-auth.test.ts`](../../test/dropbox-auth.test.ts)
+  — exercises the auth resolver in isolation via `_authHandle`.
+  Covers static / callable / refresh-token modes, the 60s pre-expiry
+  refresh leeway, the PKCE-vs-confidential `client_secret` toggle,
+  env-var fallbacks, the non-OK response and missing-`access_token`
+  failure paths, and the unreadable-error-body defensive branch.
+
+`bun test` is the runner — no vitest. When adding behaviour, prefer
+extending the existing `fakeClient` over fabricating new SDK shapes
+inline.
+
+## Coding conventions
+
+- Named exports only — no default exports.
+- Errors flow through `mapDropboxError`; `FilesError` instances
+  short-circuit so internal throws aren't rewrapped.
+- Body normalization is the local `normalizeBody` (returns `Buffer`),
+  not the shared [`normalizeBody`](../internal/core.ts) (returns
+  `Uint8Array`). The Dropbox SDK accepts `Buffer` directly;
+  converting through `Uint8Array` would force a redundant copy.
+- The SDK's published `.d.ts` omits the `auth` field on the `Dropbox`
+  class, but the constructor stores it at runtime. Cast through
+  `DropboxWithAuth` rather than `as any`.
+- No `process.env` outside [`readEnv`](../internal/env.ts). Use
+  `createStoredFile` from
+  [`../internal/stored-file.ts`](../internal/stored-file.ts) for
+  every `StoredFile` returned. The non-enumerable `_authHandle` is
+  test-only — don't promote it and don't reach for it elsewhere.
+
+## Releases
+
+Ships via Changesets. Behavioural changes (new options, default
+changes, error-shape changes, new auth modes) need a changeset — run
+`bunx changeset` from the repo root and pick `files-sdk`. README,
+AGENTS.md, and pure test additions don't. The Dropbox subpath is
+already declared in [`../../package.json`](../../package.json)
+`exports`.
+
+## Where to look next
+
+- Unified `Adapter` contract: [`../index.ts`](../index.ts); source:
+  [`./index.ts`](./index.ts); tests:
+  [`../../test/dropbox.test.ts`](../../test/dropbox.test.ts),
+  [`../../test/dropbox-auth.test.ts`](../../test/dropbox-auth.test.ts).
+- Shared helpers: [`../internal/core.ts`](../internal/core.ts),
+  [`../internal/errors.ts`](../internal/errors.ts),
+  [`../internal/env.ts`](../internal/env.ts).
+- Provider catalog (search `slug: "dropbox"`):
+  [`../providers/index.ts`](../providers/index.ts).
+- User docs:
+  [`../../../../apps/web/content/docs/adapters/dropbox.mdx`](../../../../apps/web/content/docs/adapters/dropbox.mdx);
+  package [`README`](../../README.md);
+  [`SKILL`](../../../../skills/files-sdk/SKILL.md).

--- a/packages/files-sdk/src/dropbox/CLAUDE.md
+++ b/packages/files-sdk/src/dropbox/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/packages/files-sdk/src/exoscale/AGENTS.md
+++ b/packages/files-sdk/src/exoscale/AGENTS.md
@@ -1,0 +1,220 @@
+# AGENTS.md — `files-sdk/exoscale`
+
+Guidance for coding agents working on the `exoscale` adapter. The unified
+`Adapter<Raw>` contract — call shapes, `FilesError`, `UrlOptions`,
+`SignUploadOptions`, body normalization — lives in
+[`../index.ts`](../index.ts); this file only documents exoscale-specific
+behavior. `exoscale()` is a thin wrapper around [`s3()`](../s3/index.ts)
+for Exoscale Object Storage (SOS — Simple Object Storage)'s
+S3-compatible API, so operation map, error mapping, and presign
+mechanics all live in the S3 adapter — see
+[`../s3/AGENTS.md`](../s3/AGENTS.md). Cross-references:
+[`README.md`](../../README.md),
+[`SKILL.md`](../../../../skills/files-sdk/SKILL.md).
+
+## Overview
+
+A thin shim that calls `s3()` with an Exoscale SOS endpoint, Exoscale
+API-key credentials, and a `defaultProviderMessage` of `"Exoscale error"`
+so callers don't see `"S3 error"` from an Exoscale-typed adapter. No
+per-method code: every operation is forwarded by spread. The only
+exoscale-specific knobs are endpoint derivation from the zone code, the
+credential env-var pair, and the error relabel. The returned `raw` is
+`@aws-sdk/client-s3`'s `S3Client`, so any AWS SDK feature SOS supports
+(multipart, lifecycle rules, versioning) is one property access away.
+
+## Directory layout
+
+```text
+packages/files-sdk/src/exoscale/
+├── index.ts                   # exoscale() factory + ExoscaleAdapterOptions
+├── AGENTS.md                  # this file
+└── CLAUDE.md                  # @AGENTS.md — Claude-Code re-export
+```
+
+Tests at [`../../test/exoscale.test.ts`](../../test/exoscale.test.ts);
+user-facing docs at
+[`../../../../apps/web/content/docs/adapters/exoscale.mdx`](../../../../apps/web/content/docs/adapters/exoscale.mdx).
+
+## Build, test, typecheck
+
+Run from `packages/files-sdk`:
+
+```bash
+bun test test/exoscale.test.ts   # adapter unit tests only
+bun test                          # full SDK suite
+bun run build                     # tsup → dist/, including dist/exoscale/
+bun run types                     # tsgo --noEmit (typecheck only)
+```
+
+The `exoscale` subpath is enumerated in
+[`../../package.json`](../../package.json)'s `exports` map — keep it in
+sync if the file layout changes.
+
+## Public surface
+
+Exports from [`index.ts`](./index.ts):
+
+- `exoscale(opts: ExoscaleAdapterOptions): ExoscaleAdapter` — factory.
+- `ExoscaleAdapter` — alias for `Adapter<S3Client>`; `raw` is the AWS
+  SDK client.
+- `ExoscaleAdapterOptions` — config interface; JSDoc on every field is
+  the source of truth (the docs MDX pulls it via `AutoTypeTable`).
+
+Adapter `name` is `"exoscale"` (set after spreading the inner adapter,
+overriding `s3()`'s `"s3"`).
+
+## Authentication / configuration
+
+Required:
+
+- `bucket` — string. **No env fallback**; pass it explicitly.
+- `region` — Exoscale zone code (`ch-gva-2`, `ch-dk-2`, `de-fra-1`,
+  `de-muc-1`, `at-vie-1` / `at-vie-2`, `bg-sof-1` — see the JSDoc for
+  the canonical list). Exoscale calls them **zones**, but they fill
+  the SigV4 region slot and drive endpoint derivation. **No env
+  fallback** — missing region throws `FilesError("Provider", …)` at
+  construction with a message that explicitly names the zone-vs-region
+  terminology mismatch.
+- Credentials — `accessKeyId` + `secretAccessKey`, passed in or sourced
+  from `EXOSCALE_API_KEY` / `EXOSCALE_API_SECRET`. Missing both throws
+  `FilesError("Provider", …)`.
+
+Optional:
+
+- `endpoint` — overrides the derived `https://sos-${region}.exo.io`
+  (use for VPC endpoints, custom CNAMEs, or test doubles).
+- `forcePathStyle` — defaults to `false`; flip only for proxies that
+  demand path-style.
+- `publicBaseUrl` — origin used by `url()` when set; skips signing.
+  Natural values are `https://sos-${region}.exo.io/${bucket}`
+  (path-style), `https://${bucket}.sos-${region}.exo.io`
+  (virtual-hosted), or a custom CNAME fronting the bucket.
+- `defaultUrlExpiresIn` — default presigned-URL expiry (seconds);
+  defaults to `3600` via `DEFAULT_URL_EXPIRES_IN` in
+  [`../internal/core.ts`](../internal/core.ts).
+
+No `EXOSCALE_REGION` or `EXOSCALE_BUCKET` env-var fallback. The provider
+catalog entry in [`../providers/index.ts`](../providers/index.ts) (search
+`slug: "exoscale"`) declares the same two credential env vars and treats
+`bucket` / `region` as explicit config. Env lookups go through
+[`readEnv`](../internal/env.ts) so the adapter is safe to import on
+runtimes without `process`.
+
+## Operation map
+
+`exoscale()` calls `s3()` and spreads the returned adapter, overriding
+only `name`. Every operation (`upload`, `download`, `head`, `exists`,
+`delete`, `deleteMany`, `copy`, `list`, `url`, `signedUploadUrl`) lives
+in [`../s3/index.ts`](../s3/index.ts) and is inherited unchanged —
+including `deleteMany`'s 1000-key chunking, `signedUploadUrl`'s
+PUT-vs-presigned-POST split on `maxSize`, and `exists`' 404-as-`false`
+classification. Provider errors flow through `mapS3Error` with the
+Exoscale fallback table — `Provider` messages read `"Exoscale error"`
+while preserving any server-side message on the wire.
+
+## URL behavior
+
+`url(key, opts?)` follows the standard signing-adapter rules:
+
+- Default: presigned `GetObject` URL, expiring after
+  `opts.expiresIn ?? defaultUrlExpiresIn` seconds.
+- With `publicBaseUrl`: returns `${publicBaseUrl}/${key}` unsigned, via
+  `joinPublicUrl` in [`../internal/core.ts`](../internal/core.ts)
+  (URL-encodes path segments).
+- With `opts.responseContentDisposition`: always signs, even when
+  `publicBaseUrl` is set — a permanent CDN URL has no signature to bind
+  the override to, and silently dropping it is a stored-XSS regression
+  on user-uploaded HTML/SVG. See `resolveUrlStrategy` for the rationale.
+
+SOS has no built-in CDN, so most callers leave `publicBaseUrl` unset and
+let reads flow through a presigned URL.
+
+## Provider quirks worth remembering
+
+- **Exoscale calls them "zones", not regions.** Pass the zone code
+  (`ch-gva-2`, `de-fra-1`, …) as `region`. The string fills both the
+  SigV4 region slot and the endpoint subdomain — pick the wrong one
+  and signatures fail before the request reaches the bucket. The
+  construction-time error message restates this so users debugging a
+  `missing region` throw don't go looking for a zone-shaped option.
+- **Endpoint shape is `sos-<zone>.exo.io`** — not `s3.<zone>.…` like
+  AWS-style providers, and not `<zone>.exo.io`. Override `endpoint`
+  only for VPC hosts or custom CNAMEs.
+- **Buckets are zone-scoped.** Pick at create time; the Exoscale Portal
+  has no cross-zone replication primitive.
+- **Virtual-hosted is canonical.** SOS routes by `Host` header. Set
+  `forcePathStyle: true` only for proxies that demand path-style.
+- **API keys, not IAM roles.** Generate in the Exoscale Portal under
+  *IAM → API Keys*. Static `key` / `secret` pairs are the only auth
+  mode the S3-compatible API exposes — no instance-metadata equivalent
+  for Exoscale Compute VMs at SOS.
+
+## Testing approach
+
+Unit tests at [`../../test/exoscale.test.ts`](../../test/exoscale.test.ts) cover:
+
+- Endpoint derivation from `region` (`ch-gva-2`, `de-fra-1`) —
+  `client.config.endpoint()` hostname is `sos-<zone>.exo.io`,
+  `forcePathStyle` defaults to `false`.
+- Explicit `endpoint` and `forcePathStyle: true` overrides reaching the
+  inner `S3Client` config.
+- Missing-region and missing-credential errors at construction.
+- `EXOSCALE_API_KEY` / `EXOSCALE_API_SECRET` env-var fallbacks (with
+  save/restore around `process.env` so tests stay order-independent).
+- `url()` presign default (`X-Amz-Signature`, `X-Amz-Expires=3600`,
+  `sos-ch-gva-2.exo.io` host) and `publicBaseUrl` short-circuit.
+- Operation delegation via `aws-sdk-client-mock`'s `mockClient(S3Client)`
+  — `upload` and `exists` reach the underlying client, including the
+  404-as-`false` branch on `HeadObjectCommand`.
+- Error relabeling: `mapS3Error` with the Exoscale messages table
+  returns `"Exoscale error"` for `Provider`.
+
+Add exoscale-specific fixtures here (endpoint host, relabel, env-var
+name); shared S3 semantics belong in
+[`../../test/s3.test.ts`](../../test/s3.test.ts).
+
+## Coding conventions
+
+- Named exports only — `exoscale`, `ExoscaleAdapter`,
+  `ExoscaleAdapterOptions`.
+- Construction-time errors use
+  [`FilesError("Provider", …)`](../internal/errors.ts); operation
+  errors are the inner S3 adapter's responsibility — don't try-catch
+  and rethrow in this shim.
+- Read env vars via [`readEnv`](../internal/env.ts); direct
+  `process.env` access breaks Cloudflare Workers without `nodejs_compat`.
+- Forward optional knobs with `...(opts.x !== undefined && { x: opts.x })`
+  so unset values fall through to AWS-SDK defaults rather than as
+  explicit `undefined`.
+- Spread the inner adapter, then override only `name` — preserves any
+  future additions to `Adapter` that `s3()` picks up automatically.
+- Keep `ExoscaleAdapterOptions` JSDoc accurate — the docs MDX
+  `AutoTypeTable` reads this file, so an undocumented field ships
+  undocumented.
+- Top-level regex literals only.
+
+## Releases
+
+Ships with the rest of the monorepo from
+[`../../package.json`](../../package.json). Behavioral changes (new
+options, default changes, error-shape changes) bump `files-sdk` and add
+an entry to [`../../CHANGELOG.md`](../../CHANGELOG.md); docs / test-only
+additions don't. The `exoscale` subpath is already declared in
+`exports` — no further wiring needed for new options.
+
+## Where to look next
+
+- Unified contract: [`../index.ts`](../index.ts).
+- Inner S3 adapter: [`../s3/index.ts`](../s3/index.ts) +
+  [`../s3/AGENTS.md`](../s3/AGENTS.md).
+- Shared helpers: [`../internal/core.ts`](../internal/core.ts);
+  [`FilesError`](../internal/errors.ts);
+  [`readEnv`](../internal/env.ts).
+- Provider catalog (search `slug: "exoscale"`):
+  [`../providers/index.ts`](../providers/index.ts).
+- User docs:
+  [`../../../../apps/web/content/docs/adapters/exoscale.mdx`](../../../../apps/web/content/docs/adapters/exoscale.mdx);
+  [README](../../README.md);
+  [SKILL](../../../../skills/files-sdk/SKILL.md);
+  [tests](../../test/exoscale.test.ts).

--- a/packages/files-sdk/src/exoscale/CLAUDE.md
+++ b/packages/files-sdk/src/exoscale/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/packages/files-sdk/src/filebase/AGENTS.md
+++ b/packages/files-sdk/src/filebase/AGENTS.md
@@ -1,0 +1,230 @@
+# AGENTS.md — `files-sdk/filebase`
+
+Guidance for coding agents working inside the `files-sdk/filebase`
+subpath. The unified `Adapter<Raw>` contract lives in
+[`../index.ts`](../index.ts); this file only documents filebase-specific
+deviations. `filebase()` is a thin wrapper around
+[`s3()`](../s3/index.ts) pointed at [Filebase](https://filebase.com)'s
+S3-compatible gateway, which fronts decentralized storage networks
+(IPFS, Sia, Storj) with the network chosen *per bucket* in the Filebase
+console. See [`../s3/AGENTS.md`](../s3/AGENTS.md) for primitive-level
+details on the operation map, error mapping, and presign mechanics.
+Cross-references: [`README.md`](../../README.md),
+[`SKILL.md`](../../../../skills/files-sdk/SKILL.md).
+
+## Overview
+
+`filebase()` is a config translator: every call is forwarded to
+`s3({ ... })` with the Filebase endpoint, Filebase credentials, and a
+`defaultProviderMessage` of `"Filebase error"` so callers don't see
+`"S3 error"` from a Filebase-typed adapter. No per-method code lives
+here; every operation is inherited by spread. The only filebase-specific
+knobs are the default endpoint (`https://s3.filebase.com`), the
+credential env-var pair, and the error-message relabel. The returned
+adapter's `raw` is the underlying `@aws-sdk/client-s3` `S3Client`, so
+anything the AWS SDK can do against the gateway is one property access
+away.
+
+What makes Filebase unusual: the bucket's storage network is chosen in
+the dashboard at create time, not per-request. IPFS-backed buckets
+populate `x-amz-meta-cid` on `HeadObject` / `GetObject` responses, so
+the s3 adapter's pass-through of `result.Metadata` surfaces the content
+address as `storedFile.metadata?.cid`. Sia and Storj buckets behave like
+opaque S3 with no extra headers.
+
+## Directory layout
+
+```
+packages/files-sdk/src/filebase/
+├── index.ts        # filebase() factory + FilebaseAdapterOptions
+├── AGENTS.md       # this file
+└── CLAUDE.md       # @AGENTS.md — Claude-Code re-export
+```
+
+Tests at [`../../test/filebase.test.ts`](../../test/filebase.test.ts);
+docs at [`filebase.mdx`](../../../../apps/web/content/docs/adapters/filebase.mdx).
+The `filebase` subpath is enumerated in
+[`../../package.json`](../../package.json)'s `exports` map — keep it in
+sync if the file layout changes.
+
+## Build, test, typecheck
+
+Run from `packages/files-sdk`:
+
+```bash
+bun test test/filebase.test.ts   # adapter unit tests only
+bun test                          # full SDK suite
+bun run build                     # tsup → dist/, including dist/filebase/
+bun run types                     # tsgo --noEmit (typecheck only)
+```
+
+## Public surface
+
+Exports from [`./index.ts`](./index.ts):
+
+- `filebase(opts: FilebaseAdapterOptions): FilebaseAdapter` — primary
+  factory. Throws `FilesError("Provider", "filebase adapter: missing
+  credentials…")` when neither option nor env var supplies the key pair.
+- `FilebaseAdapter` — type alias for `Adapter<S3Client>`. `raw` is the
+  underlying AWS SDK client.
+- `FilebaseAdapterOptions` — config interface. JSDoc on every field
+  feeds the docs site via `<AutoTypeTable>`; keep those comments
+  user-facing.
+
+The returned adapter sets `name: "filebase"` (overriding the inner s3
+adapter's `"s3"`) so it's distinguishable in logs and telemetry.
+
+## Authentication / configuration
+
+Required: `bucket` (string, no env fallback), plus `accessKeyId` +
+`secretAccessKey` passed in or sourced from `FILEBASE_ACCESS_KEY_ID` /
+`FILEBASE_SECRET_ACCESS_KEY`. Missing either credential throws
+`FilesError("Provider", …)` at construction.
+
+Optional:
+
+- `endpoint` — overrides `https://s3.filebase.com`. Filebase runs a
+  single global gateway, so this is rarely set in production; use it
+  for local proxies or test doubles.
+- `region` — SigV4 region, defaults to `us-east-1`. Filebase ignores it
+  for routing but SigV4 still requires *some* value.
+- `forcePathStyle` — defaults to `false`. The gateway supports
+  virtual-hosted style on `<bucket>.s3.filebase.com`; flip on only for
+  a proxy that demands path-style.
+- `publicBaseUrl` — origin used by `url()` when set; skips signing. For
+  IPFS-backed buckets the natural value is a CID gateway like
+  `https://ipfs.filebase.io/ipfs/<CID>`; Sia and Storj buckets expose
+  their own gateway URLs in the dashboard.
+- `defaultUrlExpiresIn` — default presigned-URL expiry, seconds.
+  Defaults to `3600` via `DEFAULT_URL_EXPIRES_IN` in
+  [`../internal/core.ts`](../internal/core.ts).
+
+There is no `FILEBASE_BUCKET` or `FILEBASE_REGION` env-var fallback. The
+provider catalog entry in
+[`../providers/index.ts`](../providers/index.ts) (search
+`slug: "filebase"`) declares the same credential env vars via the shared
+`s3Compatible(...)` helper. Env lookups go through
+[`readEnv`](../internal/env.ts) so the adapter is safe to import on
+runtimes without `process` (Cloudflare Workers without `nodejs_compat`).
+
+## Operation map
+
+`filebase()` calls `s3()` with the resolved config and spreads the
+returned adapter, overriding only `name`. Every method — `upload`,
+`download`, `head`, `exists`, `delete`, `deleteMany`, `copy`, `list`,
+`url`, `signedUploadUrl` — lives in [`../s3/index.ts`](../s3/index.ts)
+and is inherited unchanged, including `deleteMany`'s 1000-key chunking,
+`signedUploadUrl`'s PUT-vs-presigned-POST split on `maxSize`, and
+`exists`' 404-as-`false` classification. Errors flow through
+`mapS3Error` with the Filebase fallback table — `Provider`-coded
+messages read `"Filebase error"`. `UploadResult` doesn't carry
+metadata, so reach for a follow-up `head()` if you need the IPFS CID
+at write time.
+
+## URL behavior
+
+`url(key, opts?)` follows the standard signing-adapter rules:
+
+- **Default**: presigned `GetObject` URL against the gateway, expiring
+  after `opts.expiresIn ?? defaultUrlExpiresIn ?? 3600` seconds.
+- **With `publicBaseUrl`**: returns `${publicBaseUrl}/${key}` unsigned
+  via `joinPublicUrl` from [`../internal/core.ts`](../internal/core.ts)
+  (URL-encodes path segments). IPFS gateway URLs serve the
+  CID-addressed object regardless of authentication.
+- **With `opts.responseContentDisposition`**: always signs, even when
+  `publicBaseUrl` is set — a permanent gateway URL has no signature to
+  bind the override to, and silently dropping it would be a stored-XSS
+  regression on user-uploaded HTML/SVG. See `resolveUrlStrategy` in
+  [`../internal/core.ts`](../internal/core.ts).
+
+The natural Filebase setup points `publicBaseUrl` at the per-network
+gateway from the dashboard; otherwise every read flows through a
+presigned URL against `s3.filebase.com`.
+
+## Provider quirks worth remembering
+
+- **Network is per-bucket, not per-request.** Pick IPFS, Sia, or Storj
+  at bucket-creation time in the Filebase console. The S3 API surface
+  is identical across all three; the network only changes durability,
+  cost, and whether you get a CID back.
+- **IPFS buckets surface a CID** as `x-amz-meta-cid` on `HeadObject` /
+  `GetObject`; read it off `storedFile.metadata?.cid`. Sia and Storj
+  buckets don't populate it.
+- **Single global gateway.** `s3.filebase.com` is the only production
+  endpoint; `endpoint` exists for proxies and tests rather than regional
+  selection. Region is a SigV4 ritual — the gateway ignores it.
+- **Access keys** are generated in the Filebase console under *Access
+  Keys*; each key is bucket-scoped. No IAM-role equivalent — static
+  credentials are the only auth mode the S3-compatible API exposes.
+- **No native CDN, but every network has a gateway.** Public reads
+  typically flow through the network's gateway (e.g. IPFS) rather than
+  back through `s3.filebase.com`; `publicBaseUrl` lets `url()` skip the
+  SigV4 round-trip entirely.
+- **Errors are relabeled, not reclassified.** HTTP status codes still
+  map through the same `S3_NOT_FOUND_CODES` / `S3_UNAUTH_CODES` /
+  `S3_CONFLICT_CODES` sets in [`../s3/index.ts`](../s3/index.ts); only
+  the unknown-error fallback message changes.
+
+## Testing approach
+
+Unit tests at
+[`../../test/filebase.test.ts`](../../test/filebase.test.ts) cover the
+narrow surface: default-config plumbing (endpoint `s3.filebase.com`,
+`forcePathStyle: false`, `us-east-1`) read off the inner `S3Client`'s
+resolved config; explicit `endpoint` / `region` / `forcePathStyle`
+overrides reaching the inner client; missing-credential error at
+construction (`/credentials/`); env-var fallback via
+`FILEBASE_ACCESS_KEY_ID` / `FILEBASE_SECRET_ACCESS_KEY`; `url()`
+returning a presigned GET (`X-Amz-Signature=`, `X-Amz-Expires=3600`,
+`s3.filebase.com` host) by default and short-circuiting to
+`${publicBaseUrl}/${key}` concat when configured; `Files` integration
+via `aws-sdk-client-mock` proving `upload` / `exists` reach
+`PutObjectCommand` / `HeadObjectCommand`; and `mapS3Error` invoked with
+the Filebase table returning `"Filebase error"` for `Provider`.
+
+Add fixtures here rather than to `s3.test.ts` whenever a behavior
+depends on filebase-specific config (endpoint host, relabel, env-var
+name, CID round-trip); shared S3 semantics belong in
+[`../../test/s3.test.ts`](../../test/s3.test.ts).
+
+## Coding conventions
+
+- Named exports only — `filebase`, `FilebaseAdapter`,
+  `FilebaseAdapterOptions`.
+- Construction-time errors use
+  [`FilesError("Provider", …)`](../internal/errors.ts); operation
+  errors are the inner S3 adapter's responsibility — don't try-catch
+  and rethrow in this shim.
+- Read env via [`readEnv`](../internal/env.ts); direct `process.env`
+  breaks Cloudflare Workers without `nodejs_compat`.
+- Forward optional knobs with `...(opts.x !== undefined && { x: opts.x })`
+  so unset values fall through to AWS-SDK defaults rather than being
+  passed as explicit `undefined`. Spread the inner adapter, then
+  override only `name` — preserves any future additions to `Adapter`
+  that `s3()` picks up automatically.
+- Top-level regex literals only. The current file has none; keep it
+  that way unless adding a real parser.
+
+## Releases
+
+Ships with the monorepo from
+[`../../package.json`](../../package.json). Behavioral changes (new
+options, default changes, error-shape changes) bump `files-sdk` and add
+a [`CHANGELOG.md`](../../CHANGELOG.md) entry; docs / test-only edits
+don't. The `filebase` subpath is already declared in `exports`.
+
+## Where to look next
+
+- Unified `Adapter` contract: [`../index.ts`](../index.ts); inner S3
+  adapter: [`../s3/index.ts`](../s3/index.ts) +
+  [`../s3/AGENTS.md`](../s3/AGENTS.md).
+- Shared helpers: [`../internal/core.ts`](../internal/core.ts) (URL
+  strategy, body normalization, error-mapper factory);
+  [`FilesError`](../internal/errors.ts); [`readEnv`](../internal/env.ts).
+- Provider catalog (search `slug: "filebase"`):
+  [`../providers/index.ts`](../providers/index.ts).
+- User-facing docs:
+  [`filebase.mdx`](../../../../apps/web/content/docs/adapters/filebase.mdx);
+  package [`README.md`](../../README.md);
+  [`SKILL.md`](../../../../skills/files-sdk/SKILL.md);
+  tests: [`../../test/filebase.test.ts`](../../test/filebase.test.ts).

--- a/packages/files-sdk/src/filebase/CLAUDE.md
+++ b/packages/files-sdk/src/filebase/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/packages/files-sdk/src/firebase-storage/AGENTS.md
+++ b/packages/files-sdk/src/firebase-storage/AGENTS.md
@@ -1,0 +1,260 @@
+# AGENTS.md — `files-sdk/firebase-storage`
+
+Guidance for coding agents working on the `firebase-storage` adapter.
+The unified `Adapter` contract — call shapes, `FilesError`, `UrlOptions`,
+`SignUploadOptions`, body normalization — lives in
+[`../index.ts`](../index.ts); this file only documents firebase-storage-specific
+behavior. **`firebase-storage` is a primary native adapter** built on
+[`firebase-admin`](https://www.npmjs.com/package/firebase-admin)'s
+`initializeApp` → `getStorage(app).bucket(name)` chain; the returned
+`Bucket` is `@google-cloud/storage` under the hood, so V4 signing, POST
+policy uploads, and server-side copy match the GCS surface — see
+[`../gcs/AGENTS.md`](../gcs/AGENTS.md) for primitive-level parallels. It does
+**not** wrap [`gcs()`](../gcs/index.ts) or [`s3()`](../s3/index.ts).
+Cross-references: [`README.md`](../../README.md),
+[`SKILL.md`](../../../../skills/files-sdk/SKILL.md).
+
+## Overview
+
+[Firebase Cloud Storage](https://firebase.google.com/docs/storage) via the
+official `firebase-admin` SDK. Family: **native adapter, GCS JSON API
+(Firebase-flavoured credentials and bucket defaults)**. Every operation
+targets `bucket.file(key)` primitives — `save()`, `download()`,
+`createReadStream()` / `createWriteStream()`, `getMetadata()`, `exists()`,
+`delete()`, `copy()`, `bucket.getFiles()`, `getSignedUrl({ version: "v4" })`,
+and `generateSignedPostPolicyV4()` for presigned upload forms.
+
+Peer dependency (optional in [`../../package.json`](../../package.json)):
+
+- `firebase-admin` — direct import in [`index.ts`](./index.ts); missing it
+  throws `ERR_MODULE_NOT_FOUND` at module load. `@google-cloud/storage` is
+  transitive via `firebase-admin/storage`.
+
+## Directory layout
+
+```text
+packages/files-sdk/src/firebase-storage/
+├── index.ts                   # firebaseStorage() + options + mapFirebaseStorageError
+├── AGENTS.md                  # this file
+└── CLAUDE.md                  # @AGENTS.md — Claude-Code re-export
+```
+
+Sibling files: tests at
+[`../../test/firebase-storage.test.ts`](../../test/firebase-storage.test.ts);
+user docs at
+[`../../../../apps/web/content/docs/adapters/firebase-storage.mdx`](../../../../apps/web/content/docs/adapters/firebase-storage.mdx);
+provider catalog entry (search `slug: "firebase-storage"`) in
+[`../providers/index.ts`](../providers/index.ts).
+
+## Build, test, typecheck
+
+Run from `packages/files-sdk`:
+
+```bash
+bun test test/firebase-storage.test.ts   # this adapter only
+bun test                                 # full SDK suite
+bun run build                            # tsup ESM bundle -> dist/firebase-storage/
+bun run types                            # tsgo --noEmit
+```
+
+This package uses **`bun test`** (not vitest) and **`tsgo`** (not `tsc`).
+The `./firebase-storage` subpath is enumerated in
+[`../../package.json`](../../package.json)'s `exports` map — keep that entry
+in sync if the file layout changes.
+
+## Public surface
+
+Exports from [`index.ts`](./index.ts):
+
+- `firebaseStorage(opts?: FirebaseStorageAdapterOptions): FirebaseStorageAdapter`
+  — primary factory.
+- `FirebaseStorageAdapter` — `Adapter<Bucket> & { readonly bucket: string }`.
+  `raw` is the underlying `@google-cloud/storage` `Bucket`, so any GCS-side
+  primitive (resumable uploads, lifecycle rules, generation preconditions,
+  Firebase download-token URLs) is one property access away.
+- `FirebaseStorageAdapterOptions` — JSDoc on every field is the source of
+  truth; the docs MDX pulls it via `AutoTypeTable`.
+- `mapFirebaseStorageError(err): FilesError` — exported for tests and for
+  callers reusing the same HTTP-status classification through `raw`.
+
+The adapter's `name` is `"firebase-storage"`. The factory also exposes
+`adapter.bucket` (resolved bucket name string).
+
+## Authentication / configuration
+
+Credential resolution (first match wins):
+
+1. **`opts.app` as a `Bucket`** — returned as-is; no Firebase init.
+2. **`opts.app` as a Firebase `App`** — `getStorage(app).bucket(name)` where
+   `name` is `opts.bucket` → `FIREBASE_STORAGE_BUCKET` →
+   `app.options.storageBucket` → default bucket (no arg).
+3. **Inline `opts.credentials`** — `{ clientEmail, privateKey }` via
+   `cert()`. Literal `\n` in the private key is unescaped before `cert()`
+   when threaded through user code (env-sourced keys are normalized by
+   Firebase when read directly).
+4. **`opts.serviceAccountPath`** — JSON file path via `cert()`; wins over
+   inline credentials. Falls back to `GOOGLE_APPLICATION_CREDENTIALS`.
+5. **Application Default Credentials** — `applicationDefault()` when none of
+   the above apply (`gcloud auth application-default login`, GCE/GKE/Cloud
+   Run metadata, workload identity).
+
+Env fallbacks (via [`readEnv`](../internal/env.ts), safe on Workers without
+`nodejs_compat`):
+
+| Field | Options / env |
+| ----- | ------------- |
+| `bucket` | `opts.bucket` → `FIREBASE_STORAGE_BUCKET` → `<projectId>.firebasestorage.app` when `projectId` is known |
+| `projectId` | `opts.projectId` → `FIREBASE_PROJECT_ID` → `GOOGLE_CLOUD_PROJECT` → `GCLOUD_PROJECT` (optional — ADC may carry it) |
+| Inline SA | `FIREBASE_CLIENT_EMAIL` + `FIREBASE_PRIVATE_KEY` (both required) |
+| JSON path | `GOOGLE_APPLICATION_CREDENTIALS` |
+
+**Bucket naming.** The Firebase console shows `<project>.appspot.com` on
+older projects and `<project>.firebasestorage.app` on newer ones. Pass the
+literal name from the console — do not assume the default matches your
+project era. Construction throws
+`FilesError("Provider", "firebase-storage adapter: missing bucket. …")`
+when neither `bucket`, `FIREBASE_STORAGE_BUCKET`, nor a derivable
+`projectId` is available.
+
+**Idempotent Firebase init.** `initializeApp()` is called at most once per
+stable app name `files-sdk:${projectId ?? "default"}:${storageBucket}`
+(override with `opts.appName`). Subsequent `firebaseStorage()` calls with
+the same name reuse the existing app via `getApps()`.
+
+Optional knobs: `publicBaseUrl` (unsigned `url()` when set), and
+`defaultUrlExpiresIn` (signed-read expiry; defaults to `3600` via
+`DEFAULT_URL_EXPIRES_IN` in [`../internal/core.ts`](../internal/core.ts);
+GCS V4 caps at 7 days).
+
+**Emulator support.** The adapter does not wire Firebase Storage or GCS
+emulator hosts. For local emulation, pass a pre-configured `Bucket` (or
+`App` whose storage client points at the emulator) via `opts.app`, or use
+`adapter.raw` with emulator-aware `@google-cloud/storage` client options.
+
+## Operation map
+
+Every method wraps its `try` in `mapFirebaseStorageError`. `metaToStored` is
+the single translation point from `FileMetadata` to `StoredFile`.
+
+- `upload` — `file.save(buffer, writeOpts)` for buffered bodies;
+  `file.createWriteStream(writeOpts)` for `ReadableStream` bodies (piped via
+  `Readable.fromWeb` + `pipeline`). `writeOpts.metadata.metadata` carries
+  `options.metadata` (user custom metadata); `cacheControl` is top-level.
+  **`resumable: false` is forced.** Post-upload `getMetadata()` supplies
+  authoritative `etag` / `lastModified` / `size` on `UploadResult`.
+- `download` — buffer path: parallel `download()` + `getMetadata()`. Stream
+  path: metadata first, then `createReadStream()` as a web stream.
+- `head` — `getMetadata()` only; body accessors lazily `download()`.
+- `exists` — `file.exists()` tuple; caught `NotFound` → `false`.
+- `delete` — `file.delete()`.
+- `copy` — `bucket.file(from).copy(bucket.file(to))` (same bucket).
+- `list` — `bucket.getFiles({ autoPaginate: false, prefix?, maxResults?,
+  pageToken? })`; cursor from `nextQuery?.pageToken`.
+- `url` — `resolveUrlStrategy` → `joinPublicUrl` or
+  `getSignedUrl({ action: "read", version: "v4", expires, responseDisposition? })`.
+  `expires` is absolute ms via `expiresAt(seconds)`.
+- `signedUploadUrl` — without `maxSize`: V4 PUT via `getSignedUrl`. With
+  `maxSize`: `generateSignedPostPolicyV4` with
+  `content-length-range` (and optional `Content-Type` eq). `minSize`
+  defaults to `1`.
+
+No `deleteMany` primitive — `files.deleteMany` uses per-key `delete()` with
+bounded concurrency via `deleteManyWithFallback` in
+[`../internal/core.ts`](../internal/core.ts).
+
+## URL behavior
+
+- **`publicBaseUrl`.** When set and `responseContentDisposition` is absent,
+  `url()` returns `${publicBaseUrl}/${encodedKey}` via `joinPublicUrl`.
+- **Default.** V4 signed read URL; per-call `expiresIn` overrides
+  `defaultUrlExpiresIn`.
+- **`responseContentDisposition` always forces signing**, even with
+  `publicBaseUrl` — same stored-XSS rationale as other signing adapters
+  (`resolveUrlStrategy` in [`../internal/core.ts`](../internal/core.ts)).
+- **Firebase download tokens (`?alt=media&token=…`) are out of scope for
+  v1.** `url()` never mints them; use `adapter.raw` if the client SDK URL
+  form is required.
+
+## Provider quirks worth remembering
+
+- **Same HTTP-status error model as GCS.** `@google-cloud/storage` puts HTTP
+  status on `err.code` (number); `mapFirebaseStorageError` also reads
+  `err.status`. String codes (e.g. `"ENOTFOUND"`) → `Provider`. Mapping:
+  404 → `NotFound`, 401/403 → `Unauthorized`, 409/412 → `Conflict`.
+- **Share Firebase with Firestore/Auth.** Pass an existing `App` via `opts.app`
+  so credentials and project config aren't duplicated. Pass a `Bucket` when
+  the consumer already holds a storage handle.
+- **Service account needs Storage permissions.** Firebase console rules govern
+  client access; server-side Admin SDK calls need IAM roles on the bucket
+  (typically `roles/storage.objectAdmin` or tighter scoped roles).
+- **Rules vs Admin SDK.** Security rules do not apply to `firebase-admin`
+  server calls — treat the adapter as trusted backend access only.
+- **Resumable uploads off.** Large objects need `raw` and resumable
+  `createWriteStream` / upload session APIs.
+- **`metadata.metadata` is custom metadata.** Top-level `cacheControl` /
+  `contentType` are separate from the nested user-metadata map; round-trip
+  matches GCS conventions.
+- **Signed URLs need a signing-capable credential.** Service-account keys
+  (inline, JSON file, or ADC with a key) work; some ADC modes without a
+  private key cannot sign — surface as `Provider` errors from `getSignedUrl`.
+
+## Testing approach
+
+Tests in
+[`../../test/firebase-storage.test.ts`](../../test/firebase-storage.test.ts)
+mock `firebase-admin/app` and `firebase-admin/storage` with hand-rolled
+bucket/file hooks (`saveMock`, `getSignedUrlMock`,
+`generateSignedPostPolicyV4Mock`, …). `beforeEach` clears mocks and env vars.
+
+Coverage spans construction (missing bucket, derived bucket from `projectId`,
+explicit bucket, cert vs ADC, env fallbacks, `\n` unescaping,
+`serviceAccountPath` precedence, idempotent `initializeApp`, pre-built `App` /
+`Bucket`), upload (metadata, stream pipe, `resumable: false`), download
+(buffer / stream), `head` / `exists` / `delete` / `copy` / `list`, `url`
+(public short-circuit, signing, `responseContentDisposition`), `signedUploadUrl`
+(PUT vs POST policy), lazy bodies on `head` / `list`, pre-built `App` bucket
+fallbacks, and the full `mapFirebaseStorageError` matrix plus wrapped
+operation errors. Add firebase-specific fixtures here, not in `gcs.test.ts`.
+
+## Coding conventions
+
+- Named exports only — `firebaseStorage`, `mapFirebaseStorageError`,
+  `FirebaseStorageAdapter`, `FirebaseStorageAdapterOptions`.
+- Construction-time errors use
+  [`FilesError("Provider", …)`](../internal/errors.ts); operation errors
+  go through `mapFirebaseStorageError`.
+- Environment access via [`readEnv`](../internal/env.ts) — never
+  `process.env` directly.
+- Body normalization via `normalizeBody` from
+  [`../internal/core.ts`](../internal/core.ts).
+- Use `createStoredFile` from
+  [`../internal/stored-file.ts`](../internal/stored-file.ts) for every
+  `StoredFile`. `uint8ToBuffer` / `bufferToUint8` preserve byte offsets.
+- `isBucket()` duck-types `opts.app` so both `App` and `Bucket` share one
+  option slot without a union import cycle at the type level.
+- Top-level regex literals only.
+
+## Releases
+
+Ships with the monorepo from [`../../package.json`](../../package.json).
+Behavioral changes need a Changesets entry and
+[`../../CHANGELOG.md`](../../CHANGELOG.md) note; docs-only edits do not.
+The `firebase-storage` subpath is already in `exports`.
+
+## Where to look next
+
+- Unified contract: [`../index.ts`](../index.ts). Sibling GCS adapter:
+  [`../gcs/index.ts`](../gcs/index.ts) + [`../gcs/AGENTS.md`](../gcs/AGENTS.md).
+- Shared helpers: [`../internal/core.ts`](../internal/core.ts),
+  [`../internal/errors.ts`](../internal/errors.ts),
+  [`../internal/env.ts`](../internal/env.ts),
+  [`../internal/stored-file.ts`](../internal/stored-file.ts).
+- Provider catalog (`slug: "firebase-storage"`):
+  [`../providers/index.ts`](../providers/index.ts).
+- User-facing docs:
+  [`../../../../apps/web/content/docs/adapters/firebase-storage.mdx`](../../../../apps/web/content/docs/adapters/firebase-storage.mdx).
+- Package README: [`../../README.md`](../../README.md).
+- SKILL: [`../../../../skills/files-sdk/SKILL.md`](../../../../skills/files-sdk/SKILL.md).
+- Tests: [`../../test/firebase-storage.test.ts`](../../test/firebase-storage.test.ts).
+- CLI registry: [`../cli/registry.ts`](../cli/registry.ts) (`--key-filename`,
+  `--config-json` for inline / `FIREBASE_*` env vars).

--- a/packages/files-sdk/src/firebase-storage/CLAUDE.md
+++ b/packages/files-sdk/src/firebase-storage/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/packages/files-sdk/src/fs/AGENTS.md
+++ b/packages/files-sdk/src/fs/AGENTS.md
@@ -1,0 +1,233 @@
+# AGENTS.md — `files-sdk/fs`
+
+Guidance for coding agents working on the `fs` adapter. The unified
+`Adapter` contract — call shapes, `FilesError`, `UrlOptions`,
+`SignUploadOptions`, body normalization — lives in
+[`../index.ts`](../index.ts); this file documents only fs-specific
+behavior. Cross-references: [`README.md`](../../README.md),
+[`SKILL.md`](../../../../skills/files-sdk/SKILL.md).
+
+## Overview
+
+Native Node.js filesystem adapter for **local dev and CI**. Family:
+**direct-binding / no peer deps**. Implements the common adapter surface
+against `node:fs/promises` — `upload`, `download`, `head`, `exists`,
+`delete`, `copy`, `list`, `url`, `signedUploadUrl` — with no cloud SDK,
+no replication, no auth, and no real signing. Each object is a body file
+on disk plus a JSON sidecar (`.meta.json`) for Content-Type, ETag,
+`cacheControl`, and user metadata. Swap this adapter in to exercise the
+same `Files` call sites as production without changing application code.
+**Not for production.**
+
+Peer dependencies: none. Requires Node or Bun with `node:fs`,
+`node:fs/promises`, `node:path`, `node:crypto`, and `node:stream`.
+
+## Directory layout
+
+```text
+packages/files-sdk/src/fs/
+├── index.ts                # fs() factory + FsAdapterOptions
+├── AGENTS.md               # this file
+└── CLAUDE.md               # @AGENTS.md — Claude-Code re-export
+```
+
+Tests: [`../../test/fs.test.ts`](../../test/fs.test.ts); user docs:
+[`../../../../apps/web/content/docs/adapters/fs.mdx`](../../../../apps/web/content/docs/adapters/fs.mdx);
+provider catalog: [`../providers/index.ts`](../providers/index.ts)
+(search `slug: "fs"`).
+
+## Build, test, typecheck
+
+```bash
+# from packages/files-sdk/
+bun test test/fs.test.ts            # adapter unit tests only
+bun test                            # full SDK suite
+bun run build                       # tsup -> dist/fs/index.js
+bun run types                       # tsgo --noEmit
+```
+
+The `fs` subpath is in [`package.json`](../../package.json) `exports` as
+`files-sdk/fs` → `dist/fs/index.{js,d.ts}`.
+
+## Public surface
+
+Exports from [`index.ts`](index.ts):
+
+- `fs(opts: FsAdapterOptions): FsAdapter` — primary factory.
+- `FsAdapterOptions` — `root`, optional `urlBaseUrl`,
+  `defaultUrlExpiresIn`. JSDoc is the source of truth; docs MDX uses
+  `AutoTypeTable`.
+- `FsAdapter` — `Adapter<{ root: string }> & { readonly root: string }`.
+  `raw` is `{ root }` (resolved absolute path); getter `root` mirrors it.
+- `mapFsError(err: unknown): FilesError` — errno → `FilesErrorCode`.
+
+Adapter `name` is `"fs"`.
+
+## Authentication / configuration
+
+No credentials and **no env-var fallbacks**. Catalog entry `slug: "fs"`
+documents `root` only; `listEnvVars("fs")` and `getSecretEnvVars("fs")`
+return `[]`.
+
+Required:
+
+- `root` — directory the adapter manages (`path.resolve` at
+  construction). Missing `root` throws `FilesError("Provider", …)` at
+  construction. **Created on first upload** (`mkdir` recursive on the body
+  parent). `list()` before any upload returns `{ items: [] }`.
+
+Optional:
+
+- `urlBaseUrl` — HTTP origin for `url()` / `signedUploadUrl()`. Set →
+  `joinPublicUrl(urlBaseUrl, key)`. Unset → `file://` via
+  `pathToFileURL` (CLIs/tests, not browsers).
+- `defaultUrlExpiresIn` — seconds for `?expires=` on `signedUploadUrl`;
+  defaults to `DEFAULT_URL_EXPIRES_IN` (3600) from
+  [`../internal/core.ts`](../internal/core.ts). `url()` ignores expiry.
+
+## Storage layout and path safety
+
+Key `avatars/a.png` maps to body `${root}/avatars/a.png` and sidecar
+`${root}/avatars/a.png.meta.json`. Nested directories are created on
+upload.
+
+Sidecar fields: `contentType`, quoted `etag` (SHA-1, 16 hex chars),
+`lastModified`, optional `cacheControl` / `metadata`. Written on every
+`upload`; `list()` / `walk()` never yield `*.meta.json` keys. Hand-placed
+bodies without sidecars still download (octet-stream, no etag). Bad JSON
+→ `Provider`; partial JSON → treat as absent fields.
+
+`delete()` removes body + sidecar (`force: true`, idempotent). `copy()`
+copies sidecar with refreshed `lastModified`, or removes stale dest
+sidecar when source had none.
+
+Every key passes `resolveKeyPath(root, key)` first:
+
+- **Traversal:** `path.resolve` + prefix guard — `..`, absolute paths,
+  and out-of-root copy destinations throw `Provider`.
+- **Root key:** resolving to `root` itself (e.g. `"."`) throws.
+- **Sidecar keys:** resolved basename aliasing `.meta.json` throws
+  (case-folded; Windows trailing dots/spaces via `FS_TRAILING_NOISE`).
+  Rejects `x.txt.meta.json`, `x.txt.META.JSON`, `x.txt.meta.json/`, etc.
+  Directory segments like `drafts.meta.json/note.txt` are fine.
+
+Checks run on `signedUploadUrl` even though it does not write.
+
+## Operation map
+
+- `upload` — non-stream bodies via `bodyToBytes` (string, `Uint8Array`,
+  `ArrayBuffer`, `ArrayBufferView` with byteOffset, `Blob`). Streams are
+  fully drained to memory, written to `${bodyPath}.${pid}.${ts}.tmp`, then
+  `rename`d — crash mid-write never leaves a partial body. Computes
+  `sha1Etag` from bytes. Defaults: string → `text/plain; charset=utf-8`,
+  `Blob.type` when set, else `application/octet-stream`. Overwrites in
+  place and rewrites the sidecar.
+- `download` — reads body; `as: "stream"` returns `createReadStream` via
+  `Readable.toWeb`. Metadata merges sidecar with `stat.mtimeMs` when
+  `lastModified` absent.
+- `head` — `stat` + sidecar metadata only; body via lazy factory.
+- `exists` — `existsByProbe(() => fsp.stat(bodyPath), mapFsError)`.
+  `stat` on directories returns true (same permissive semantics as `head`;
+  tighten both together if file-only is ever required).
+- `delete` — `rm` body + sidecar with `force: true` (idempotent).
+- `copy` — `copyFile` + sidecar copy or dest sidecar removal; mkdir dest
+  parents.
+- `list` — iterative depth-first `walk` with `withFileTypes` (no extra
+  stat per dirent). Yields posix keys (`/` on Windows too), sorted,
+  optional `prefix`, cursor pagination (last returned key; next page =
+  first key strictly greater — same as
+  [`../../test/fake-adapter.ts`](../../test/fake-adapter.ts)). Default
+  `limit` 1000. ENOENT between walk and per-item `stat` skips the entry.
+- `url` / `signedUploadUrl` — see below. No native `deleteMany`; `Files`
+  uses `deleteManyWithFallback` from [`../internal/core.ts`](../internal/core.ts).
+
+`mapFsError`: `ENOENT`/`ENOTDIR` → `NotFound`; `EACCES`/`EPERM` →
+`Unauthorized`; `EEXIST` → `Conflict`; else `Provider`. Preserves
+`FilesError`; non-`Error` throws map to `"fs error"` for `Provider`.
+
+## URL and signed upload behavior
+
+**Without `urlBaseUrl`:** `url(key)` → `file://` body path (no existence
+stat). `responseContentDisposition` throws — no signature to bind
+(stored-XSS stance, same as vercel-blob / supabase).
+
+**With `urlBaseUrl`:** `url(key)` → `joinPublicUrl`. Disposition appends
+`?response-content-disposition=` (or `&` if base has query); dev server
+must honor it.
+
+**`signedUploadUrl`:** requires `urlBaseUrl` or throws (no built-in
+upload server — wire a dev handler to the same `root`). Returns PUT URL:
+`${joinPublicUrl(urlBaseUrl, key)}?expires=<unix>` plus optional
+`content-type`, `max-size` query params and `Content-Type` header.
+Expiry is **not enforced** by the adapter; handlers may validate
+`expires`. `defaultUrlExpiresIn` / per-call `expiresIn` only shape the
+query. Serve and upload origins can differ (e.g. `/files` vs `/upload`).
+
+## Provider quirks worth remembering
+
+- Dev/test only — no replication, locking, versioning, or multi-tenant
+  isolation beyond the `root` directory boundary.
+- ETag is upload-time SHA-1 (16 hex chars, quoted), not inode-based.
+  Re-uploading identical bytes yields the same etag; editing a body file
+  by hand without updating the sidecar leaves stale metadata until the
+  next SDK `upload`.
+- Stream uploads buffer entirely in memory before disk write — fine for
+  dev payloads, not for multi-GB objects.
+- `url()` without `urlBaseUrl` does not stat the path first; a `file://`
+  URL for a missing key 404s at fetch time, matching cloud adapters that
+  return URLs for deleted objects.
+- `signedUploadUrl` and `url` can point at different `urlBaseUrl` values
+  in separate adapter instances if serve and upload handlers differ.
+- Sidecars survive `cp -r` / `git mv` / partial tree copies; deleting
+  only the body externally orphans the sidecar until manual cleanup.
+
+## Testing approach
+
+[`../../test/fs.test.ts`](../../test/fs.test.ts) uses real `mkdtemp`
+dirs under `os.tmpdir()`, removed in `afterAll` — no SDK mocks. Covers:
+
+- Construction: missing `root`, absolute resolved `root`, `name` / `raw`.
+- Upload/download: string, `Uint8Array`, `Blob`, `ArrayBuffer`,
+  `DataView` (byteOffset), explicit `contentType`, metadata/cacheControl
+  sidecar shape, nested keys, stream upload, overwrite, download stream.
+- `head` lazy body, `exists`, idempotent `delete`, `copy` (+ NotFound src).
+- `list`: sort order, prefix, limit+cursor pages, sidecar exclusion, empty
+  root before first upload, ENOENT mid-page skip, EACCES walk error.
+- Path safety: `..`, absolute paths, root key, `.meta.json` suffix and host
+  aliases (`META.JSON`, trailing dot/space/slash), allowed dir segment
+  `drafts.meta.json/note.txt`.
+- `url`: `file://`, `urlBaseUrl`, trailing-slash trim, disposition query.
+- `signedUploadUrl`: requires `urlBaseUrl`, PUT + `expires` / `content-type`
+  / `max-size` query, traversal rejected at sign time.
+- `mapFsError` table; malformed sidecar JSON; upload temp cleanup on
+  failed rename (buffer and stream paths).
+
+Add fs-specific cases here, not in cloud adapter tests.
+
+## Coding conventions
+
+- Named exports only. Construction errors → `FilesError("Provider", …)`.
+- `createStoredFile` for every `StoredFile`; `existsByProbe` /
+  `joinPublicUrl` from [`../internal/core.ts`](../internal/core.ts).
+- List keys are posix `/`; body paths use `path.join` on split segments.
+- `FS_TRAILING_NOISE` stays a top-level regex (ReDoS-safe).
+- `bestEffortRm` is intentionally silent in cleanup paths.
+- No `readEnv` — nothing to read from `process.env`.
+
+## Releases
+
+Ships with the monorepo [`package.json`](../../package.json). Behavioral
+changes need a Changesets entry; docs/tests-only do not.
+
+## Where to look next
+
+- Unified contract: [`../index.ts`](../index.ts).
+- Shared helpers: [`../internal/core.ts`](../internal/core.ts).
+- `FilesError`: [`../internal/errors.ts`](../internal/errors.ts).
+- `StoredFile`: [`../internal/stored-file.ts`](../internal/stored-file.ts).
+- Provider catalog (`slug: "fs"`): [`../providers/index.ts`](../providers/index.ts).
+- User docs:
+  [`../../../../apps/web/content/docs/adapters/fs.mdx`](../../../../apps/web/content/docs/adapters/fs.mdx).
+- README: [`../../README.md`](../../README.md).
+- SKILL: [`../../../../skills/files-sdk/SKILL.md`](../../../../skills/files-sdk/SKILL.md).
+- Tests: [`../../test/fs.test.ts`](../../test/fs.test.ts).

--- a/packages/files-sdk/src/fs/CLAUDE.md
+++ b/packages/files-sdk/src/fs/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/packages/files-sdk/src/gcs/AGENTS.md
+++ b/packages/files-sdk/src/gcs/AGENTS.md
@@ -1,0 +1,298 @@
+# AGENTS.md — `files-sdk/gcs`
+
+Guidance for coding agents working inside the `gcs` adapter. Every
+adapter in files-sdk implements the unified `Adapter<Raw>` contract from
+[`../index.ts`](../index.ts) — call shapes, `FilesError` codes,
+`UrlOptions`, `SignUploadOptions`, body normalization. This file
+documents only gcs-specific deviations. For the package-wide surface,
+[`../../README.md`](../../README.md) and the skill at
+[`../../../../skills/files-sdk/SKILL.md`](../../../../skills/files-sdk/SKILL.md)
+are the sources of truth — read them first.
+
+Unlike the ~20 S3-compatible adapters that wrap [`../s3/index.ts`](../s3/index.ts)
+with provider-friendly defaults, **`gcs` is a primary native adapter**
+built directly on
+[`@google-cloud/storage`](https://www.npmjs.com/package/@google-cloud/storage)'s
+`Storage` → `bucket(name)` → `file(key)` chain. It does **not** share
+the S3 adapter's error-mapping table or signing primitives.
+
+## Overview
+
+Google Cloud Storage via the official `@google-cloud/storage` SDK.
+Family: **native adapter, GCS JSON API**. The full unified surface is
+implemented directly against per-file primitives: `file.save()`,
+`file.download()`, `file.createReadStream()` / `createWriteStream()`,
+`file.getMetadata()`, `file.exists()`, `file.delete()`, `file.copy()`,
+`bucket.getFiles()`, `file.getSignedUrl({ version: "v4" })`, and
+`file.generateSignedPostPolicyV4()` for presigned upload forms.
+
+Peer dependencies (both optional in [`../../package.json`](../../package.json)):
+
+- `@google-cloud/storage` — direct import in [`./index.ts`](./index.ts);
+  missing it throws `ERR_MODULE_NOT_FOUND` at module load.
+- `google-auth-library` — transitive peer used by `@google-cloud/storage`
+  for credential resolution. [`../../README.md`](../../README.md)
+  bundles both into
+  `npm install files-sdk @google-cloud/storage google-auth-library`.
+
+## Directory layout
+
+```text
+packages/files-sdk/src/gcs/
+├── index.ts                # adapter + GCSAdapterOptions + mapGCSError
+├── AGENTS.md               # this file
+└── CLAUDE.md               # `@AGENTS.md`
+```
+
+Sibling files: tests at
+[`../../test/gcs.test.ts`](../../test/gcs.test.ts); user docs at
+[`../../../../apps/web/content/docs/adapters/gcs.mdx`](../../../../apps/web/content/docs/adapters/gcs.mdx);
+provider catalog entry (search `slug: "gcs"`) in
+[`../providers/index.ts`](../providers/index.ts).
+
+## Build, test, typecheck
+
+```bash
+# from packages/files-sdk/
+bun test test/gcs.test.ts            # this adapter only
+bun test                             # full SDK suite
+bun run build                        # tsup ESM bundle -> dist/gcs/index.js
+bun run types                        # tsgo --noEmit
+```
+
+This package uses **`bun test`** (not vitest) and **`tsgo`** (not
+`tsc`). The per-subpath bundle output is `dist/gcs/index.{js,d.ts}` per
+the `exports` map in [`../../package.json`](../../package.json); keep
+it in sync if the file layout changes.
+
+## Public surface
+
+Defined in [`./index.ts`](./index.ts):
+
+- `gcs(opts: GCSAdapterOptions): GCSAdapter` — primary factory.
+- `GCSAdapterOptions` — `bucket` (required), `projectId`, `keyFilename`,
+  `credentials`, `publicBaseUrl`, `defaultUrlExpiresIn`. JSDoc on each
+  field is the source of truth; the docs MDX renders it via
+  `AutoTypeTable`.
+- `GCSAdapter` — `Adapter<StorageClient> & { readonly bucket: string }`.
+  `raw` is the underlying `Storage` instance, so any primitive the GCS
+  SDK exposes (resumable uploads, lifecycle rules, HMAC keys, IAM,
+  signed cookies, generation preconditions) is one property access away.
+- `mapGCSError(err): FilesError` — exported for tests and for callers
+  reusing the same HTTP-status classification through `raw`.
+
+The adapter's `name` is `"gcs"`.
+
+## Authentication / configuration
+
+Credentials follow the GCS SDK's resolution chain. files-sdk classifies
+this as `sdk-chain` in [`../providers/index.ts`](../providers/index.ts)
+— the adapter does **not** call `readEnv` for credential values. The
+`@google-cloud/storage` client handles them, in this order:
+
+1. Explicit `opts.credentials` — `{ client_email, private_key }`. Wins
+   over `keyFilename` if both are passed. Useful when credentials land
+   in env vars (Vercel / Netlify) and materializing a JSON file is
+   awkward.
+2. Explicit `opts.keyFilename` — path to a service-account JSON file.
+3. **Application Default Credentials (ADC)** — `GOOGLE_APPLICATION_CREDENTIALS`
+   env var, `gcloud auth application-default login` user credentials,
+   or the metadata server on Cloud Run / Cloud Functions / GKE / GCE /
+   App Engine (workload identity).
+
+[`readEnv`](../internal/env.ts) is only used to resolve the project ID:
+`opts.projectId` → `GOOGLE_CLOUD_PROJECT` → `GCLOUD_PROJECT`. When none
+resolve, ADC carries a project ID alongside the credentials. Env
+lookups go through `readEnv` so the adapter is safe to import on
+runtimes without `process` (Cloudflare Workers without `nodejs_compat`).
+
+`bucket` is required and has **no env fallback** — the constructor
+throws `FilesError("Provider", "gcs adapter: missing bucket. ...")`
+when absent. Optional knobs: `publicBaseUrl` (origin used by `url()` to
+skip signing; natural value for a public bucket is
+`https://storage.googleapis.com/<bucket>`, or your CDN origin) and
+`defaultUrlExpiresIn` (presigned-URL expiry in seconds; defaults to
+`DEFAULT_URL_EXPIRES_IN` (3600 s) from
+[`../internal/core.ts`](../internal/core.ts); **GCS V4 caps at 7 days**).
+
+## Operation map
+
+Every method wraps its `try` in `mapGCSError`. The local `metaToStored`
+helper is the single translation point from `FileMetadata` to
+`StoredFile` — edit it once if a new metadata field needs to round-trip.
+
+- `upload` — `file.save(buffer, writeOpts)` for buffered bodies;
+  `file.createWriteStream(writeOpts)` for `ReadableStream` bodies
+  (piped via `Readable.fromWeb` + `node:stream/promises.pipeline`).
+  `writeOpts.contentType`, `writeOpts.metadata.cacheControl` (top-level
+  GCS metadata), and `writeOpts.metadata.metadata` (user-metadata map)
+  flow through. **`resumable: false` is forced** — v1 commits to
+  single-request uploads; multi-GB workloads drop to `raw`. `save()`
+  doesn't return etag / size, so a follow-up `file.getMetadata()`
+  surfaces authoritative values in `UploadResult`.
+- `download` — buffer path runs `file.download()` and
+  `file.getMetadata()` in parallel via `Promise.all`. Stream path
+  pre-fetches metadata (size / contentType must be on the `StoredFile`
+  before any reader pulls), wraps `file.createReadStream()` via
+  `Readable.toWeb`, and returns a `kind: "stream"` `StoredFile`.
+- `head` — `file.getMetadata()` only; body accessors lazily call
+  `file.download()`.
+- `exists` — `file.exists()` returns `[boolean]`. Some configurations
+  surface a 404 as an exception instead of `[false]`, so the adapter
+  catches the mapped `NotFound` and returns `false`; every other
+  mapped error rethrows.
+- `delete` — `file.delete()`.
+- `copy` — `bucket.file(from).copy(bucket.file(to))`. Server-side and
+  same-bucket only; cross-bucket requires `raw`.
+- `list` — `bucket.getFiles({ autoPaginate: false, prefix?,
+  maxResults?, pageToken? })`. Returns `[files, nextQuery,
+  _rawResponse]`; the unified `cursor` maps to `nextQuery?.pageToken`
+  and is omitted when absent. `autoPaginate: false` is forced so a
+  caller `limit` is honored exactly. Each item's body factory issues a
+  fresh `file.download()` on demand.
+- `url` — `resolveUrlStrategy({ publicBaseUrl,
+  responseContentDisposition })` chooses between the public path
+  (`joinPublicUrl(publicBaseUrl, key)`) and signing
+  (`file.getSignedUrl({ action: "read", version: "v4", expires,
+  responseDisposition? })`). **`expires` is absolute ms-since-epoch**
+  via `expiresAt(seconds)`, not seconds-from-now as on S3.
+- `signedUploadUrl` — **PUT or POST policy depending on `maxSize`.**
+  Without `maxSize`: `file.getSignedUrl({ action: "write", version:
+  "v4", expires, contentType? })` → `{ method: "PUT", url, headers? }`.
+  With `maxSize`: `file.generateSignedPostPolicyV4({ conditions:
+  [["content-length-range", minSize, maxSize], ["eq", "$Content-Type",
+  contentType?]], expires, fields? })` → `{ method: "POST", url,
+  fields }`. GCS exposes a **native V4 POST policy primitive**, so the
+  same `maxSize` branch as S3 / R2 works unchanged. `minSize` defaults
+  to `1`; pass `0` to allow zero-byte uploads.
+
+## URL behavior
+
+- **`publicBaseUrl` precedence.** When set and
+  `responseContentDisposition` is absent, `url()` returns
+  `${publicBaseUrl}/${encodedKey}` via `joinPublicUrl` from
+  [`../internal/core.ts`](../internal/core.ts). The base tolerates a
+  single trailing slash; the key is URL-encoded segment-by-segment.
+- **Default expiry.** Per-call `expiresIn` wins, then
+  `opts.defaultUrlExpiresIn`, then `DEFAULT_URL_EXPIRES_IN` (3600 s).
+  Both read and write signing pin `version: "v4"`.
+- **`responseContentDisposition` always forces signing**, even with
+  `publicBaseUrl` set. A permanent CDN URL has no signature in which
+  to bind the override, and silently dropping it would be a stored-XSS
+  regression on user-uploaded HTML/SVG.
+
+## Provider quirks worth remembering
+
+- **No string error codes — HTTP status only.** Unlike S3's `NoSuchKey`
+  / `AccessDenied` / `PreconditionFailed`, the GCS `ApiError` puts the
+  HTTP status on `err.code` as a **number**. `mapGCSError`'s `extract`
+  reads `code` when `typeof "number"` and falls back to `err.status`
+  for lower-level auth/transport errors; the three string-code sets in
+  the config are intentionally empty. Mapping: 404 → `NotFound`,
+  401/403 → `Unauthorized`, 409/412 → `Conflict`, anything else
+  (including string codes like `"ENOTFOUND"`) → `Provider`. Branch on
+  `FilesError.code` after the mapper, never on the raw provider error.
+- **Concurrency primitives are not wired through.** GCS has
+  `ifGenerationMatch`, `ifGenerationNotMatch`, `ifMetagenerationMatch`,
+  and `ifMetagenerationNotMatch` preconditions (map to 412 → `Conflict`
+  when they fail) but the unified `Adapter` has no precondition slot.
+  Reach for them via `files.raw.bucket("...").file("...").save(...,
+  { preconditionOpts: { ifGenerationMatch: 42 } })`. Same applies to
+  resumable upload sessions, signed cookies, lifecycle config, and
+  HMAC key management.
+- **Resumable uploads are off by default.** `resumable: false` is
+  forced on every `save()` / `createWriteStream()`. Bodies above
+  ~32 MB benefit from the resumable code path on `raw`.
+- **`save()` doesn't echo metadata back.** `etag`, `size`, and
+  `updated` only surface via the follow-up `getMetadata()` round trip
+  — don't skip that probe unless you also stop reporting authoritative
+  values on `UploadResult`.
+- **`bucket.getFiles()` returns `[files, nextQuery, rawResponse]`.**
+  Cursor lives on `nextQuery?.pageToken`; absent means exhausted.
+  `autoPaginate: false` is forced so a caller `limit` of 10 doesn't
+  silently page through the entire bucket.
+- **`metadata.metadata` is the user-metadata slot.** GCS separates
+  top-level object metadata (`cacheControl`, `contentType`,
+  `contentEncoding`, …) from arbitrary user metadata (the *nested*
+  `metadata` field). The adapter writes `cacheControl` at the top and
+  `options.metadata` into the nested map; `metaToStored` reads them
+  back the same way.
+- **Buffer view conversions preserve `byteOffset` / `byteLength`** via
+  `uint8ToBuffer`, so `DataView` and offset-`Uint8Array` uploads send
+  the right bytes — pinned by the `DataView` test.
+- **No `deleteMany` primitive.** GCS has no batch delete on the JSON
+  API surface, so `files.deleteMany` falls back to per-key `delete()`
+  with bounded concurrency via `deleteManyWithFallback` in
+  [`../internal/core.ts`](../internal/core.ts).
+- **`url()` and `signedUploadUrl()` expect absolute ms-since-epoch.**
+  The local `expiresAt(seconds)` helper converts caller seconds into
+  `Date.now() + seconds * 1000`. Don't pass raw seconds — GCS treats
+  it as 1970-era epoch ms and returns an instantly-expired URL.
+
+## Testing approach
+
+Tests in [`../../test/gcs.test.ts`](../../test/gcs.test.ts) use Bun's
+`mock.module("@google-cloud/storage", () => ({ Storage: StorageStub }))`
+to swap in a stub whose `bucket(name)` returns an object with
+`file(name)` and `getFiles(opts)` hooks. Each operation routes through
+hand-rolled mocks (`saveMock`, `downloadMock`, `getMetadataMock`,
+`getSignedUrlMock`, `generateSignedPostPolicyV4Mock`, …) that
+`beforeEach` resets so `mockImplementationOnce` from one test doesn't
+bleed into the next.
+
+Coverage spans construction (missing bucket, ADC fall-through, each
+auth-field forwarding), upload (post-save metadata, every body
+variant, stream piping), download (buffer / stream / lazy `head` body),
+`exists` (tuple-`[false]`, thrown-404, 403 rethrow), `list` (prefix /
+cursor / limit forwarding, tuple-cursor extraction, lazy item bodies),
+`url` (public short-circuit, V4 signing default, per-call `expiresIn`,
+`responseContentDisposition` forcing signing), `signedUploadUrl` (PUT
+and POST-policy branches, `minSize: 0`), and the full `mapGCSError`
+matrix (status-field fallback, `FilesError` pass-through, every
+wrapped operation re-throwing `FilesError`). Add new fixtures here,
+not in `s3.test.ts`.
+
+## Coding conventions
+
+- Named exports only — `gcs`, `mapGCSError`, `GCSAdapter`,
+  `GCSAdapterOptions`. No default exports.
+- Errors wrap as `FilesError` via `mapGCSError`; pass-through is
+  automatic (the mapper short-circuits on `instanceof FilesError`).
+  Construction-time validation throws
+  [`FilesError("Provider", …)`](../internal/errors.ts) directly.
+- Environment access goes through [`readEnv`](../internal/env.ts);
+  direct `process.env` breaks Cloudflare Workers without
+  `nodejs_compat`. Body normalization goes through `normalizeBody`
+  from [`../internal/core.ts`](../internal/core.ts) — don't branch on
+  `Body` variants in the adapter.
+- Forward optional `Storage` constructor config with
+  `...(opts.x && { x: opts.x })` so unset values fall through to SDK
+  defaults instead of being passed as explicit `undefined`.
+- Use `createStoredFile` from
+  [`../internal/stored-file.ts`](../internal/stored-file.ts) for every
+  `StoredFile` returned; don't hand-roll body accessors. Top-level
+  regex literals only.
+
+## Releases
+
+The repo uses Changesets. Behavioral changes (new options, default
+changes, error-shape changes) need a changeset (`bunx changeset`);
+README and AGENTS.md edits don't. `GCSAdapterOptions` / `GCSAdapter`
+are adapter-local — nothing in the package re-exports them — but
+still bump the `files-sdk` version when their shape changes.
+
+## Where to look next
+
+- User-facing docs: [`../../../../apps/web/content/docs/adapters/gcs.mdx`](../../../../apps/web/content/docs/adapters/gcs.mdx).
+  Source: [`./index.ts`](./index.ts). Tests:
+  [`../../test/gcs.test.ts`](../../test/gcs.test.ts). Provider catalog
+  entry: [`../providers/index.ts`](../providers/index.ts).
+- Unified contract: [`../index.ts`](../index.ts). Shared helpers:
+  [`../internal/core.ts`](../internal/core.ts),
+  [`../internal/errors.ts`](../internal/errors.ts),
+  [`../internal/env.ts`](../internal/env.ts),
+  [`../internal/stored-file.ts`](../internal/stored-file.ts).
+- Sibling native adapter for reference patterns:
+  [`../s3/AGENTS.md`](../s3/AGENTS.md). Package SKILL:
+  [`../../../../skills/files-sdk/SKILL.md`](../../../../skills/files-sdk/SKILL.md).
+  Package README: [`../../README.md`](../../README.md).

--- a/packages/files-sdk/src/gcs/CLAUDE.md
+++ b/packages/files-sdk/src/gcs/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/packages/files-sdk/src/google-drive/AGENTS.md
+++ b/packages/files-sdk/src/google-drive/AGENTS.md
@@ -1,0 +1,326 @@
+# AGENTS.md — `files-sdk/google-drive`
+
+Guidance for coding agents working on the `google-drive` adapter. The
+unified `Adapter<Raw>` contract — call shapes, `FilesError`,
+`UrlOptions`, `SignUploadOptions`, body normalization — lives in
+[`../index.ts`](../index.ts); this file documents only the
+google-drive-specific deviations. Package
+[`README.md`](../../README.md) and the agent skill at
+[`SKILL.md`](../../../../skills/files-sdk/SKILL.md) are the sources of
+truth for the unified API — read them first.
+
+`google-drive` is a **native** adapter (not an S3-compatible shim),
+calling [`@googleapis/drive`](https://www.npmjs.com/package/@googleapis/drive)
+v3 with credentials minted through
+[`google-auth-library`](https://www.npmjs.com/package/google-auth-library).
+The central design decision — projecting Drive's opaque `fileId`
+namespace onto the SDK's flat-string-key namespace via a reserved
+`appProperties.fsdkKey` slot — shows up in almost every method; read
+the [Operation map](#operation-map) before changing anything.
+
+## Overview
+
+Google Drive via the official Drive v3 client. Family: **native /
+document store** (alongside `dropbox`, `onedrive`, `box`,
+`sharepoint`). Drive is a document manager, not object storage: files
+have opaque random `fileId`s, names may collide inside the same
+folder, and there is no path namespace. The adapter maps the unified
+string key onto a reserved `appProperties.fsdkKey` slot and resolves
+keys → ids through `files.list` with a per-instance LRU cache. The
+full unified surface — `upload`, `download`, `head`, `exists`,
+`delete`, `copy`, `list`, `url`, `signedUploadUrl` — is implemented
+natively against `drive_v3.Drive`. `deleteMany` is **not** implemented
+— `Files` falls back to fanned-out `delete()` calls.
+
+Peer dependencies (both optional, declared in
+[`../../package.json`](../../package.json)): `@googleapis/drive`,
+`google-auth-library`.
+
+## Directory layout
+
+```text
+packages/files-sdk/src/google-drive/
+├── index.ts                # adapter implementation
+├── AGENTS.md               # this file
+└── CLAUDE.md               # `@AGENTS.md`
+```
+
+Tests at [`../../test/google-drive.test.ts`](../../test/google-drive.test.ts);
+user docs at [`../../../../apps/web/content/docs/adapters/google-drive.mdx`](../../../../apps/web/content/docs/adapters/google-drive.mdx);
+provider catalog (`slug: "google-drive"`) at [`../providers/index.ts`](../providers/index.ts);
+subpath export `./google-drive` in [`../../package.json`](../../package.json).
+
+## Build, test, typecheck
+
+Run from `packages/files-sdk/`:
+
+```bash
+bun test test/google-drive.test.ts   # this adapter only
+bun test                              # full SDK suite
+bun run build                         # tsup → dist/google-drive/index.js
+bun run types                         # tsgo --noEmit (typecheck only)
+```
+
+This package uses **`bun test`** (not vitest) and **`tsgo`** (not
+`tsc`).
+
+## Public surface
+
+Defined in [`index.ts`](./index.ts):
+
+- `googleDrive(opts?: GoogleDriveAdapterOptions): GoogleDriveAdapter` —
+  primary factory. The adapter's `name` is `"google-drive"`.
+- `GoogleDriveAdapterOptions` — config interface; JSDoc on every field
+  is the source of truth (the docs MDX pulls it via `AutoTypeTable`).
+- `GoogleDriveAdapter` —
+  `Adapter<drive_v3.Drive> & { readonly rootFolderId: string }` so
+  callers can introspect the resolved root without re-passing it.
+- `GoogleDriveClient` — alias for `drive_v3.Drive`, the type of
+  `adapter.raw`.
+- `mapDriveError(err): FilesError` — exported so callers reaching for
+  `adapter.raw` can re-classify stray googleapis errors against the
+  same code table the adapter uses.
+
+## Authentication / configuration
+
+Four explicit auth shapes plus env-var fallbacks. Mutually exclusive —
+pass exactly one shape. The factory throws
+`FilesError("Provider", …)` at construction if no explicit shape and
+no env credentials resolve.
+
+- **Service account, inline** — `credentials: { client_email, private_key }`
+  mints a `JWT` with scope `https://www.googleapis.com/auth/drive`.
+- **Service account, key file** — `keyFilename: "/path/to/sa.json"`
+  builds a `GoogleAuth` against that key. Node-only.
+- **OAuth refresh token** — `oauth: { clientId, clientSecret, refreshToken }`
+  builds an `OAuth2Client` for 3-legged OAuth to an end-user account.
+- **Pre-built `client` escape hatch** — `client: drive_v3.Drive`. Use
+  when auth is wired elsewhere (workload identity, Application Default
+  Credentials, custom token providers). The adapter cannot recover
+  the auth handle, so `signedUploadUrl()` refuses; ADC users who need
+  signed uploads should wire the service-account or OAuth path.
+
+Env-var fallbacks (consulted only when no explicit auth is passed; via
+[`readEnv`](../internal/env.ts) so the adapter is safe to import on
+runtimes without `process` — e.g. Cloudflare Workers without
+`nodejs_compat`):
+
+- `GOOGLE_DRIVE_CLIENT_EMAIL` + `GOOGLE_DRIVE_PRIVATE_KEY` → `JWT`.
+- `GOOGLE_DRIVE_KEY_FILE` → `GoogleAuth` with that key file.
+- `GOOGLE_DRIVE_SUBJECT` → domain-wide delegation subject (only honored
+  with `credentials` / `keyFilename`; ignored with `oauth` / `client`).
+- `GOOGLE_DRIVE_ID` → `driveId`. When set and `rootFolderId` is unset,
+  the Shared Drive id doubles as the root.
+- `GOOGLE_DRIVE_ROOT_FOLDER_ID` → `rootFolderId`. Overrides the
+  `driveId` fallback when both are present.
+
+Other knobs: `driveId` (Shared Drive id; **strongly recommended for
+service-account auth** — service accounts have a 15 GB personal
+quota, so production workloads should target a Shared Drive with the
+service account added as a member); `rootFolderId` (virtual "bucket
+root" — files are created with `parents: [rootFolderId]`, defaults to
+`driveId` when set, else `"root"`); `publicByDefault` (when `true`,
+every `upload()` follows up with
+`permissions.create({ role: "reader", type: "anyone" })` and `url()`
+returns a public Drive download URL — adapter-wide, instantiate two
+`Files` instances for a mix); `fileIdCacheSize` (per-instance LRU
+capacity, default `1024`).
+
+## Operation map
+
+Every method wraps provider errors through `mapDriveError`, and every
+googleapis call receives the operation's `AbortSignal` via the second
+`MethodOptions` arg (`signalOpts(signal)`).
+
+- `upload` — `files.create` with a multipart media body and a
+  `requestBody` of `{ name: basename(key), parents: [rootFolderId],
+  mimeType, appProperties }`. `appProperties` carries `fsdkKey`,
+  `fsdkContentType`, an optional `fsdkCacheControl`, and the caller's
+  `metadata` minus reserved keys. Stream bodies are pumped through a
+  Node `Readable` (`Readable.fromWeb` for web streams). When
+  `publicByDefault: true`, a follow-up `permissions.create` grants
+  anyone-reader on the new `fileId`.
+- `download` — resolves the `fileId`, then issues parallel `files.get`
+  calls for metadata and `alt: "media"` body. Buffer path returns
+  bytes; stream path converts the Node stream to a web `ReadableStream`
+  via `Readable.toWeb`.
+- `head` — `files.get` with `FILE_FIELDS`; the returned `StoredFile`
+  installs a lazy body factory that issues `alt: "media"` on first
+  access. Not free.
+- `exists` — `existsByProbe(files.get, mapDriveError)` from
+  [`../internal/core.ts`](../internal/core.ts). `NotFound` → `false`;
+  other failures propagate.
+- `delete` — resolves the `fileId`, then `files.delete`. **Hard
+  delete** — `files.delete` permanently removes the item; the adapter
+  does not call `files.update({ trashed: true })` or `files.trash`,
+  matching every other adapter's `delete()` semantics. Idempotent: a
+  `NotFound` from either step is swallowed and the cache entry evicted.
+- `copy` — `files.copy` server-side; the destination `fsdkKey` is set
+  on the new file and the new `fileId` is seeded into the cache.
+- `list` — `files.list` scoped to
+  `'<rootFolderId>' in parents and trashed=false`. Results are
+  filtered client-side to files carrying an `fsdkKey` (foreign files
+  in the same folder are excluded), and `prefix` is applied
+  client-side per page. `cursor` round-trips Drive's `nextPageToken`;
+  `limit` → `pageSize`.
+- `url` — when `publicByDefault: true` and no
+  `responseContentDisposition`, returns
+  `https://drive.google.com/uc?export=download&id=${fileId}`.
+  Otherwise throws `Provider`.
+- `signedUploadUrl` — mints an access token from the stored auth
+  handle, POSTs to the Drive resumable endpoint
+  (`/upload/drive/v3/files?uploadType=resumable&supportsAllDrives=true`)
+  with `Authorization: Bearer …`, `X-Upload-Content-Type` (when set),
+  `X-Upload-Content-Length` (when `maxSize` is set), and a JSON body
+  of `{ name, parents, appProperties }`. Returns the session URL from
+  the `Location` header as `{ method: "PUT", url, headers? }`. Drive
+  has no presigned-POST analogue.
+
+`resolveFileId(key)` is the shared lookup hot path. Checks the LRU,
+otherwise issues `files.list` with
+`q = "appProperties has { key='fsdkKey' and value='…' } and trashed=false"`
+asking for at most 2 hits. Zero matches throw `NotFound`; two-or-more
+throw `Conflict` rather than picking one silently.
+
+## URL behavior
+
+- **`url()` requires `publicByDefault: true`** — otherwise throws
+  `Provider`. Drive has no signed-URL primitive comparable to S3's
+  `GetObject` presign; the closest analogues (`webViewLink`,
+  `webContentLink` returned by `files.get`) only work once
+  `permissions.create` has run, which is what `publicByDefault` does
+  at upload time.
+- **`url()` returns a permanent download URL.** Shape:
+  `https://drive.google.com/uc?export=download&id=${fileId}`.
+  `expiresIn` is silently ignored. For temporary exposure, proxy
+  `download()` through your own endpoint.
+- **`responseContentDisposition` always throws.** Drive's
+  `webContentLink`-style download URL has no Content-Disposition
+  override, and silently dropping the override would be a stored-XSS
+  regression on user-uploaded HTML/SVG (per
+  [`resolveUrlStrategy`](../internal/core.ts) rationale).
+
+## Provider quirks worth remembering
+
+- **Keys are virtual; no path hierarchy.** Drive identifies files by
+  opaque random `fileId`s. `docs/a.txt` and `other/a.txt` live as flat
+  files inside `rootFolderId`, distinguished only by `fsdkKey`;
+  `basename(key)` is the Drive `name`.
+- **No folder creation.** A Drive "folder" is a file with mime type
+  `application/vnd.google-apps.folder`. The adapter does not create
+  folders for slash-separated key segments — every uploaded file is
+  parented directly to `rootFolderId`. Build folder hierarchy via
+  `adapter.raw.files.create` if you want the segments to render as
+  Drive folders in the UI.
+- **Reserved `fsdk` metadata prefix.** `fsdkKey`, `fsdkContentType`,
+  `fsdkCacheControl` are bookkeeping; caller `metadata` keys starting
+  with `fsdk` throw `Provider` at upload time
+  (`assertNoReservedMetadata`).
+- **`appProperties` is per-application.** Drive scopes it to the OAuth
+  client (or service account) that wrote them — switching auth modes
+  looks like a wiped bucket.
+- **Shared Drive plumbing is unconditional.** When `driveId` is set,
+  every call carries the four `supportsAllDrives` /
+  `includeItemsFromAllDrives` / `corpora` / `driveId` params. The
+  resumable-upload endpoint URL also pins `supportsAllDrives=true`.
+- **Multipart-upload boundary.** `files.create` with a `media` body is
+  Drive's "multipart" upload path (supported up to ~5 GB per request).
+  Larger bodies should go through the resumable-session URL minted by
+  `signedUploadUrl()`, or call `adapter.raw.files.create` with
+  `media.body` set up for resumable yourself. Smaller bodies sail
+  through the multipart path even when streamed.
+- **Duplicate `fsdkKey` is a `Conflict`.** If two files share a virtual
+  key (out-of-band or via racing clients), `resolveFileId` throws
+  `Conflict` rather than picking one silently. Resolve via
+  `adapter.raw`.
+- **Per-instance cache, not shared.** `fileIdCache` lives on the
+  adapter instance; cross-process consumers pay the `files.list`
+  round-trip on every cold key.
+- **Drive quotas.** Default per-user limits are on the order of
+  1000 requests / 100 s (see
+  [Drive API limits](https://developers.google.com/drive/api/guides/limits));
+  bursts return 403 `userRateLimitExceeded`, which `mapDriveError`
+  classifies as `Unauthorized`.
+- **`signedUploadUrl` is advisory on size.** Drive does not enforce a
+  server-side size policy on resumable sessions. `maxSize` is forwarded
+  as `X-Upload-Content-Length` but is **not binding**. `minSize` is
+  ignored entirely.
+- **Error classification.** `mapDriveError` reads HTTP status from
+  `err.code` (number), `err.status`, or `err.response.status`. 404 →
+  `NotFound`; 401/403 → `Unauthorized`; 409/412 → `Conflict`; else
+  `Provider`. Original error preserved on `.cause`.
+
+## Testing approach
+
+Tests at
+[`../../test/google-drive.test.ts`](../../test/google-drive.test.ts)
+mock `@googleapis/drive` and `google-auth-library` via `mock.module`
+and back the fake `files.*` calls with a `Map<string, FakeFile>`, so
+the suite round-trips uploads and reads in-memory. `signedUploadUrl`
+is tested by stubbing `globalThis.fetch` and asserting on the
+resumable POST. Coverage includes construction-time failures, env-var
+fallbacks (the `GOOGLE_DRIVE_ID` → `rootFolderId` fallback and the
+`GOOGLE_DRIVE_ROOT_FOLDER_ID` override), `upload` writing the right
+`appProperties`, `publicByDefault`'s `permissions.create` follow-up,
+every read/list/copy/delete path, the duplicate-key `Conflict`, both
+`url` invariants, the `signedUploadUrl` POST (headers, body shape,
+returned `Location`), the full status-code classification table
+(including `err.response.status` fallback), and signal forwarding for
+every method. Add new tests here — Drive's surface is its own.
+
+## Coding conventions
+
+- Named exports only — `googleDrive`, `mapDriveError`,
+  `GoogleDriveAdapter`, `GoogleDriveAdapterOptions`,
+  `GoogleDriveClient`. No default exports.
+- Errors wrap as `FilesError` via `mapDriveError`; pass `FilesError`
+  instances through unchanged (the mapper short-circuits on them).
+- Body normalization is **local** (`normalizeBody` in this file)
+  because Drive's media body wants a Node `Readable`; the shared
+  [`normalizeBody`](../internal/core.ts) returns
+  `Uint8Array | ReadableStream`. Keep content-type defaulting rules
+  in sync if either ever changes.
+- Use [`createStoredFile`](../internal/stored-file.ts) for every
+  `StoredFile` returned. Don't hand-roll body accessors — the
+  `factory` / `kind: "lazy"` path is what `head()`'s body-on-demand
+  contract depends on.
+- Forward `operationOpts.signal` via `signalOpts(signal)` — the second
+  arg of every `drive_v3.Drive` method. Tests assert on this for
+  every operation.
+- Drive's `q` syntax requires single-quote escaping with backslashes.
+  Use `escapeQueryValue` for any user-derived value spliced into a
+  `q` string.
+- Reserved `appProperties` keys live as `KEY_PROP` /
+  `CONTENT_TYPE_PROP` / `CACHE_CONTROL_PROP` module constants. Don't
+  inline the strings.
+- No `process.env` outside [`readEnv`](../internal/env.ts). Top-level
+  regex literals only (the current file has none).
+
+## Releases
+
+Ships with the rest of the monorepo via Changesets. Behavioral changes
+(new options, default changes, error-shape changes, new auth modes)
+need a changeset (`bunx changeset` from the repo root, pick
+`files-sdk`); docs / test-only edits don't. The `google-drive`
+subpath is already declared in
+[`../../package.json`](../../package.json)'s `exports` map. Update
+[`../../CHANGELOG.md`](../../CHANGELOG.md) when shipping behavioral
+changes.
+
+## Where to look next
+
+- Source: [`./index.ts`](./index.ts); tests:
+  [`../../test/google-drive.test.ts`](../../test/google-drive.test.ts).
+- User docs:
+  [`../../../../apps/web/content/docs/adapters/google-drive.mdx`](../../../../apps/web/content/docs/adapters/google-drive.mdx);
+  provider catalog (`slug: "google-drive"`):
+  [`../providers/index.ts`](../providers/index.ts).
+- Unified `Adapter` contract: [`../index.ts`](../index.ts).
+- Shared helpers: [`../internal/core.ts`](../internal/core.ts);
+  errors [`../internal/errors.ts`](../internal/errors.ts); env
+  [`../internal/env.ts`](../internal/env.ts); stored-file
+  [`../internal/stored-file.ts`](../internal/stored-file.ts).
+- Package [`README`](../../README.md); SKILL
+  [`../../../../skills/files-sdk/SKILL.md`](../../../../skills/files-sdk/SKILL.md).
+- Drive API limits:
+  [https://developers.google.com/drive/api/guides/limits](https://developers.google.com/drive/api/guides/limits).

--- a/packages/files-sdk/src/google-drive/CLAUDE.md
+++ b/packages/files-sdk/src/google-drive/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/packages/files-sdk/src/hetzner/AGENTS.md
+++ b/packages/files-sdk/src/hetzner/AGENTS.md
@@ -1,0 +1,219 @@
+# AGENTS.md — `files-sdk/hetzner`
+
+Guidance for coding agents working inside the Hetzner Object Storage
+adapter. Every adapter in files-sdk implements the same `Adapter<Raw>`
+contract from [`packages/files-sdk/src/index.ts`](../index.ts); this
+file documents only the deviations and pitfalls specific to `hetzner`.
+For the unified API, the package-wide [README.md](../../README.md) and
+the agent skill at [`skills/files-sdk/SKILL.md`](../../../../skills/files-sdk/SKILL.md)
+are the sources of truth — read them first.
+
+`hetzner` is a thin wrapper around [`s3()`](../s3/index.ts) configured
+for Hetzner's S3-compatible Object Storage. Upload, download, presigning,
+bulk delete, and error classification all come straight from the inner
+`s3` adapter; consult [`../s3/AGENTS.md`](../s3/AGENTS.md) for those
+primitive-level details. This file covers only the Hetzner-shaped
+defaults layered on top: the derived endpoint, the `HCLOUD_*`
+credential fallback, the relabelled error message, and the
+construction-time validation.
+
+## Overview
+
+Hetzner Object Storage via the S3 HTTP API. Family: **S3 / S3-compatible
+wrapper**. Hetzner is wire-compatible with S3 — there is no dedicated
+Hetzner SDK. The factory builds the endpoint from a location code
+(`fsn1`, `nbg1`, `hel1`), composes static credentials with `HCLOUD_*`
+env vars, and calls `s3()` with the right knobs set, so users get
+sensible defaults instead of hand-rolling `s3({ endpoint: ... })`. Peer
+dependencies (all optional, in [`package.json`](../../package.json)):
+
+- `@aws-sdk/client-s3`
+- `@aws-sdk/s3-presigned-post`
+- `@aws-sdk/s3-request-presigner`
+
+## Directory layout
+
+```text
+packages/files-sdk/src/hetzner/
+├── index.ts                # adapter implementation
+├── AGENTS.md               # this file
+└── CLAUDE.md               # `@AGENTS.md`
+```
+
+Sibling files outside this directory:
+
+- Tests: [`packages/files-sdk/test/hetzner.test.ts`](../../test/hetzner.test.ts)
+- User docs: [`apps/web/content/docs/adapters/hetzner.mdx`](../../../../apps/web/content/docs/adapters/hetzner.mdx)
+- Provider catalog entry: [`packages/files-sdk/src/providers/index.ts`](../providers/index.ts) (search for `slug: "hetzner"`)
+- Underlying S3 adapter: [`packages/files-sdk/src/s3/`](../s3/)
+
+## Build, test, typecheck
+
+```bash
+# from packages/files-sdk/
+bun test test/hetzner.test.ts       # run only this adapter's tests
+bun test                            # run the whole test suite
+bun run build                       # tsup ESM bundle -> dist/hetzner/index.js
+bun run types                       # tsgo --noEmit
+```
+
+Same conventions as the rest of the package: **`bun test`** (not
+vitest), **`tsgo`** (not `tsc`). The per-subpath bundle is at
+`dist/hetzner/index.{js,d.ts}` per the `exports` map in
+[`packages/files-sdk/package.json`](../../package.json).
+
+## Public surface
+
+Defined in [`index.ts`](index.ts):
+
+- `hetzner(opts: HetznerAdapterOptions): HetznerAdapter` — factory
+  (lines 57-99). Constructs an inner `s3()` and returns it with `name`
+  rewritten to `"hetzner"`. No class, no extra methods.
+- `HetznerAdapterOptions` interface (lines 8-53) — `bucket`, `region`,
+  `endpoint`, `accessKeyId`, `secretAccessKey`, `forcePathStyle`,
+  `publicBaseUrl`, `defaultUrlExpiresIn`. Inline JSDoc is what
+  `<AutoTypeTable>` renders into [`apps/web/content/docs/adapters/hetzner.mdx`](../../../../apps/web/content/docs/adapters/hetzner.mdx) —
+  treat edits there as public-API changes.
+- `HetznerAdapter` type alias — `Adapter<S3Client>`. `raw` is the inner
+  `@aws-sdk/client-s3` `S3Client`, so the escape hatch works as it does
+  on `s3`. Consumers import via the `files-sdk/hetzner` subpath
+  declared in [`../../package.json`](../../package.json).
+
+## Authentication / configuration
+
+Static credentials only — unlike vanilla `s3()`, the AWS credential
+chain is **not** used (Hetzner doesn't participate in IMDS, SSO, or
+shared-profile flows, so silently picking up ambient AWS credentials
+would be a footgun). The factory reads `opts.accessKeyId` /
+`opts.secretAccessKey`, falling back to `HCLOUD_ACCESS_KEY_ID` /
+`HCLOUD_SECRET_ACCESS_KEY` via `readEnv`
+([`../internal/env.ts`](../internal/env.ts)). If either resolves to a
+falsy value, the factory throws a `FilesError` with code `Provider`
+(lines 68-73). `region` and `bucket` are also required and have no env
+fallback — missing region throws a separate `FilesError` (lines 62-67)
+with a hint to pass `"fsn1"`.
+
+`opts.endpoint`, when supplied, overrides the derived
+`https://${region}.your-objectstorage.com`. `opts.forcePathStyle`,
+`opts.publicBaseUrl`, and `opts.defaultUrlExpiresIn` flow through to
+`s3()` and follow the rules documented there.
+
+## Operation map
+
+The returned adapter is **the inner `s3()` adapter, spread**, with
+`name` overridden to `"hetzner"` (lines 95-98). Every method (`upload`,
+`download`, `head`, `exists`, `delete`, `deleteMany`, `copy`, `list`,
+`url`, `signedUploadUrl`) is the S3 implementation byte-for-byte —
+there is no method-level Hetzner code path. For per-operation details
+(lazy body accessors, `DeleteObjects` chunking at 1000 keys,
+`existsByProbe` classification, presigned-POST vs presigned-PUT on
+`maxSize`), see [`../s3/AGENTS.md`](../s3/AGENTS.md); anything you
+change there changes Hetzner too.
+
+The only Hetzner-side adjustments happen at construction: endpoint
+derivation (lines 75-76), `defaultProviderMessage: "Hetzner error"`
+forwarded to `s3()` (line 86) so the inner `mapS3Error` produces
+`"Hetzner error"` for unknown failures, and the `name: "hetzner"`
+override (line 97).
+
+## URL behavior
+
+Identical to `s3` — same `resolveUrlStrategy` precedence (see
+[`../internal/core.ts`](../internal/core.ts)):
+
+- With `publicBaseUrl` and no `responseContentDisposition`, `url()`
+  returns `${publicBaseUrl}/${encodedKey}`. Hetzner Object Storage has
+  no built-in CDN, so this is typically a custom CNAME or reverse
+  proxy; leaving `publicBaseUrl` unset is the common case.
+- Otherwise, `url()` returns a presigned `GetObject` URL signed against
+  `<region>.your-objectstorage.com`. Per-call `expiresIn` beats
+  `opts.defaultUrlExpiresIn`, which beats `DEFAULT_URL_EXPIRES_IN` (3600s).
+- `responseContentDisposition` always forces signing even when
+  `publicBaseUrl` is set — same security override rule as `s3`.
+
+## Provider quirks worth remembering
+
+- **Endpoint hostname is `<region>.your-objectstorage.com`.** Not
+  `objectstorage.hetzner.com`, not `hetzner.cloud`. Hetzner documents
+  only the `your-objectstorage.com` form; getting it wrong fails at
+  the TLS handshake, not with an S3 error body, which is awkward to
+  debug from a stack trace alone.
+- **`region` doubles as the SigV4 region.** Hetzner ignores the region
+  for request routing (the endpoint encodes the location), but the SDK
+  still includes it in the signature. The factory wires `opts.region`
+  into both the endpoint and the SigV4 region exactly to keep them in
+  sync — don't split them.
+- **No env fallback for `region` or `bucket`.** No Hetzner CLI
+  convention exists for these (unlike `AWS_REGION` / `AWS_S3_BUCKET`).
+  Don't invent `HCLOUD_REGION` / `HCLOUD_BUCKET` reads unless Hetzner
+  adopts canonical names — wire them through `readEnv` in
+  [`../internal/env.ts`](../internal/env.ts) the same way the credential
+  fallbacks are wired if that day comes.
+- **Virtual-hosted style is canonical.** Hetzner routes by `Host` header
+  and expects `<bucket>.<region>.your-objectstorage.com`. The adapter
+  forwards `forcePathStyle` only when the caller sets it explicitly, so
+  the AWS SDK's `false` default carries through. The test suite pins
+  `forcePathStyle === false` by default so a drive-by AWS-SDK default
+  change would fail loudly.
+- **Errors say "Hetzner error".** `defaultProviderMessage` (an
+  `@internal` knob on `S3AdapterOptions`) is set to `"Hetzner error"`
+  so unknown errors don't read "S3 error" to users importing
+  `files-sdk/hetzner`. The final test in `hetzner.test.ts` exercises
+  `mapS3Error` with this fallback table directly — preserve that
+  coverage when refactoring the inner mapper.
+
+## Testing approach
+
+Tests in [`packages/files-sdk/test/hetzner.test.ts`](../../test/hetzner.test.ts)
+use the same pattern as `s3.test.ts`: `aws-sdk-client-mock` against the
+inner `S3Client`. Coverage includes endpoint derivation for `fsn1` and
+`hel1` plus the explicit `endpoint` override; `forcePathStyle` default
+and override; construction-time validation for missing `region` and
+missing credentials; env-var credential fallback (`HCLOUD_*`, with
+save/restore around ambient values); `url()` defaults and the
+`publicBaseUrl` branch; `upload` / `exists` delegation through
+`mockClient`; and the relabelled `mapS3Error` fallback asserting
+`"Hetzner error"` wins.
+
+Add a test for any new behaviour. The adapter is shallow enough that
+test coverage is the only durable guard against a future `s3()`
+refactor silently regressing the Hetzner-specific defaults.
+
+## Coding conventions
+
+- Named exports only — no default exports.
+- Read env vars exclusively through `readEnv` in
+  [`../internal/env.ts`](../internal/env.ts). Bare `process.env` reads
+  throw `ReferenceError` on Cloudflare Workers without `nodejs_compat`,
+  and the shared helper handles that case.
+- Construction-time validation throws `FilesError` with code `Provider`
+  ([`../internal/errors.ts`](../internal/errors.ts)). Don't invent new
+  codes; the unified set covers the cases here.
+- Keep this adapter a thin wrapper. If you need behaviour that differs
+  from the inner `s3()` call, extend `S3AdapterOptions` in
+  [`../s3/index.ts`](../s3/index.ts) with an opt-in toggle and pass it
+  through, instead of forking an operation here. The
+  `defaultProviderMessage` / `endpoint` knobs are the existing
+  precedent.
+- Conditional spread (`...(opts.foo !== undefined && { foo: opts.foo })`)
+  is the established pattern for forwarding optional fields without
+  collapsing them to `undefined` — keep it consistent with existing
+  usage here and in `s3/index.ts`.
+
+## Releases
+
+The repo uses Changesets. Behavioural changes here (env-var names,
+default expiries, endpoint derivation, the provider message label) need
+a changeset (`bunx changeset`, commit under `.changeset/`); docs and
+AGENTS.md edits don't. When an inner `s3()` change affects this
+wrapper, call it out in the changeset so users watching only the
+Hetzner subpath notice.
+
+## Where to look next
+
+- User-facing docs: [`apps/web/content/docs/adapters/hetzner.mdx`](../../../../apps/web/content/docs/adapters/hetzner.mdx)
+- Source and tests: [`index.ts`](index.ts), [`packages/files-sdk/test/hetzner.test.ts`](../../test/hetzner.test.ts)
+- Inner S3 adapter: [`packages/files-sdk/src/s3/index.ts`](../s3/index.ts) + [`packages/files-sdk/src/s3/AGENTS.md`](../s3/AGENTS.md)
+- Provider catalog entry: [`packages/files-sdk/src/providers/index.ts`](../providers/index.ts)
+- Unified Adapter contract and shared helpers: [`packages/files-sdk/src/index.ts`](../index.ts), [`packages/files-sdk/src/internal/core.ts`](../internal/core.ts)
+- Package SKILL and README: [`skills/files-sdk/SKILL.md`](../../../../skills/files-sdk/SKILL.md), [`packages/files-sdk/README.md`](../../README.md)

--- a/packages/files-sdk/src/hetzner/CLAUDE.md
+++ b/packages/files-sdk/src/hetzner/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/packages/files-sdk/src/ibm-cos/AGENTS.md
+++ b/packages/files-sdk/src/ibm-cos/AGENTS.md
@@ -1,0 +1,230 @@
+# AGENTS.md — `files-sdk/ibm-cos`
+
+Guidance for coding agents working on the `ibm-cos` adapter. The unified
+`Adapter<Raw>` contract — call shapes, `FilesError`, `UrlOptions`,
+`SignUploadOptions`, body normalization — lives in
+[`../index.ts`](../index.ts); this file only documents IBM Cloud Object
+Storage-specific behavior. `ibmCos()` is a thin wrapper around
+[`s3()`](../s3/index.ts) for [IBM Cloud Object Storage](https://www.ibm.com/cloud/object-storage)'s
+S3-compatible API, so the operation map, error mapping, and presign
+mechanics live in the S3 adapter — see [`../s3/AGENTS.md`](../s3/AGENTS.md)
+for primitive-level details. Cross-references: [`README.md`](../../README.md),
+[`SKILL.md`](../../../../skills/files-sdk/SKILL.md).
+
+## Overview
+
+A thin shim that calls `s3()` with an IBM COS endpoint, IBM HMAC
+credentials, and a `defaultProviderMessage` of
+`"IBM Cloud Object Storage error"` so users importing
+`files-sdk/ibm-cos` don't see `"S3 error"`. No per-method code: every
+operation is forwarded by spread, and the only IBM-specific logic
+happens at construction — endpoint derivation from the region code,
+credential env-var pair, error-message relabel, and the
+`name: "ibm-cos"` override. The returned adapter's `raw` is the
+underlying `@aws-sdk/client-s3` `S3Client`, so anything the AWS SDK
+can do against IBM COS (multipart, lifecycle rules, immutable object
+storage / WORM) is one property access away.
+
+## Directory layout
+
+```text
+packages/files-sdk/src/ibm-cos/
+├── index.ts                   # ibmCos() factory + IbmCosAdapterOptions
+├── AGENTS.md                  # this file
+└── CLAUDE.md                  # @AGENTS.md — Claude-Code re-export
+```
+
+Tests at [`../../test/ibm-cos.test.ts`](../../test/ibm-cos.test.ts);
+user-facing docs at
+[`../../../../apps/web/content/docs/adapters/ibm-cos.mdx`](../../../../apps/web/content/docs/adapters/ibm-cos.mdx);
+provider catalog entry in [`../providers/index.ts`](../providers/index.ts)
+(search `slug: "ibm-cos"`); inner S3 adapter at [`../s3/`](../s3/).
+
+## Build, test, typecheck
+
+Run from `packages/files-sdk`:
+
+```bash
+bun test test/ibm-cos.test.ts   # this adapter's tests only
+bun test                         # full SDK suite
+bun run build                    # tsup -> dist/, including dist/ibm-cos/
+bun run types                    # tsgo --noEmit (typecheck only)
+```
+
+The `ibm-cos` subpath is enumerated in
+[`../../package.json`](../../package.json)'s `exports` map — keep that
+in sync if the file layout ever changes.
+
+## Public surface
+
+Exports from [`./index.ts`](./index.ts):
+
+- `ibmCos(opts: IbmCosAdapterOptions): IbmCosAdapter` — primary factory.
+  The adapter's `name` is `"ibm-cos"` (set after spreading the inner
+  adapter, so it overrides the S3 adapter's `"s3"`).
+- `IbmCosAdapter` — type alias for `Adapter<S3Client>`. `raw` is the
+  underlying AWS SDK client.
+- `IbmCosAdapterOptions` — config interface. JSDoc on every field is
+  the source of truth; the docs MDX renders it via `<AutoTypeTable>`,
+  so edits to the JSDoc are public-API changes.
+
+## Authentication / configuration
+
+Required (no env fallback for either):
+
+- `bucket` — string.
+- `region` — IBM COS region code (`us-south`, `us-east`, `eu-de`,
+  `eu-gb`, `eu-es`, `jp-tok`, `jp-osa`, `au-syd`, `br-sao`, `ca-tor`,
+  …). Missing region throws `FilesError("Provider", …)` at
+  construction. Doubles as the SigV4 region.
+- Credentials — `accessKeyId` + `secretAccessKey` HMAC pair, passed in
+  or sourced from `IBM_COS_ACCESS_KEY_ID` / `IBM_COS_SECRET_ACCESS_KEY`
+  via [`readEnv`](../internal/env.ts). Missing both throws
+  `FilesError("Provider", …)`. **Not an IBM Cloud IAM API key** — see
+  *Provider quirks*.
+
+Optional:
+
+- `endpoint` — overrides the derived
+  `https://s3.${region}.cloud-object-storage.appdomain.cloud`. Use for
+  the public / direct / private variants (see *Provider quirks*).
+- `forcePathStyle` — defaults to `false`. Virtual-hosted is canonical
+  for IBM COS; only flip this for proxies that demand path-style.
+- `publicBaseUrl` — origin used by `url()` when set; skips signing.
+  Natural value is
+  `https://${bucket}.s3.${region}.cloud-object-storage.appdomain.cloud`
+  for public-read buckets, or a custom CNAME.
+- `defaultUrlExpiresIn` — default presigned-URL expiry in seconds.
+  Falls back to `DEFAULT_URL_EXPIRES_IN` (3600) in
+  [`../internal/core.ts`](../internal/core.ts) when unset.
+
+## Operation map
+
+`ibmCos()` calls `s3()` and spreads the returned adapter, overriding
+only `name`. `upload`, `download`, `head`, `exists`, `delete`,
+`deleteMany`, `copy`, `list`, `url`, and `signedUploadUrl` are
+inherited unchanged from [`../s3/index.ts`](../s3/index.ts) —
+including `deleteMany`'s 1000-key chunking, `signedUploadUrl`'s
+PUT-vs-presigned-POST split on `maxSize`, and `exists`' 404-as-`false`
+classification. Provider errors flow through `mapS3Error` with the IBM
+COS fallback table; `Provider`-coded messages read
+`"IBM Cloud Object Storage error"` while preserving any server-side
+message on the wire.
+
+## URL behavior
+
+`url(key, opts?)` follows the standard signing-adapter rules:
+
+- Default: presigned `GetObject` URL, expiring after
+  `opts.expiresIn ?? defaultUrlExpiresIn` seconds.
+- With `publicBaseUrl`: returns `${publicBaseUrl}/${key}` unsigned via
+  `joinPublicUrl` from [`../internal/core.ts`](../internal/core.ts)
+  (URL-encodes path segments).
+- With `opts.responseContentDisposition`: always signs, even when
+  `publicBaseUrl` is set — a permanent CDN URL has no signature to
+  bind the override to, and silently dropping it would be a stored-XSS
+  regression on user-uploaded HTML/SVG. See `resolveUrlStrategy` in
+  [`../internal/core.ts`](../internal/core.ts).
+
+IBM COS has no built-in CDN, so `publicBaseUrl` is usually unset.
+
+## Provider quirks worth remembering
+
+- **HMAC credentials only.** IBM Cloud IAM API keys cannot sign S3
+  requests; pasting one into `accessKeyId` produces opaque
+  `SignatureDoesNotMatch` from the wire with no construction-time
+  hint. Generate the HMAC pair by ticking *Advanced options → Include
+  HMAC Credential* when creating the IBM COS service credential — the
+  resulting object exposes `cos_hmac_keys.access_key_id` /
+  `cos_hmac_keys.secret_access_key`, which are the values this adapter
+  expects.
+- **Endpoint variants route by `Host` header.** Three siblings under
+  `*.cloud-object-storage.appdomain.cloud` differ only in hostname:
+  public (`s3.${region}.…`, the factory default), direct
+  (`s3.direct.${region}.…`, in-region IBM Cloud only), and private
+  (`s3.private.${region}.…`, legacy private-network). Pass the variant
+  through `opts.endpoint` when running inside the same IBM Cloud
+  region — it skips egress fees and keeps traffic on the IBM backbone.
+- **Region naming is IBM's, not AWS's.** `us-south`, `eu-de`,
+  `jp-tok` look AWS-shaped, but reusing an AWS region string
+  (`us-east-1`) silently signs against a non-existent endpoint. The
+  factory wires `opts.region` into both the endpoint and the SigV4
+  region to keep them in sync.
+- **No env fallback for `region` or `bucket`.** IBM Cloud has no
+  canonical CLI env-var convention for these. Don't invent
+  `IBM_COS_REGION` reads unless IBM publishes one — wire through
+  `readEnv` the same way as the credential fallbacks if that day comes.
+- **Virtual-hosted style is canonical.** IBM COS expects
+  `<bucket>.s3.<region>.cloud-object-storage.appdomain.cloud`. The
+  adapter forwards `forcePathStyle` only when the caller sets it
+  explicitly, so the AWS SDK's `false` default carries through; the
+  test suite pins it to `false` so a drive-by AWS-SDK default change
+  would fail loudly.
+- **Errors say "IBM Cloud Object Storage error".**
+  `defaultProviderMessage` (an `@internal` knob on `S3AdapterOptions`)
+  is set so unknown failures don't read "S3 error". The final test in
+  [`../../test/ibm-cos.test.ts`](../../test/ibm-cos.test.ts) pins this
+  via `mapS3Error` directly — preserve that coverage when refactoring
+  the inner mapper.
+
+## Testing approach
+
+Tests in [`../../test/ibm-cos.test.ts`](../../test/ibm-cos.test.ts)
+follow the same pattern as `s3.test.ts`: `aws-sdk-client-mock` against
+the inner `S3Client`. Coverage includes endpoint derivation for
+`us-south` and `eu-de` plus the explicit `endpoint` override;
+`forcePathStyle` default and override; construction-time validation
+for missing `region` and missing credentials; `IBM_COS_*` env-var
+fallback with save/restore around ambient values; `url()` defaults
+and the `publicBaseUrl` short-circuit; `upload` / `exists` delegation
+through `mockClient`; and the relabelled `mapS3Error` fallback
+asserting `"IBM Cloud Object Storage error"` wins.
+
+Add fixtures here rather than to `s3.test.ts` whenever a behavior
+depends on IBM COS-specific config (endpoint host, relabel, env-var
+name); shared S3 semantics belong in
+[`../../test/s3.test.ts`](../../test/s3.test.ts).
+
+## Coding conventions
+
+- Named exports only — `ibmCos`, `IbmCosAdapter`, `IbmCosAdapterOptions`.
+- Construction-time errors use
+  [`FilesError("Provider", …)`](../internal/errors.ts); operation
+  errors are the inner S3 adapter's responsibility — don't try-catch
+  and rethrow in this shim.
+- Read env vars via [`readEnv`](../internal/env.ts); direct
+  `process.env` access throws on Cloudflare Workers without
+  `nodejs_compat`.
+- Forward optional knobs with
+  `...(opts.x !== undefined && { x: opts.x })` so unset values fall
+  through to AWS-SDK defaults rather than as explicit `undefined`.
+- Spread the inner adapter, then override only `name` — preserves
+  future `Adapter` additions that `s3()` picks up. Top-level regex
+  literals only.
+
+## Releases
+
+Ships with the rest of the monorepo from
+[`../../package.json`](../../package.json). Behavioral changes (new
+options, default changes, endpoint derivation tweaks, env-var renames)
+bump the `files-sdk` version and add an entry to
+[`../../CHANGELOG.md`](../../CHANGELOG.md); docs / test-only additions
+don't. When an inner `s3()` change affects this wrapper, call it out
+in the changeset so users watching only `files-sdk/ibm-cos` notice.
+
+## Where to look next
+
+- Unified contract: [`../index.ts`](../index.ts).
+- Inner S3 adapter: [`../s3/index.ts`](../s3/index.ts) +
+  [`../s3/AGENTS.md`](../s3/AGENTS.md).
+- Shared helpers (URL strategy, body normalization, error-mapper
+  factory): [`../internal/core.ts`](../internal/core.ts).
+- `FilesError`: [`../internal/errors.ts`](../internal/errors.ts). Env
+  reader: [`../internal/env.ts`](../internal/env.ts). Provider
+  catalog (search `slug: "ibm-cos"`):
+  [`../providers/index.ts`](../providers/index.ts).
+- User-facing docs:
+  [`../../../../apps/web/content/docs/adapters/ibm-cos.mdx`](../../../../apps/web/content/docs/adapters/ibm-cos.mdx).
+  Tests: [`../../test/ibm-cos.test.ts`](../../test/ibm-cos.test.ts).
+- Package README: [`../../README.md`](../../README.md). SKILL:
+  [`../../../../skills/files-sdk/SKILL.md`](../../../../skills/files-sdk/SKILL.md).

--- a/packages/files-sdk/src/ibm-cos/CLAUDE.md
+++ b/packages/files-sdk/src/ibm-cos/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/packages/files-sdk/src/idrive-e2/AGENTS.md
+++ b/packages/files-sdk/src/idrive-e2/AGENTS.md
@@ -1,0 +1,220 @@
+# AGENTS.md — `files-sdk/idrive-e2`
+
+Guidance for coding agents working inside the `idrive-e2` adapter. The
+unified `Adapter<Raw>` contract — call shapes, `FilesError`,
+`UrlOptions`, `SignUploadOptions`, body normalization — lives in
+[`../index.ts`](../index.ts); this file only documents the
+idrive-e2-specific behavior. `idriveE2()` is a thin wrapper around
+[`s3()`](../s3/index.ts) for [iDrive e2](https://www.idrive.com/e2/)'s
+S3-compatible API, so the operation map, error mapping, and presign
+mechanics live in the S3 adapter — see
+[`../s3/AGENTS.md`](../s3/AGENTS.md) for primitive-level details.
+Cross-references: [`../../README.md`](../../README.md),
+[`../../../../skills/files-sdk/SKILL.md`](../../../../skills/files-sdk/SKILL.md).
+
+## Overview
+
+A thin shim that calls `s3()` with the caller-supplied iDrive e2
+endpoint, iDrive credentials, a SigV4 region (defaulted to
+`"us-east-1"`), and a `defaultProviderMessage` of `"iDrive e2 error"`
+so users don't see `"S3 error"` from an iDrive-typed adapter. No
+per-method code: every operation is forwarded by spread. The only
+idrive-e2-specific knobs are the required endpoint, the credential
+env-var pair, the relabelled error, and construction-time validation.
+The returned adapter's `raw` is the underlying `S3Client` — anything
+the AWS SDK can do against iDrive e2 (multipart, lifecycle, object
+versioning where exposed) is one property access away.
+
+## Directory layout
+
+```text
+packages/files-sdk/src/idrive-e2/
+├── index.ts                # idriveE2() factory + IdriveE2AdapterOptions
+├── AGENTS.md               # this file
+└── CLAUDE.md               # @AGENTS.md — Claude-Code re-export
+```
+
+Tests at [`../../test/idrive-e2.test.ts`](../../test/idrive-e2.test.ts);
+user-facing docs at
+[`../../../../apps/web/content/docs/adapters/idrive-e2.mdx`](../../../../apps/web/content/docs/adapters/idrive-e2.mdx).
+Provider catalog entry in
+[`../providers/index.ts`](../providers/index.ts) under
+`slug: "idrive-e2"`.
+
+## Build, test, typecheck
+
+From `packages/files-sdk`:
+
+```bash
+bun test test/idrive-e2.test.ts   # adapter unit tests only
+bun test                           # full SDK suite
+bun run build                      # tsup → dist/, including dist/idrive-e2/
+bun run types                      # tsgo --noEmit (typecheck only)
+```
+
+The `idrive-e2` subpath is enumerated in
+[`../../package.json`](../../package.json)'s `exports` map — keep it
+in sync if the file layout changes.
+
+## Public surface
+
+Exports from [`./index.ts`](./index.ts):
+
+- `idriveE2(opts: IdriveE2AdapterOptions): IdriveE2Adapter` — factory.
+- `IdriveE2Adapter` — alias for `Adapter<S3Client>`. `raw` is the
+  underlying AWS SDK client.
+- `IdriveE2AdapterOptions` — config interface (JSDoc on every field is
+  the source of truth; the docs MDX pulls it via `AutoTypeTable`).
+
+The adapter's `name` is `"idrive-e2"` (set after spreading the inner
+adapter, so it overrides `"s3"`).
+
+## Authentication / configuration
+
+Required: `bucket` (no env fallback); `endpoint` (no derivation, no
+env fallback — see *Provider quirks*); and credentials
+(`accessKeyId` + `secretAccessKey`, passed in or sourced from
+`IDRIVE_E2_ACCESS_KEY_ID` / `IDRIVE_E2_SECRET_ACCESS_KEY` via
+[`readEnv`](../internal/env.ts)). Missing endpoint or credentials
+throw `FilesError("Provider", …)` at construction.
+
+Optional: `region` (defaults to `"us-east-1"` — iDrive ignores it for
+routing, but SigV4 still needs *some* value); `forcePathStyle`
+(defaults to `false`; virtual-hosted on the bucket subdomain is
+canonical); `publicBaseUrl` (skips signing — typically a custom CNAME
+or reverse proxy since iDrive ships no CDN); `defaultUrlExpiresIn`
+(presigned-URL expiry in seconds, defaulting to `3600` via
+`DEFAULT_URL_EXPIRES_IN` in
+[`../internal/core.ts`](../internal/core.ts)).
+
+Static credentials only — the AWS credential chain is **not**
+consulted (iDrive doesn't participate in IMDS or SSO; silently
+picking up ambient AWS credentials would be a footgun). Env lookups
+go through `readEnv` so the adapter imports cleanly on runtimes
+without `process` (Cloudflare Workers without `nodejs_compat`).
+
+## Operation map
+
+`idriveE2()` calls `s3()` with the resolved config and spreads the
+returned adapter, overriding only `name`. Every method (`upload`,
+`download`, `head`, `exists`, `delete`, `deleteMany`, `copy`, `list`,
+`url`, `signedUploadUrl`) is inherited unchanged from
+[`../s3/index.ts`](../s3/index.ts) — including `deleteMany`'s
+1000-key chunking, `signedUploadUrl`'s PUT-vs-presigned-POST split on
+`maxSize`, and `exists`' 404-as-`false` classification. Provider
+errors flow through `mapS3Error` with the iDrive fallback table —
+`Provider`-coded messages read `"iDrive e2 error"` instead of
+`"S3 error"` while preserving any server-side message.
+
+## URL behavior
+
+`url(key, opts?)` follows the standard signing-adapter rules:
+
+- Default: presigned `GetObject` URL signed against the configured
+  endpoint host, expiring after
+  `opts.expiresIn ?? defaultUrlExpiresIn` seconds.
+- With `publicBaseUrl`: returns `${publicBaseUrl}/${key}` unsigned,
+  via `joinPublicUrl` from
+  [`../internal/core.ts`](../internal/core.ts) (URL-encodes path
+  segments).
+- With `opts.responseContentDisposition`: always signs, even when
+  `publicBaseUrl` is set — a permanent CDN URL has no signature in
+  which to bind the override, and silently dropping it would be a
+  stored-XSS regression on user-uploaded HTML/SVG. See
+  `resolveUrlStrategy` in
+  [`../internal/core.ts`](../internal/core.ts).
+
+## Provider quirks worth remembering
+
+- **Endpoint is required and not derivable.** Other S3-compatible
+  wrappers here build the host from a region code; iDrive e2
+  hostnames are cluster-private (`q9z7.va.idrivee2-NN.com`-shaped —
+  cluster id, location code, service shard) and only the dashboard
+  (*Access Keys → Endpoint*) knows the exact host. The factory
+  throws if `endpoint` is missing rather than signing against a host
+  that won't resolve.
+- **Region is a SigV4 sentinel, not a routing value.** Defaults to
+  `"us-east-1"`; iDrive ignores it for dispatch but SigV4 still
+  embeds it in the signature. Revisit only if iDrive starts
+  validating it server-side.
+- **No env fallback for `region`, `bucket`, or `endpoint`.** No
+  iDrive CLI convention exists; inventing `IDRIVE_E2_REGION` /
+  `_BUCKET` / `_ENDPOINT` risks colliding with a future official one.
+- **Virtual-hosted addressing is canonical.** iDrive e2 routes by
+  Host header to the bucket subdomain; the test suite pins
+  `forcePathStyle === false` by default so a drive-by AWS-SDK default
+  change would fail loudly. No native CDN, so set `publicBaseUrl`
+  only when a CDN or reverse proxy has been wired up manually.
+- **Errors say `"iDrive e2 error"`.** `defaultProviderMessage` (an
+  `@internal` knob on `S3AdapterOptions`) is set so unknown errors
+  don't read `"S3 error"`. The final test in `idrive-e2.test.ts`
+  exercises `mapS3Error` with this fallback table directly —
+  preserve that coverage when refactoring the inner mapper.
+- **Access keys** are generated in the iDrive dashboard under
+  *Access Keys*; static credentials are the only auth mode.
+
+## Testing approach
+
+Unit tests at
+[`../../test/idrive-e2.test.ts`](../../test/idrive-e2.test.ts) cover:
+endpoint + protocol round-trip through the inner `S3Client` config
+(`q9z7.va.idrivee2-12.com` as the canonical sample host); default
+SigV4 region `"us-east-1"` and explicit override; default
+`forcePathStyle: false` and explicit override; missing-endpoint and
+missing-credential construction errors; `IDRIVE_E2_ACCESS_KEY_ID` /
+`IDRIVE_E2_SECRET_ACCESS_KEY` env-var fallbacks (save/restore around
+ambient values); `url()` presign default (endpoint host and
+`X-Amz-Signature=` in the result) and `publicBaseUrl` short-circuit;
+operation delegation via `aws-sdk-client-mock`'s `mockClient(S3Client)`
+for `upload` and both `exists` paths (success + 404); and error
+relabeling — `mapS3Error` with the iDrive messages table returns
+`"iDrive e2 error"` for the `Provider` code.
+
+Add fixtures here when behavior depends on idrive-e2-specific config;
+shared S3 semantics belong in [`../../test/s3.test.ts`](../../test/s3.test.ts).
+
+## Coding conventions
+
+- Named exports only — `idriveE2`, `IdriveE2Adapter`,
+  `IdriveE2AdapterOptions`.
+- Construction-time errors use
+  [`FilesError("Provider", …)`](../internal/errors.ts) naming the env
+  vars and dashboard; operation errors are the inner S3 adapter's
+  responsibility.
+- Read env vars via [`readEnv`](../internal/env.ts); direct
+  `process.env` access breaks Cloudflare Workers without
+  `nodejs_compat`.
+- Forward optional knobs with
+  `...(opts.x !== undefined && { x: opts.x })` so unset values fall
+  through to AWS-SDK defaults instead of being passed as `undefined`.
+- Spread the inner adapter, then override only `name` — preserves
+  future additions to the `Adapter` interface that `s3()` picks up.
+- Top-level regex literals only; brand casing is `"iDrive e2"` in
+  user-facing strings and `"idrive-e2"` (kebab) in the slug, adapter
+  `name`, subpath, and filenames.
+
+## Releases
+
+Ships with the rest of the monorepo from
+[`../../package.json`](../../package.json). Behavioral changes (new
+options, default changes, error-shape changes) bump `files-sdk` and
+add an entry to [`../../CHANGELOG.md`](../../CHANGELOG.md); docs and
+test-only additions don't. The `idrive-e2` subpath is already in
+`exports` — no further wiring for new options.
+
+## Where to look next
+
+- Unified `Adapter` contract: [`../index.ts`](../index.ts); inner S3
+  adapter: [`../s3/index.ts`](../s3/index.ts) +
+  [`../s3/AGENTS.md`](../s3/AGENTS.md).
+- Shared helpers (URL strategy, body normalization, error mapper):
+  [`../internal/core.ts`](../internal/core.ts); `FilesError`:
+  [`../internal/errors.ts`](../internal/errors.ts); env reader:
+  [`../internal/env.ts`](../internal/env.ts).
+- Provider catalog (search `slug: "idrive-e2"`):
+  [`../providers/index.ts`](../providers/index.ts).
+- User-facing docs:
+  [`../../../../apps/web/content/docs/adapters/idrive-e2.mdx`](../../../../apps/web/content/docs/adapters/idrive-e2.mdx);
+  README: [`../../README.md`](../../README.md); SKILL:
+  [`../../../../skills/files-sdk/SKILL.md`](../../../../skills/files-sdk/SKILL.md);
+  tests: [`../../test/idrive-e2.test.ts`](../../test/idrive-e2.test.ts).

--- a/packages/files-sdk/src/idrive-e2/CLAUDE.md
+++ b/packages/files-sdk/src/idrive-e2/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/packages/files-sdk/src/minio/AGENTS.md
+++ b/packages/files-sdk/src/minio/AGENTS.md
@@ -1,0 +1,224 @@
+# AGENTS.md — `files-sdk/minio`
+
+Guidance for coding agents working inside the MinIO adapter. The unified
+`Adapter<Raw>` contract — methods, option shapes, error codes, and
+URL/signing semantics — lives in [src/index.ts](../index.ts); this file only
+documents what minio adds (or constrains) on top of it. The adapter is a
+thin wrapper over [`s3()`](../s3/index.ts) with self-hosted-friendly
+defaults, so for the underlying primitive details (signing, error mapping,
+presigned POST, bulk delete) read alongside the s3 source. See also
+[README.md](../../README.md) and
+[SKILL.md](../../../../skills/files-sdk/SKILL.md).
+
+## Overview
+
+`files-sdk/minio` connects a `Files` instance to a self-hosted MinIO server
+(or any other server speaking the MinIO/S3 wire protocol on a custom
+endpoint). It exists because every MinIO deployment needs the same three
+knobs flipped from the AWS defaults:
+
+- An explicit `endpoint` — no DNS-based bucket routing.
+- `forcePathStyle: true` — virtual-hosted style needs per-bucket subdomain
+  setup that self-hosted clusters rarely have.
+- A region placeholder — SigV4 requires *some* region in the signature;
+  MinIO ignores it for routing.
+
+The adapter sets those for you, relabels the fallback error message so users
+see "MinIO error" instead of "S3 error", reads env-var fallbacks under
+`MINIO_*` names, and otherwise hands every operation to the inner s3 adapter
+unchanged.
+
+## Directory layout
+
+```
+packages/files-sdk/src/minio/
+├── index.ts        # minio() factory; everything else lives in ../s3/
+├── AGENTS.md       # this file
+└── CLAUDE.md       # → @AGENTS.md
+```
+
+Tests live one level up at [`test/minio.test.ts`](../../test/minio.test.ts).
+The user-facing docs page lives at
+[`apps/web/content/docs/adapters/minio.mdx`](../../../../apps/web/content/docs/adapters/minio.mdx).
+
+## Build, test, typecheck
+
+```bash
+bun test test/minio.test.ts   # adapter-only suite
+bun test                      # full SDK test suite
+bun run build                 # tsup ESM bundle → dist/
+bun run types                 # tsgo --noEmit
+```
+
+Mocks are provided by `aws-sdk-client-mock` (the adapter speaks the same
+wire protocol as s3, so the same mock library covers both). Tests should
+exercise the minio-specific behaviour (defaults, env fallbacks, error
+relabelling); the underlying operation tests already live in
+[`test/s3.test.ts`](../../test/s3.test.ts) and don't need to be duplicated.
+
+## Public surface
+
+`src/minio/index.ts` exports:
+
+- `minio(opts: MinioAdapterOptions): MinioAdapter` — primary factory.
+- `MinioAdapterOptions` — option shape (see below).
+- `MinioAdapter` — alias for `Adapter<S3Client>`. The `raw` escape hatch is
+  the same `@aws-sdk/client-s3` `S3Client` you'd get from `s3()`.
+
+`opts` deviates from `S3AdapterOptions` in a few places:
+
+- `endpoint: string` — **required** (the factory throws if empty).
+- `bucket: string` — required.
+- `accessKeyId`, `secretAccessKey` — optional only if both env vars below
+  are set; otherwise the factory throws.
+- `region` — defaults to `"us-east-1"`.
+- `forcePathStyle` — defaults to `true`.
+- `publicBaseUrl`, `defaultUrlExpiresIn` — passthrough to s3.
+
+Construction-time failures throw `FilesError("Provider", …)`. Match them in
+tests with `/endpoint/u` and `/credentials/u` patterns rather than
+full-string comparisons so the wording can evolve.
+
+## Authentication / configuration
+
+```ts
+import { Files } from "files-sdk";
+import { minio } from "files-sdk/minio";
+
+const files = new Files({
+  adapter: minio({
+    bucket: "uploads",
+    endpoint: "http://localhost:9000",
+    // accessKeyId / secretAccessKey auto-loaded from
+    // MINIO_ACCESS_KEY_ID / MINIO_SECRET_ACCESS_KEY when omitted
+  }),
+});
+```
+
+Env-var fallbacks (read via `readEnv` so the adapter still constructs on
+runtimes where `process` is missing — see
+[`internal/env.ts`](../internal/env.ts)):
+
+- `MINIO_ACCESS_KEY_ID` — backs `opts.accessKeyId`.
+- `MINIO_SECRET_ACCESS_KEY` — backs `opts.secretAccessKey`.
+
+These are **adapter-read** vars, distinct from `MINIO_ROOT_USER` /
+`MINIO_ROOT_PASSWORD` — those are read by the MinIO server itself to
+bootstrap its admin account, not by the SDK. The provider catalog entry in
+[`providers/index.ts`](../providers/index.ts) (search for `slug: "minio"`)
+is the source of truth for the env spec.
+
+There is **no** env fallback for `endpoint` — pass it inline.
+
+## Operation map
+
+Every method delegates to the inner s3 adapter; there is no per-method code
+in `minio/index.ts`. Behaviour is therefore identical to s3:
+
+| Method            | Backed by                                                                            |
+| ----------------- | ------------------------------------------------------------------------------------ |
+| `upload`          | `PutObjectCommand` (plus a follow-up `HEAD` for stream bodies with no known length). |
+| `download`        | `GetObjectCommand`; `as: "stream"` returns the raw web stream.                       |
+| `head` / `exists` | `HeadObjectCommand`; `exists` returns `false` on `NotFound`, rethrows others.        |
+| `delete`          | `DeleteObjectCommand`.                                                               |
+| `deleteMany`      | `DeleteObjectsCommand` (native bulk; chunked at 1000 keys per request).              |
+| `copy`            | `CopyObjectCommand`.                                                                 |
+| `list`            | `ListObjectsV2Command`; `cursor` round-trips `NextContinuationToken`.                |
+| `url`             | Presigned `GetObject` URL or `publicBaseUrl` join — see [URL behavior](#url-behavior). |
+| `signedUploadUrl` | Presigned POST (`createPresignedPost`) when `maxSize` is set; presigned PUT otherwise. |
+
+The returned `name` is `"minio"` (overridden after spreading the s3
+adapter). `raw` is the underlying `S3Client`.
+
+## URL behavior
+
+Inherited from the s3 adapter via `resolveUrlStrategy` in
+[`internal/core.ts`](../internal/core.ts):
+
+- `publicBaseUrl` set and no `responseContentDisposition` → returns
+  `${publicBaseUrl}/${encodeURIComponent(key)}`, unsigned.
+- Otherwise → presigned `GetObject` URL (default expiry `3600` s, override
+  with `defaultUrlExpiresIn` on the adapter or `expiresIn` per call).
+- `responseContentDisposition` **always forces signing**, even when
+  `publicBaseUrl` is configured: a permanent CDN URL has no signature to
+  bind the override to. This is a deliberate stored-XSS mitigation for
+  buckets hosting user-uploaded HTML/SVG — see the JSDoc on
+  `UrlOptions.responseContentDisposition` in [`src/index.ts`](../index.ts).
+
+## Provider quirks worth remembering
+
+- **`forcePathStyle: true` by default.** MinIO routes via path-style
+  (`/<bucket>/<key>`) unless you've fronted it with per-bucket DNS. Flip
+  `forcePathStyle: false` only when you've actually configured that.
+- **Region is a placeholder.** SigV4 needs *some* region in the signature;
+  MinIO doesn't use it for routing. The default `"us-east-1"` is correct
+  for ~every deployment. Override only when you've intentionally configured
+  per-region buckets and want the signature to reflect that.
+- **HTTP endpoints are normal.** Production should run TLS, but
+  `endpoint: "http://localhost:9000"` is fine for local dev. Include the
+  scheme; the adapter doesn't synthesize one.
+- **No env fallback for `endpoint`.** Unlike `region` (which the s3 adapter
+  falls back to `AWS_REGION` for), `endpoint` must be passed explicitly or
+  the factory throws. There is no `MINIO_ENDPOINT` fallback.
+- **Error messages read "MinIO error".** The factory passes
+  `defaultProviderMessage: "MinIO error"` into `s3()`, so the fallback on a
+  no-message provider error is "MinIO error" instead of "S3 error".
+  Server-side messages (when present) still surface unchanged.
+- **`raw` is `S3Client`, not a MinIO-specific client.** The escape hatch is
+  the AWS SDK; there's no separate MinIO SDK to reach for.
+
+## Testing approach
+
+Tests at [`test/minio.test.ts`](../../test/minio.test.ts) cover:
+
+- Construction: defaults (`region`, `forcePathStyle`, endpoint
+  hostname/port), region override, missing-endpoint and
+  missing-credentials throws.
+- `url()`: presigned by default (asserts on `X-Amz-Signature` and
+  `X-Amz-Expires=3600` query params), `publicBaseUrl` concatenation.
+- Delegation: `upload` and `exists` go through the inner s3 adapter
+  unchanged (mocked via `aws-sdk-client-mock`).
+- Error relabelling: `mapS3Error` invoked directly with the minio messages
+  table to confirm the `"MinIO error"` fallback fires when the source
+  error has no message of its own.
+
+Prefer testing minio-specific behaviour (defaults, env fallbacks,
+relabelling) rather than re-testing s3 operations — the s3 suite already
+covers those end-to-end.
+
+## Coding conventions
+
+- Named exports only — no default exports.
+- `process.env` is never touched directly; route every read through
+  [`readEnv`](../internal/env.ts) so the adapter still constructs on
+  runtimes (Cloudflare Workers without `nodejs_compat`) where `process` is
+  undefined.
+- Don't reimplement s3 operations here. If a behaviour change needs to land
+  for both s3 and minio, change it in `s3/index.ts` and let minio inherit
+  it. The only minio-specific code paths should be option defaults, env
+  fallback, construction-time validation, and `defaultProviderMessage`.
+- Throw `FilesError` for construction failures, never plain `Error`.
+- Match the JSDoc style in [`src/index.ts`](../index.ts) — full sentences,
+  explain the *why* (e.g. "SigV4 requires *some* region…") not just the
+  *what*.
+
+## Releases
+
+`files-sdk` ships as a single package; the `files-sdk/minio` subpath rides
+along with every release. Behavioural changes need a changeset at the
+monorepo root. Docs-only edits (this file, the MDX page, JSDoc tweaks that
+don't change runtime behaviour) don't.
+
+## Where to look next
+
+- Underlying primitive: [`../s3/index.ts`](../s3/index.ts) — every minio
+  call funnels through this. Error mapper, presigner, and `existsByProbe`
+  scaffold all live there.
+- Shared helpers: [`../internal/core.ts`](../internal/core.ts),
+  [`../internal/env.ts`](../internal/env.ts),
+  [`../internal/errors.ts`](../internal/errors.ts).
+- Provider catalog entry: [`../providers/index.ts`](../providers/index.ts).
+- User-facing docs:
+  [`apps/web/content/docs/adapters/minio.mdx`](../../../../apps/web/content/docs/adapters/minio.mdx).
+- SDK README and mental model: [`README.md`](../../README.md) and
+  [`SKILL.md`](../../../../skills/files-sdk/SKILL.md).

--- a/packages/files-sdk/src/minio/CLAUDE.md
+++ b/packages/files-sdk/src/minio/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/packages/files-sdk/src/netlify-blobs/AGENTS.md
+++ b/packages/files-sdk/src/netlify-blobs/AGENTS.md
@@ -1,0 +1,260 @@
+# AGENTS.md — `files-sdk/netlify-blobs`
+
+Guidance for coding agents working inside the Netlify Blobs adapter. Every
+adapter in files-sdk implements the same `Adapter<Raw>` contract from
+[`../index.ts`](../index.ts); this file documents only the deviations and
+pitfalls specific to `netlify-blobs`. The package-wide
+[`README.md`](../../README.md) and the agent skill at
+[`SKILL.md`](../../../../skills/files-sdk/SKILL.md) are the sources of
+truth for the unified API — read them first.
+
+`netlify-blobs` is a **native** adapter built directly on
+[`@netlify/blobs`](https://www.npmjs.com/package/@netlify/blobs). It does
+not wrap `s3()` — Netlify Blobs has its own protocol, no SigV4, no public
+URL primitive, and no presigned-upload primitive, so every operation runs
+against the `@netlify/blobs` `Store` API.
+
+## Overview
+
+Family: **edge/serverless blob, native**. `upload`, `download`, `head`,
+`exists`, `delete`, `copy`, and `list` are implemented in
+[`index.ts`](./index.ts) on top of `Store.set`, `Store.get`,
+`Store.getMetadata`, `Store.getWithMetadata`, `Store.delete`, and
+`Store.list`. `url` and `signedUploadUrl` throw `FilesError("Provider", …)`
+— Netlify has neither primitive.
+
+Netlify Blobs has **no native fields for content type, size, or
+last-modified**. The adapter packs those plus `cacheControl` and user
+`metadata` into Netlify's per-object `metadata` map at upload time, then
+reads them back on `head()` / `download()` / `list()` so the unified
+`StoredFile` shape matches the cloud adapters.
+
+Peer dependency (optional, declared in [`../../package.json`](../../package.json)): `@netlify/blobs`.
+
+## Directory layout
+
+```text
+packages/files-sdk/src/netlify-blobs/
+├── index.ts                # adapter implementation
+├── AGENTS.md               # this file
+└── CLAUDE.md               # @AGENTS.md — Claude-Code re-export
+```
+
+Sibling files outside this directory:
+
+- Tests: [`../../test/netlify-blobs.test.ts`](../../test/netlify-blobs.test.ts)
+- User docs: [`../../../../apps/web/content/docs/adapters/netlify-blobs.mdx`](../../../../apps/web/content/docs/adapters/netlify-blobs.mdx)
+- Provider catalog entry: [`../providers/index.ts`](../providers/index.ts) (search `slug: "netlify-blobs"`)
+
+## Build, test, typecheck
+
+Run from `packages/files-sdk`:
+
+```bash
+bun test test/netlify-blobs.test.ts   # this adapter's tests only
+bun test                              # full SDK suite
+bun run build                         # tsup → dist/netlify-blobs/index.js
+bun run types                         # tsgo --noEmit (typecheck)
+```
+
+`bun test` is the runner (not vitest); `tsgo` is the typechecker (not
+`tsc`). The per-subpath bundle output is `dist/netlify-blobs/index.{js,d.ts}`
+per the `exports` map in [`../../package.json`](../../package.json).
+
+## Public surface
+
+Defined in [`index.ts`](./index.ts):
+
+- `netlifyBlobs(opts: NetlifyBlobsAdapterOptions): NetlifyBlobsAdapter` —
+  factory. Throws `FilesError("Provider", …)` synchronously if `name` is
+  missing or non-string, and re-wraps `getStore()` / `getDeployStore()`
+  failures via `mapNetlifyError`.
+- `NetlifyBlobsAdapterOptions` — config interface (`name`, `siteID`,
+  `token`, `deployScoped`, `consistency`). JSDoc on every field is the
+  source of truth; the docs MDX pulls it via `AutoTypeTable`.
+- `NetlifyBlobsClient` — alias for the `@netlify/blobs` `Store`.
+- `NetlifyBlobsAdapter` — alias for `Adapter<NetlifyBlobsClient>`. `raw`
+  is the underlying `Store`; anything `@netlify/blobs` exposes that the
+  unified surface doesn't (`setJSON`, the SDK's typed JSON helper, plus
+  any future primitives) is one property access away on `files.raw`.
+
+The adapter's `name` is `"netlify-blobs"`.
+
+## Authentication / configuration
+
+Required:
+
+- `name` — Netlify store name. Every operation runs against this store
+  (max 64 bytes per Netlify's limit). Missing or non-string throws
+  `FilesError("Provider", …)` at construction.
+
+Optional:
+
+- `siteID` — falls back to `NETLIFY_SITE_ID` via [`readEnv`](../internal/env.ts).
+- `token` — falls back to `NETLIFY_API_TOKEN`, then `NETLIFY_BLOBS_TOKEN`.
+- `deployScoped` — `false` (default) selects `getStore()` (site-scoped,
+  persists across deploys); `true` selects `getDeployStore()` (lifetime
+  of the current deploy, for build artifacts that should be
+  garbage-collected with it).
+- `consistency` — `"eventual"` (default, edge-cache reads) or `"strong"`
+  (origin reads, read-your-writes). Threaded straight through to the SDK.
+
+`siteID` and `token` are passed to the Netlify SDK **only when both are
+set together**. If either is missing the adapter omits both and lets the
+SDK pick up its ambient context from `NETLIFY_BLOBS_CONTEXT`, which
+Netlify Functions / Edge Functions / build runtimes inject automatically
+— that's the common configuration on Netlify; explicit creds are required
+only outside Netlify (local scripts, your own server). When neither path
+resolves, the SDK surfaces `MissingBlobsEnvironmentError` on first call,
+classified as `Provider`.
+
+## Operation map
+
+Every method goes through `mapNetlifyError`, which forwards `FilesError`
+instances unchanged and otherwise extracts a status code from the
+provider error message (see [Provider quirks](#provider-quirks-worth-remembering)).
+
+- `upload` — `bodyToStorable` normalizes the body to `string | ArrayBuffer
+  | Blob` (the shapes `Store.set` accepts). `Uint8Array` /
+  `ArrayBufferView` are sliced into fresh `ArrayBuffer`s so the SDK never
+  sees a view covering more bytes than the user's. `ReadableStream` is
+  buffered up-front via `new Response(body).arrayBuffer()` — `set()` has
+  no streaming form. Result size prefers `sizeOf(body)` and falls back
+  to the buffered length.
+- `download` — `Store.getWithMetadata` in `"arrayBuffer"` (default) or
+  `"stream"` mode (when `opts.as === "stream"`). The buffered path
+  reports the **actual byte length**, falling back to packed `__size`
+  only when the buffer is empty — so blobs written outside the SDK still
+  report a sensible size. `null` → `NotFound`.
+- `head` — `Store.getMetadata` only; no body transfer. The returned
+  `StoredFile`'s body accessors lazily issue a `Store.get` on first use
+  — not free.
+- `exists` — `Store.getMetadata`. `null` → `false`; a mapped `NotFound`
+  (404 in the SDK's internal-error message) also → `false`. Every other
+  error propagates.
+- `delete` — `Store.delete`. Idempotent: calling on a missing key
+  succeeds and does not throw.
+- `copy` — **no native primitive.** Read-then-write via
+  `getWithMetadata(from)` + `set(to, …)`. The source's packed metadata
+  is forwarded verbatim so `contentType`, `size`, user `metadata`, and
+  `cacheControl` round-trip; `__lastModified` is refreshed to the time of
+  the copy (matches S3 server-side copy semantics). **Not server-side
+  atomic** — concurrent writes to `from` between the get and put are not
+  detected.
+- `list` — `Store.list({ paginate: true, prefix? })` async iterator.
+  `paginate` is always set so a small `limit` actually bounds
+  server-side I/O; iteration stops once `blobs.length >= limit`. Items
+  carry `size: 0` and `type: "application/octet-stream"` with a lazy
+  body factory (a fresh `Store.get`) — Netlify's list response only
+  carries `key` + `etag`. `ListResult.cursor` is always `undefined` —
+  Netlify's pagination cursor is internal to the iterator.
+- `url` / `signedUploadUrl` — both throw `FilesError("Provider", …)`
+  with a netlify-specific message. See [URL behavior](#url-behavior).
+- `deleteMany` — not implemented; the SDK falls back to bounded-
+  concurrency fan-out via `deleteManyWithFallback` in
+  [`../internal/core.ts`](../internal/core.ts). Netlify has no bulk-
+  delete primitive, so a native impl wouldn't win round-trips.
+
+## URL behavior
+
+`url(key, opts?)` always throws. No `publicBaseUrl` knob, no signing
+primitive — Netlify Blobs reads require the access token and go through
+`@netlify/blobs`. If you need permanent public URLs, copy the blob to a
+different provider (S3 + CDN, Vercel Blob public) at upload time.
+
+`signedUploadUrl(key, opts)` throws the same way. Direct browser uploads
+aren't possible; upload from your server using the SDK, or proxy the
+request through an authenticated endpoint that calls `files.upload(...)`
+on the client's behalf. Both throws are deliberate and asserted in the
+test suite — don't paper over them with a "best-effort" implementation.
+
+## Provider quirks worth remembering
+
+- **No size / content-type / last-modified in Netlify's wire format.** The
+  adapter packs them under reserved metadata keys (`__contentType`,
+  `__size`, `__lastModified`, `__cacheControl`, `__user`). User metadata
+  round-trips under `__user` so it can never collide with the internal
+  fields. Blobs written outside the SDK have no packed metadata and read
+  back as `size: 0` (or actual byte length on the buffered `download`
+  path) and `type: "application/octet-stream"`.
+- **`set()` doesn't take streams.** `ReadableStream` bodies are buffered
+  in full before upload. Memory cost scales with body size; chunk at the
+  application layer or pick a different provider for large uploads.
+- **Error classification rides on the message string.** Netlify throws
+  `BlobsInternalError` whose `message` embeds the upstream status
+  (`"… (401 status code, ID: …)"`). `classifyNetlifyError` pattern-matches
+  `\(\d{3} status code\)` because the SDK has no structured `status`
+  field. Buckets follow the unified mapping: 404 → `NotFound`, 401/403
+  → `Unauthorized`, 409/412 → `Conflict`, else → `Provider`; message-only
+  fallbacks catch `/not found/i` and `/unauthor|forbidden/i` when no
+  status is present. `MissingBlobsEnvironmentError` → `Provider`.
+- **Two store types, one adapter.** `deployScoped: true` swaps the
+  factory for `getDeployStore()`; everything else (metadata packing,
+  error mapping, op delegation) is identical. Pick deploy-scoped only
+  for build artifacts that should be garbage-collected with the deploy.
+- **`consistency` is per-store, not per-call.** It binds to the `Store`
+  instance returned at construction — every read on the adapter uses
+  that mode.
+
+## Testing approach
+
+Tests in [`../../test/netlify-blobs.test.ts`](../../test/netlify-blobs.test.ts)
+use `bun:test` with `mock.module("@netlify/blobs", …)` to swap the SDK
+for an in-memory `Map` plus mocked `set` / `get` / `getMetadata` /
+`getWithMetadata` / `delete` / `list`. The matrix covers:
+
+- `getStore` vs `getDeployStore` selection, `consistency` threading, and
+  the explicit-vs-env-vs-ambient credential ladder (including the
+  `NETLIFY_BLOBS_TOKEN` fallback).
+- Upload across every body shape and the metadata packing
+  (`__contentType`, `__size`, `__cacheControl`, `__lastModified`,
+  `__user.*`).
+- Download buffered vs streaming, `head()` lazy-body fetch, `exists`'
+  swallow-`NotFound` / rethrow-other behaviour, and `copy()`'s metadata
+  round-trip plus refreshed `__lastModified`.
+- `list()` pagination: `paginate: true` is forwarded; a small `limit`
+  stops iterating early (`listPagesYielded` asserts the perf-cliff fix);
+  no `cursor` is returned.
+- `url()` / `signedUploadUrl()` throw `Provider`; error mapping for each
+  status (401, 403, 404, 409, 500), `MissingBlobsEnvironmentError`,
+  message-only `"not found"` / `"forbidden"`, and stream errors during
+  upload.
+
+The shared `FakeAdapter` at [`../../test/fake-adapter.ts`](../../test/fake-adapter.ts)
+is for `Files`-class tests, not adapter unit tests — new netlify-blobs
+tests go in `netlify-blobs.test.ts` and mock the SDK directly.
+
+## Coding conventions
+
+- Named exports only — no default exports.
+- Errors wrap as `FilesError` via `mapNetlifyError`. Existing
+  `FilesError` instances pass through unchanged.
+- Internal metadata keys (`__contentType`, `__size`, `__lastModified`,
+  `__cacheControl`, `__user`) are reserved. Pick a fresh `__`-prefixed
+  key for new features so existing blobs keep reading correctly.
+- Use `createStoredFile` from [`../internal/stored-file.ts`](../internal/stored-file.ts)
+  for every `StoredFile` you return. Don't hand-roll body accessors.
+- Env reads go through [`readEnv`](../internal/env.ts). Direct
+  `process.env` access breaks Cloudflare Workers without `nodejs_compat`
+  (and the Netlify Edge runtime is similar).
+- Top-level regex literals only — the current file has one (`STATUS_RE`).
+- Don't introduce a `signedUploadUrl` or `url` implementation without
+  upstream support — the current throw is deliberate and tested.
+
+## Releases
+
+Ships with the rest of the monorepo from
+[`../../package.json`](../../package.json). Behavioural changes need a
+changeset (`bunx changeset`, then commit the entry under `.changeset/`).
+README updates and AGENTS.md edits don't require one. The
+`netlify-blobs` subpath is already declared in `exports` — no further
+wiring needed for new options.
+
+## Where to look next
+
+- Source + tests: [`./index.ts`](./index.ts), [`../../test/netlify-blobs.test.ts`](../../test/netlify-blobs.test.ts)
+- User-facing docs: [`../../../../apps/web/content/docs/adapters/netlify-blobs.mdx`](../../../../apps/web/content/docs/adapters/netlify-blobs.mdx)
+- Provider catalog entry (`slug: "netlify-blobs"`): [`../providers/index.ts`](../providers/index.ts)
+- Unified `Adapter` contract: [`../index.ts`](../index.ts)
+- Shared helpers: [`../internal/core.ts`](../internal/core.ts), [`../internal/errors.ts`](../internal/errors.ts), [`../internal/env.ts`](../internal/env.ts)
+- Package README & skill: [`../../README.md`](../../README.md), [`../../../../skills/files-sdk/SKILL.md`](../../../../skills/files-sdk/SKILL.md)

--- a/packages/files-sdk/src/netlify-blobs/CLAUDE.md
+++ b/packages/files-sdk/src/netlify-blobs/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/packages/files-sdk/src/onedrive/AGENTS.md
+++ b/packages/files-sdk/src/onedrive/AGENTS.md
@@ -1,0 +1,320 @@
+# AGENTS.md — `files-sdk/onedrive`
+
+Guidance for coding agents working on the `onedrive` adapter. The
+unified `Adapter<Raw>` contract — call shapes, `FilesError`,
+`UrlOptions`, `SignUploadOptions`, body normalization — lives in
+[`../index.ts`](../index.ts); this file documents only the
+onedrive-specific deviations. Read [`../../README.md`](../../README.md)
+and [`../../../../skills/files-sdk/SKILL.md`](../../../../skills/files-sdk/SKILL.md)
+first for the unified surface.
+
+`onedrive` is a **native** adapter on `@microsoft/microsoft-graph-client`
+plus `@azure/identity` — not a wrapper around `s3()`. The sibling
+[`sharepoint`](../sharepoint/index.ts) adapter delegates here for its
+file-operation layer after resolving site / library to a `driveId`;
+behavior changes cascade there, so edit with care.
+
+## Overview
+
+OneDrive (personal and Business) and SharePoint document libraries via
+Microsoft Graph. Graph is path-addressable
+(`/drive/root:/folder/file.txt`), so the adapter maps virtual keys
+straight onto real OneDrive paths — no virtual-key cache, no `fsdkKey`
+bookkeeping, the path you upload is the path you see in the OneDrive
+UI. The full unified surface (`upload`, `download`, `head`, `exists`,
+`delete`, `copy`, `list`, `url`, `signedUploadUrl`) is implemented
+natively against the Graph client.
+
+Optional peer dependencies declared in
+[`../../package.json`](../../package.json):
+`@microsoft/microsoft-graph-client`, `@azure/identity`.
+
+## Directory layout
+
+```text
+packages/files-sdk/src/onedrive/
+├── index.ts                # adapter implementation
+├── AGENTS.md               # this file
+└── CLAUDE.md               # `@AGENTS.md`
+```
+
+Siblings outside this directory: tests at
+[`../../test/onedrive.test.ts`](../../test/onedrive.test.ts) and
+[`../../test/onedrive-auth.test.ts`](../../test/onedrive-auth.test.ts);
+user docs at
+[`../../../../apps/web/content/docs/adapters/onedrive.mdx`](../../../../apps/web/content/docs/adapters/onedrive.mdx);
+catalog entry at [`../providers/index.ts`](../providers/index.ts)
+(search `slug: "onedrive"`).
+
+## Build, test, typecheck
+
+Run from `packages/files-sdk/`:
+
+```bash
+bun test test/onedrive.test.ts        # operation-map unit tests
+bun test test/onedrive-auth.test.ts   # auth construction + token paths
+bun test                              # full SDK suite
+bun run build                         # tsup → dist/onedrive/
+bun run types                         # tsgo --noEmit (typecheck only)
+```
+
+Pinned tooling: **`bun test`** (not vitest) and **`tsgo`** (not `tsc`).
+The `onedrive` subpath is enumerated in
+[`../../package.json`](../../package.json)'s `exports` map — keep it in
+sync with the file layout.
+
+## Public surface
+
+Exports from [`./index.ts`](./index.ts):
+
+- `onedrive(opts?: OneDriveAdapterOptions): OneDriveAdapter` — primary
+  factory; all fields optional (env fallback covers no-args).
+- `OneDriveAdapter` — alias for
+  `Adapter<Client> & { readonly basePath; readonly rootFolderPath }`;
+  the extras let callers introspect the resolved drive target.
+- `OneDriveClient` — alias for the Graph `Client`; `raw` is typed as
+  this.
+- `OneDriveAdapterOptions` — config interface; JSDoc on every field is
+  the source of truth (the docs MDX pulls it via `AutoTypeTable`).
+- `mapGraphError(err): FilesError` — exported so callers dropping to
+  `raw` can route Graph errors through the same classifier.
+- `buildAuthProvider(opts)` — consumed by
+  [`sharepoint`](../sharepoint/index.ts); not part of the documented
+  public API.
+
+The adapter's `name` is `"onedrive"`.
+
+## Authentication / configuration
+
+Four explicit auth shapes plus an env-var fallback, **mutually
+exclusive** — the factory throws `FilesError("Provider", …)` if more
+than one shape is set or none resolves.
+
+1. **`clientCredentials: { tenantId, clientId, clientSecret }`** —
+   app-only via `@azure/identity`'s `ClientSecretCredential`. The app
+   acts on its own behalf, so `/me/drive` is unavailable: pass
+   `driveId`, `siteId`, or `userId`. Scoped to
+   `https://graph.microsoft.com/.default` via
+   `TokenCredentialAuthenticationProvider`.
+2. **`oauth: { clientId, clientSecret, refreshToken, tenantId? }`** —
+   delegated (3-legged), analogous to the Dropbox refresh-token mode.
+   `@azure/identity` ships no native refresh-token credential, so the
+   adapter hand-rolls a private `RefreshTokenCredential` that POSTs
+   `grant_type=refresh_token` to
+   `https://login.microsoftonline.com/{tenantId}/oauth2/v2.0/token`
+   (default `tenantId: "common"`) and caches the access token until
+   60 s before expiry. Non-OK responses and 200s missing `access_token`
+   throw `Unauthorized`.
+3. **`accessToken: string | (() => string | Promise<string>)`** — static
+   or dynamic bearer. The string form is returned verbatim; the
+   callable runs on every Graph call. The adapter does **not** cache;
+   your callable owns cache / refresh.
+4. **`client: Client`** — pre-built Graph client. Escape hatch for
+   callers wiring auth themselves (NextAuth, MSAL Node, an external
+   broker). `signedUploadUrl()` still works because Graph's
+   upload-session URL is pre-authenticated by Graph itself.
+
+**Env-var fallback** — when no auth field is passed.
+`ONEDRIVE_ACCESS_TOKEN` takes the static-token path;
+`ONEDRIVE_TENANT_ID` + `ONEDRIVE_CLIENT_ID` + `ONEDRIVE_CLIENT_SECRET`
+(all three) take the `clientCredentials` path. The catalog entry in
+[`../providers/index.ts`](../providers/index.ts) enumerates these.
+
+Drive targets (pass at most one):
+
+- `driveId` → `/drives/{driveId}` (env `ONEDRIVE_DRIVE_ID`).
+  **Required** for `clientCredentials`.
+- `siteId` → `/sites/{siteId}/drive` (env `ONEDRIVE_SITE_ID`) — default
+  document library of a SharePoint site.
+- `userId` → `/users/{userId}/drive` (env `ONEDRIVE_USER_ID`) — typical
+  with app-only auth.
+- Unset → `/me/drive`. Interactive (delegated) auth only.
+
+Other knobs: `rootFolderPath` (logical bucket root, must already exist),
+`publicByDefault` (gates `url()`), `copyTimeoutMs` (default `60_000`).
+Env lookups go through [`readEnv`](../internal/env.ts) so the adapter
+imports cleanly on runtimes without `process` (Cloudflare Workers
+without `nodejs_compat`).
+
+## Operation map
+
+Errors route through `mapGraphError`, which classifies by HTTP status
+(404 → `NotFound`, 401/403 → `Unauthorized`, 409/412 → `Conflict`, else
+→ `Provider`) and by Graph's named codes (`itemNotFound`,
+`InvalidAuthenticationToken`, `accessDenied`, `unauthenticated`,
+`nameAlreadyExists`, `resourceModified`). Messages prefer
+`err.body.error.message`, then `err.message`, then a per-code default.
+
+- `upload` — `PUT {basePath}/root:/{encodedKey}:/content` with the body
+  as a `Buffer` and explicit `Content-Type`. Bodies above
+  `SIMPLE_UPLOAD_LIMIT_BYTES = 250 MiB` throw `Provider`; use
+  `signedUploadUrl()` or drop to `raw` for chunked sessions.
+  `metadata` and `cacheControl` both throw — drive items carry no
+  arbitrary-metadata field (use `raw` + Open Extensions) and no
+  `Cache-Control` primitive. When `publicByDefault: true`, also calls
+  `createLink` after the PUT.
+- `download` — buffer path uses `responseType(ARRAYBUFFER)`; stream
+  path uses `responseType(STREAM)` then `Readable.toWeb`. Both fire the
+  metadata GET in parallel with `/content` so the `StoredFile` carries
+  authoritative `size` / `type` / `etag` / `lastModified`.
+- `head` — single item GET. Body accessors lazily issue `/content` on
+  first call via a `lazyDownload` factory; not free.
+- `exists` — `existsByProbe(client.api(item).get, mapGraphError)` from
+  [`../internal/core.ts`](../internal/core.ts); `NotFound` → `false`,
+  other failures propagate.
+- `delete` — `DELETE {item}`; idempotent on mapped `NotFound`.
+- `copy` — Graph's copy is async. POST to `{item}/copy` with
+  `responseType(RAW)` to expose the raw `Response` (202 + `Location`
+  monitor URL), then poll every `COPY_POLL_INTERVAL_MS = 500 ms` until
+  `status === "completed"`, failing on `"failed"` and throwing
+  `Provider` after `copyTimeoutMs`. A 2xx with no monitor URL is
+  treated as success.
+- `list` — `GET {container}/children`. Folders are filtered
+  client-side; `prefix` is applied client-side per page (no server-side
+  prefix primitive on `/children`). Cursor is the `@odata.nextLink`
+  absolute URL — the Graph client accepts it as a path, so paging
+  re-issues with `cursor` plumbed through.
+- `url` — throws `Provider` unless `publicByDefault: true`. Graph has
+  no signed-URL primitive for private items; the workaround is
+  `POST {item}/createLink` with `{ scope: "anonymous", type: "view" }`,
+  returning `link.webUrl`. `responseContentDisposition` always throws.
+- `signedUploadUrl` — `POST {item}/createUploadSession` with
+  `item: { "@microsoft.graph.conflictBehavior": "replace", name }`;
+  returns `{ method: "PUT", url: uploadUrl }`. The session URL is
+  pre-authenticated by Graph (no bearer needed); intended for chunked
+  resumable uploads, surfaced as a one-shot PUT for symmetry.
+
+## URL behavior
+
+- **`publicByDefault: false` (default)** — `url()` throws `Provider`.
+  Use `download()` for private items.
+- **`publicByDefault: true`** — `url()` calls `createLink` with
+  `scope: "anonymous"`, `type: "view"` and returns `link.webUrl`.
+  `createLink` is idempotent for the same `scope` + `type` pair, so
+  repeat calls return the existing link rather than duplicating.
+- **`expiresIn` is silently ignored** — share links use the tenant's
+  default link expiry; Graph exposes no per-link override.
+- **`responseContentDisposition` always throws** — Graph has no
+  Content-Disposition override on share links or
+  `@microsoft.graph.downloadUrl`. The unified surface treats this as a
+  security ask (avoiding a stored-XSS regression on user-uploaded
+  HTML/SVG) and fails loudly. See
+  [`resolveUrlStrategy`](../internal/core.ts) for the rationale applied
+  on signing adapters.
+- **Tenant policy** — anonymous sharing can be disabled at the
+  tenant / site / library level; `createLink` then returns
+  `accessDenied`, which the mapper surfaces as `Unauthorized`.
+
+## Provider quirks worth remembering
+
+- **Path encoding.** `itemApiPath` percent-encodes each segment of
+  `rootFolderPath + key` with `encodeURIComponent` and joins with `/`.
+  The literal `:` in `/root:/{path}:` is structural — Graph's separator
+  switching from path-addressable to children/content suffix mode.
+  Never let a user-supplied `:` reach it unescaped; route every new
+  endpoint through `encodePathSegments`.
+- **Simple-upload cap is 250 MiB, not Graph's old 4 MiB.** Graph raised
+  the limit; `SIMPLE_UPLOAD_LIMIT_BYTES` reflects the current value.
+  Anything above goes through `createUploadSession` (the resumable URL
+  `signedUploadUrl` returns).
+- **Copy blocks until it resolves.** Set a short `copyTimeoutMs` or
+  drop to `raw` and own the monitor URL for fire-and-forget. Poll
+  interval is fixed at 500 ms.
+- **`@azure/identity` has no refresh-token credential.** The adapter
+  hand-rolls `RefreshTokenCredential` rather than reusing
+  `OnBehalfOfCredential` (different flow) or MSAL public-client flows
+  (interactive). New delegated flows should implement `TokenCredential`,
+  hand it to `TokenCredentialAuthenticationProvider`, and cache with a
+  60 s buffer.
+- **`/me/drive` requires interactive auth.** `resolveBasePath` enforces
+  this at construction so the failure is a clear `Provider`-coded error
+  instead of an opaque 401 at first call.
+- **Throttling (429) and 5xx aren't retried here.** The Files SDK's
+  `retries` option still handles `Provider`-coded errors. Graph's
+  `Retry-After` is not honored explicitly; `Client.initWithMiddleware`
+  picks up the default middleware retry handler when you keep the
+  default stack.
+- **`prefix` / `limit` on `list` are best-effort.** `prefix` filters
+  the current page client-side; `limit` only applies on the first page
+  via `.top(limit)` — `@odata.nextLink` URLs carry the original page
+  size.
+- **Drive-item ETags carry literal quotes.** `itemToStoredMeta` strips
+  them via `replaceAll('"', "")` so callers see `abc`, not `"abc"`.
+  Stay consistent on new ETag-returning paths.
+
+## Testing approach
+
+Two files, one per concern; `bun test` is the runner.
+
+- [`../../test/onedrive.test.ts`](../../test/onedrive.test.ts) wires a
+  fake Graph client (`{ api(path) → builder }` shim) through the
+  `client` option and asserts path / body / headers each operation
+  issues. Covers path encoding, the four basePath variants
+  (`/me/drive`, `/drives/{id}`, `/sites/{id}/drive`, `/users/{id}/drive`),
+  `rootFolderPath`, the upload-size cap, the copy monitor-URL poll
+  (mocking `globalThis.fetch`), the `publicByDefault` `createLink`
+  path, and every `mapGraphError` branch — including
+  `GraphError.body.error.message` extraction and the plain-object
+  `statusCode` / `status` / `code` fallbacks.
+- [`../../test/onedrive-auth.test.ts`](../../test/onedrive-auth.test.ts)
+  monkey-patches `Client.initWithMiddleware` and
+  `ClientSecretCredential.prototype.getToken` to capture the
+  `AuthenticationProvider` the adapter builds, then exercises every
+  auth shape: static + callable `accessToken`, `clientCredentials`
+  wiring, the OAuth refresh-token POST (URL, body, scope, default
+  tenant, caching, near-expiry re-fetch, non-OK, missing
+  `access_token`), and the env-var fallbacks — including the
+  "still need a target" failure when only the credentials triple is
+  set.
+
+Add operation fixtures to `onedrive.test.ts`; auth-shape ones to
+`onedrive-auth.test.ts`. No vitest config; no network-calling
+integration tests in this package.
+
+## Coding conventions
+
+- Named exports only — `onedrive`, `OneDriveAdapter`,
+  `OneDriveAdapterOptions`, `OneDriveClient`, `mapGraphError`,
+  `buildAuthProvider`. No default exports.
+- Construction-time and unsupported-option errors use
+  [`FilesError("Provider", …)`](../internal/errors.ts) with an
+  `onedrive:` message prefix. Operation errors flow through
+  `mapGraphError` — pass `FilesError` instances through unchanged
+  (the mapper short-circuits on them).
+- Use [`createStoredFile`](../internal/stored-file.ts) for every
+  `StoredFile` returned — don't hand-roll body accessors. The
+  `factory` / `kind: "lazy"` path is the contract `head()`'s
+  body-on-demand depends on.
+- Read env vars via [`readEnv`](../internal/env.ts). Direct
+  `process.env` breaks Cloudflare Workers without `nodejs_compat`.
+- Top-level regex literals only; the current file has none.
+- `encodePathSegments` is the only path-building helper — route new
+  endpoints through it so the `:` / `/` separator rules stay
+  consistent. Keep `RefreshTokenCredential` private.
+
+## Releases
+
+The repo uses Changesets. Behavioral changes need a changeset
+(`bunx changeset`, committed under `.changeset/`); new options, default
+changes, auth-flow changes, and error-shape changes bump `files-sdk`.
+README / AGENTS.md edits don't. Public-type changes in
+`OneDriveAdapterOptions` or `OneDriveAdapter` should also flag the
+dependent [`sharepoint`](../sharepoint/index.ts) adapter — it consumes
+this surface for its file-operation layer.
+
+## Where to look next
+
+- Source [`./index.ts`](./index.ts); tests
+  [`../../test/onedrive.test.ts`](../../test/onedrive.test.ts) +
+  [`../../test/onedrive-auth.test.ts`](../../test/onedrive-auth.test.ts);
+  docs [`../../../../apps/web/content/docs/adapters/onedrive.mdx`](../../../../apps/web/content/docs/adapters/onedrive.mdx).
+- Provider catalog (`slug: "onedrive"`):
+  [`../providers/index.ts`](../providers/index.ts); sibling
+  [`../sharepoint/index.ts`](../sharepoint/index.ts).
+- Unified contract [`../index.ts`](../index.ts); shared helpers
+  [`../internal/core.ts`](../internal/core.ts),
+  [`../internal/errors.ts`](../internal/errors.ts),
+  [`../internal/env.ts`](../internal/env.ts),
+  [`../internal/stored-file.ts`](../internal/stored-file.ts); package
+  [`../../README.md`](../../README.md); SKILL
+  [`../../../../skills/files-sdk/SKILL.md`](../../../../skills/files-sdk/SKILL.md).

--- a/packages/files-sdk/src/onedrive/CLAUDE.md
+++ b/packages/files-sdk/src/onedrive/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/packages/files-sdk/src/oracle-cloud/AGENTS.md
+++ b/packages/files-sdk/src/oracle-cloud/AGENTS.md
@@ -1,0 +1,227 @@
+# AGENTS.md — `files-sdk/oracle-cloud`
+
+Guidance for coding agents working in the `files-sdk/oracle-cloud`
+subpath. The unified `Adapter<Raw>` contract lives in
+[`../index.ts`](../index.ts); this file documents only the
+oracle-cloud-specific deviations. `oracleCloud()` wraps
+[`s3()`](../s3/index.ts) for [Oracle Cloud Infrastructure (OCI) Object
+Storage](https://www.oracle.com/cloud/storage/object-storage/)'s S3
+compatibility layer, so operation, error, and presign mechanics live
+in the S3 adapter — see [`../s3/AGENTS.md`](../s3/AGENTS.md) for
+primitive-level details. Cross-references:
+[`README.md`](../../README.md),
+[`SKILL.md`](../../../../skills/files-sdk/SKILL.md).
+
+## Overview
+
+A thin shim that calls `s3()` with an OCI-derived endpoint, OCI HMAC
+credentials, `forcePathStyle: true`, and a `defaultProviderMessage`
+of `"Oracle Cloud error"`. No per-method code lives here. The
+oracle-cloud deviations are endpoint derivation from
+`<namespace>.<region>`, the credential env-var pair, the path-style
+default (TLS reasons — see
+[Provider quirks](#provider-quirks-worth-remembering)), and the
+error-message relabel. The returned adapter's `raw` is the underlying
+`@aws-sdk/client-s3` `S3Client` — anything the AWS SDK can do against
+OCI's S3-compatible API is one property access away.
+
+## Directory layout
+
+```text
+packages/files-sdk/src/oracle-cloud/
+├── index.ts                   # oracleCloud() factory + OracleCloudAdapterOptions
+├── AGENTS.md                  # this file
+└── CLAUDE.md                  # @AGENTS.md — Claude-Code re-export
+```
+
+Tests at [`../../test/oracle-cloud.test.ts`](../../test/oracle-cloud.test.ts);
+user-facing docs at
+[`../../../../apps/web/content/docs/adapters/oracle-cloud.mdx`](../../../../apps/web/content/docs/adapters/oracle-cloud.mdx).
+
+## Build, test, typecheck
+
+Run from `packages/files-sdk`:
+
+```bash
+bun test test/oracle-cloud.test.ts   # focused oracle-cloud suite
+bun test                              # full SDK suite
+bun run build                         # tsup → dist/oracle-cloud/
+bun run types                         # tsgo --noEmit
+```
+
+The `oracle-cloud` subpath is enumerated in
+[`../../package.json`](../../package.json)'s `exports` map — keep
+it in sync if the file layout changes.
+
+## Public surface
+
+[`index.ts`](./index.ts) exports the
+`oracleCloud(opts: OracleCloudAdapterOptions): OracleCloudAdapter`
+factory, the `OracleCloudAdapter` alias for `Adapter<S3Client>`
+(`raw` is the underlying AWS SDK client), and the
+`OracleCloudAdapterOptions` config interface. JSDoc on every option
+field is the source of truth — the docs MDX pulls it via
+`<AutoTypeTable>`. The adapter's `name` is `"oracle-cloud"` (set
+after spreading, so it overrides the inner `"s3"`).
+
+## Authentication / configuration
+
+| Option                | Required | Default                                                              | Notes                                                                                          |
+| --------------------- | -------- | -------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| `bucket`              | yes      | —                                                                    | OCI bucket name. Tenancy-scoped, **not globally unique** — see quirks.                         |
+| `namespace`           | yes      | —                                                                    | Tenancy Object Storage namespace (e.g. `axoki12345`). Drives the endpoint host.                |
+| `region`              | yes      | —                                                                    | OCI region identifier (`us-ashburn-1`, `eu-frankfurt-1`, …). Drives host **and** SigV4 region. |
+| `accessKeyId`         | yes\*    | `OCI_ACCESS_KEY_ID`                                                  | OCI Customer Secret Key access ID — **not** an API signing key.                                |
+| `secretAccessKey`     | yes\*    | `OCI_SECRET_ACCESS_KEY`                                              | Customer Secret Key secret.                                                                    |
+| `endpoint`            | no       | `https://${namespace}.compat.objectstorage.${region}.oraclecloud.com` | Override for VPC private endpoints, FastConnect origins, or test doubles.                      |
+| `forcePathStyle`      | no       | `true`                                                               | OCI-specific default — see quirks.                                                             |
+| `publicBaseUrl`       | no       | —                                                                    | Origin for unsigned `url()` (PAR prefix or WAF / Load Balancer custom domain).                 |
+| `defaultUrlExpiresIn` | no       | `3600`                                                               | Fallback expiry for presigned `url()` results when `publicBaseUrl` is unset.                   |
+
+\* Pass explicitly or set the env var. Find the namespace under
+**Profile → Tenancy → Object Storage Namespace** (or `oci os ns
+get`); generate Customer Secret Keys under **Profile → User Settings
+→ Customer Secret Keys**. No `OCI_REGION` / `OCI_NAMESPACE` /
+`OCI_BUCKET` env-var fallback — each missing required field throws
+`FilesError("Provider", …)` at construction with its own message.
+Env lookups go through [`readEnv`](../internal/env.ts) for runtimes
+without `process` (Cloudflare Workers without `nodejs_compat`). The
+provider catalog row in [`../providers/index.ts`](../providers/index.ts)
+(search `slug: "oracle-cloud"`) declares the same env contract via
+the shared `s3Compatible(…)` helper.
+
+## Operation map
+
+`oracleCloud()` spreads the inner `s3()` adapter and overrides only
+`name`. `upload`, `download`, `head`, `exists`, `delete`,
+`deleteMany`, `copy`, `list`, `url`, and `signedUploadUrl` all live
+in [`../s3/index.ts`](../s3/index.ts) and are inherited unchanged —
+including `deleteMany`'s 1000-key chunking, `signedUploadUrl`'s
+PUT-vs-presigned-POST split on `maxSize`, and `exists`'
+404-as-`false` classification. Provider errors flow through
+`mapS3Error` with the oracle-cloud fallback table — `Provider`-coded
+messages read `"Oracle Cloud error"` while preserving any server-side
+message on the wire.
+
+## URL behavior
+
+`url(key, opts?)` follows the standard signing-adapter rules
+(`resolveUrlStrategy` in [`../internal/core.ts`](../internal/core.ts)):
+
+- **No `publicBaseUrl`** → presigned `GetObject` against the OCI
+  S3-compat endpoint, signed with SigV4 in `region`, expiring after
+  `opts.expiresIn ?? defaultUrlExpiresIn ?? 3600` seconds.
+- **`publicBaseUrl` set** → unsigned `${publicBaseUrl}/${key}` via
+  `joinPublicUrl` (URL-encodes segments). Typically a
+  Pre-Authenticated Request (PAR) URL prefix or a WAF custom domain.
+- **`responseContentDisposition` set** → forces signing even when
+  `publicBaseUrl` is configured: a permanent CDN URL has no signature
+  to bind the override to, and silently dropping it would be a
+  stored-XSS regression on user-uploaded HTML/SVG.
+
+OCI doesn't bundle a managed CDN with Object Storage, so most configs
+leave `publicBaseUrl` unset and sign every read.
+
+## Provider quirks worth remembering
+
+- **Customer Secret Keys, not API signing keys.** The S3-compatible
+  API requires *Customer Secret Keys* — HMAC keys generated under
+  **Profile → User Settings → Customer Secret Keys**. OCI's other
+  credential type (API Signing Keys, used by the native OCI APIs)
+  **will not authenticate** against the S3 endpoint. The most common
+  setup error is pasting an API key fingerprint into `accessKeyId`.
+- **Bucket names are tenancy-scoped, not global.** `(namespace,
+  bucket)` is the unique pair. Two unrelated tenancies can each own
+  `uploads`; the namespace prefix disambiguates. No AWS-style global
+  collision risk on creation.
+- **Path-style default is deliberate.** OCI's wildcard TLS cert
+  covers `*.compat.objectstorage.<region>.oraclecloud.com` but does
+  **not** cover the additional bucket subdomain that virtual-hosted
+  style would need (`<bucket>.<namespace>.compat.…`). Flipping
+  `forcePathStyle` to `false` against the default endpoint typically
+  yields a TLS hostname mismatch before any S3 error surfaces.
+  Override only when fronted by infrastructure that owns its own cert.
+- **Namespace ≠ tenancy OCID.** The namespace is a short
+  auto-generated string (e.g. `axoki12345`), not the
+  `ocid1.tenancy.oc1.…` identifier. Not interchangeable.
+- **Region drives both host and SigV4.** A mismatch fails fast at
+  signing rather than silently writing to the wrong region.
+- **No public-read ACL.** Buckets are private by default with a
+  Private/Public toggle; for granular public access, use a
+  Pre-Authenticated Request with `publicBaseUrl`.
+- **Errors are relabeled, not reclassified.** Status codes still map
+  through the same `S3_NOT_FOUND_CODES` / `S3_UNAUTH_CODES` /
+  `S3_CONFLICT_CODES` sets in [`../s3/index.ts`](../s3/index.ts);
+  only the unknown-error fallback message changes.
+
+## Testing approach
+
+[`../../test/oracle-cloud.test.ts`](../../test/oracle-cloud.test.ts)
+covers the adapter's narrow surface:
+
+- Default-config plumbing — endpoint derived from
+  `<namespace>.compat.objectstorage.<region>.oraclecloud.com`,
+  `forcePathStyle: true`, region threaded into both inner client and
+  endpoint host. `region` override flows through to both; explicit
+  `endpoint` wins (hostname + port forwarded); `forcePathStyle: false`
+  opt-out is forwarded faithfully.
+- Missing-namespace, missing-region, and missing-credentials each
+  throw at factory time; `OCI_ACCESS_KEY_ID` / `OCI_SECRET_ACCESS_KEY`
+  env-var fallbacks are picked up when options are omitted.
+- `url()` returns a presigned GET (`X-Amz-Signature=…`,
+  `X-Amz-Expires=3600`, namespace-prefixed host) by default, and
+  switches to the unsigned concat form when `publicBaseUrl` is set.
+- `Files` integration via `aws-sdk-client-mock` — `upload` and
+  `exists` go through `PutObjectCommand` and `HeadObjectCommand`.
+  `mapS3Error` is exercised directly with the oracle-cloud table to
+  confirm the `Provider` fallback says `"Oracle Cloud error"`.
+
+Add fixtures here when behavior depends on oracle-cloud-specific
+config (endpoint host, namespace, relabel, env-var name); shared S3
+semantics belong in [`../../test/s3.test.ts`](../../test/s3.test.ts).
+Use `mockClient(S3Client)` rather than a live OCI tenancy.
+
+## Coding conventions
+
+- Named exports only — `oracleCloud`, `OracleCloudAdapter`,
+  `OracleCloudAdapterOptions`.
+- Construction-time errors throw
+  [`FilesError("Provider", …)`](../internal/errors.ts) with messages
+  that name the adapter (`"oracle-cloud adapter: …"`). Operation
+  errors are the inner S3 adapter's responsibility — don't try-catch
+  and rethrow in this shim.
+- Read env vars via [`readEnv`](../internal/env.ts), not
+  `process.env` (breaks Cloudflare Workers without `nodejs_compat`).
+- Forward optional knobs conditionally
+  (`...(opts.x !== undefined && { x: opts.x })`) so unset values
+  fall through to the inner adapter's defaults. `forcePathStyle` is
+  the exception: this shim opts in to a non-S3 default via `?? true`.
+- Spread the inner adapter, then override only `name` — preserves
+  future additions to the `Adapter` interface automatically. Top-level
+  regex literals only.
+
+## Releases
+
+Ships with the monorepo on the repo-wide Changesets schedule.
+Behavioral changes (new options, default changes, error-shape
+changes) bump `files-sdk` and add an entry to
+[`../../CHANGELOG.md`](../../CHANGELOG.md) (`bun changeset`, pick
+`files-sdk`); pure docs / test-only additions don't. The
+`oracle-cloud` subpath is already declared in `exports`.
+
+## Where to look next
+
+- Unified contract: [`../index.ts`](../index.ts).
+- Inner S3 adapter: [`../s3/index.ts`](../s3/index.ts) +
+  [`../s3/AGENTS.md`](../s3/AGENTS.md) — `s3()`, `S3AdapterOptions`,
+  `mapS3Error`, default error code sets.
+- Shared helpers: [`../internal/core.ts`](../internal/core.ts) (URL
+  strategy, body normalization, error-mapper factory),
+  [`../internal/errors.ts`](../internal/errors.ts) (`FilesError`),
+  [`../internal/env.ts`](../internal/env.ts) (`readEnv`).
+- Provider catalog row (search `slug: "oracle-cloud"`):
+  [`../providers/index.ts`](../providers/index.ts).
+- User-facing docs: [`oracle-cloud.mdx`](../../../../apps/web/content/docs/adapters/oracle-cloud.mdx);
+  README: [`../../README.md`](../../README.md); SKILL:
+  [`SKILL.md`](../../../../skills/files-sdk/SKILL.md); tests:
+  [`oracle-cloud.test.ts`](../../test/oracle-cloud.test.ts).

--- a/packages/files-sdk/src/oracle-cloud/CLAUDE.md
+++ b/packages/files-sdk/src/oracle-cloud/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/packages/files-sdk/src/ovhcloud/AGENTS.md
+++ b/packages/files-sdk/src/ovhcloud/AGENTS.md
@@ -1,0 +1,219 @@
+# AGENTS.md — `files-sdk/ovhcloud`
+
+Guidance for coding agents working on the `ovhcloud` adapter. The unified
+`Adapter<Raw>` contract — call shapes, `FilesError`, `UrlOptions`,
+`SignUploadOptions`, body normalization — lives in
+[`../index.ts`](../index.ts); this file documents ovhcloud-specific
+deviations only. `ovhcloud()` is a thin wrapper around
+[`s3()`](../s3/index.ts) for OVHcloud Object Storage's S3-compatible
+API. OVHcloud ships two tiers — High Performance S3 (native S3, the
+default this adapter targets) and Standard (Swift-backed but exposing
+the same S3 front door) — and both flow through the inner adapter
+unchanged. See [`../s3/AGENTS.md`](../s3/AGENTS.md) for primitive-level
+details; cross-reference [`README.md`](../../README.md) and
+[`SKILL.md`](../../../../skills/files-sdk/SKILL.md).
+
+## Overview
+
+A thin shim that calls `s3()` with an OVHcloud endpoint, OVHcloud
+credentials, and a `defaultProviderMessage` of `"OVHcloud error"` so
+callers don't see `"S3 error"` from an OVHcloud-typed adapter. No
+per-method code here: every operation is forwarded by spread. The only
+ovhcloud-specific knobs are endpoint derivation from the region code,
+the credential env-var pair, and the error-message relabel. The
+returned adapter's `raw` is the underlying `@aws-sdk/client-s3`
+`S3Client` — anything the AWS SDK can do against OVHcloud (multipart,
+lifecycle, versioning where the tier supports it) is one property
+access away.
+
+## Directory layout
+
+```
+packages/files-sdk/src/ovhcloud/
+├── index.ts                   # ovhcloud() factory + OvhcloudAdapterOptions
+├── AGENTS.md                  # this file
+└── CLAUDE.md                  # @AGENTS.md — Claude-Code re-export
+```
+
+Tests at [`../../test/ovhcloud.test.ts`](../../test/ovhcloud.test.ts);
+user-facing docs at
+[`../../../../apps/web/content/docs/adapters/ovhcloud.mdx`](../../../../apps/web/content/docs/adapters/ovhcloud.mdx).
+
+## Build, test, typecheck
+
+Run from `packages/files-sdk/`. The `ovhcloud` subpath is enumerated in
+[`../../package.json`](../../package.json)'s `exports` map — keep it in
+sync if the file layout changes.
+
+```bash
+bun test test/ovhcloud.test.ts   # adapter unit tests only
+bun test                          # full SDK suite
+bun run build                     # tsup → dist/, including dist/ovhcloud/
+bun run types                     # tsgo --noEmit
+```
+
+## Public surface
+
+Exports from [`./index.ts`](./index.ts):
+
+- `ovhcloud(opts: OvhcloudAdapterOptions): OvhcloudAdapter` — primary
+  factory.
+- `OvhcloudAdapter` — alias for `Adapter<S3Client>`. `raw` is the AWS
+  SDK client.
+- `OvhcloudAdapterOptions` — config interface. JSDoc on every field is
+  the source of truth; the docs MDX pulls it via `<AutoTypeTable>`.
+
+The adapter's `name` is `"ovhcloud"` (set after spreading the inner
+adapter, so it overrides the S3 adapter's `"s3"`).
+
+## Authentication / configuration
+
+Required:
+
+- `bucket` — string. **No env fallback**; pass it explicitly.
+- `region` — OVHcloud region code: `gra`, `sbg`, `bhs`, `de`, `uk`,
+  `waw`, `sgp`, `syd` (full list with city names in the JSDoc on
+  `OvhcloudAdapterOptions.region`). Drives the endpoint host **and**
+  the SigV4 signing region. **No env fallback** — missing region throws
+  `FilesError("Provider", 'ovhcloud adapter: missing region. …')`.
+- Credentials — `accessKeyId` + `secretAccessKey`, passed in or sourced
+  from `OVH_ACCESS_KEY_ID` / `OVH_SECRET_ACCESS_KEY` via
+  [`readEnv`](../internal/env.ts). Missing both throws
+  `FilesError("Provider", "ovhcloud adapter: missing credentials. …")`.
+
+Optional:
+
+- `endpoint` — overrides the derived
+  `https://s3.${region}.io.cloud.ovh.net` (High Performance S3). Pass
+  `https://s3.${region}.cloud.ovh.net` for the Standard (Swift-backed)
+  tier; OVHcloud routes by Host header, so the SDK still prepends the
+  bucket subdomain for virtual-hosted requests.
+- `forcePathStyle` — defaults to `false`. Virtual-hosted is canonical
+  for OVHcloud; flip on only for proxies that demand path-style.
+- `publicBaseUrl` — origin used by `url()` when set; skips signing.
+  Natural value for a public container is
+  `https://${bucket}.s3.${region}.io.cloud.ovh.net`, or a custom CNAME.
+- `defaultUrlExpiresIn` — default presigned-URL expiry in seconds,
+  defaults to `3600` via `DEFAULT_URL_EXPIRES_IN` in
+  [`../internal/core.ts`](../internal/core.ts).
+
+There is no `OVH_REGION`, `OVH_BUCKET`, or `OVH_ENDPOINT` fallback. The
+catalog entry at [`../providers/index.ts`](../providers/index.ts)
+(search `slug: "ovhcloud"`) declares the same two credential env vars
+and treats `bucket` / `region` as explicit config. Env lookups go
+through [`readEnv`](../internal/env.ts) so the adapter stays safe on
+runtimes without `process` (Cloudflare Workers without `nodejs_compat`).
+
+## Operation map
+
+`ovhcloud()` calls `s3()` with the resolved config and spreads the
+returned adapter, overriding only `name`. Every method (`upload`,
+`download`, `head`, `exists`, `delete`, `deleteMany`, `copy`, `list`,
+`url`, `signedUploadUrl`) is the s3 implementation talking to OVHcloud
+— including `deleteMany`'s 1000-key chunking, `signedUploadUrl`'s
+PUT-vs-presigned-POST split on `maxSize`, and `exists`' 404-as-`false`
+classification. Provider errors flow through `mapS3Error` with the
+OVHcloud fallback table; `Provider`-coded messages read
+`"OVHcloud error"` while preserving any server-side message.
+
+## URL behavior
+
+`url(key, opts?)` follows the standard signing-adapter rules:
+
+- Default: presigned `GetObject` URL, expiring after
+  `opts.expiresIn ?? defaultUrlExpiresIn` seconds.
+- With `publicBaseUrl`: returns `${publicBaseUrl}/${key}` unsigned, via
+  `joinPublicUrl` from [`../internal/core.ts`](../internal/core.ts)
+  (URL-encodes path segments).
+- With `opts.responseContentDisposition`: always signs, even when
+  `publicBaseUrl` is set — a permanent URL has no signature in which to
+  bind the override, and silently dropping it would be a stored-XSS
+  regression on user-uploaded HTML/SVG. See `resolveUrlStrategy` in
+  [`../internal/core.ts`](../internal/core.ts) for the rationale.
+
+OVHcloud has no built-in CDN on Object Storage, so the common setup
+leaves `publicBaseUrl` unset and reads flow through presigned URLs; a
+platform CDN add-on or third-party CDN is the usual unsigned-origin
+escape hatch.
+
+## Provider quirks worth remembering
+
+- **Two tiers, one factory.** `ovhcloud()` defaults to High Performance
+  S3 (`s3.${region}.io.cloud.ovh.net`); for Standard (Swift-backed),
+  pass `endpoint: "https://s3.${region}.cloud.ovh.net"` explicitly.
+  Both speak S3 — the inner adapter doesn't care.
+- **Region is the endpoint.** Like Akamai and DigitalOcean Spaces, the
+  region string is the literal subdomain — pick the wrong code and the
+  request goes to the wrong datacenter. It also doubles as the SigV4
+  region; mismatches fail signature validation before reaching storage.
+- **S3 users are separate from API users.** Generate the key pair in
+  the OVHcloud Control Panel under Public Cloud → Object Storage → S3
+  users — distinct from OpenStack/Swift credentials, even on Standard.
+- **Buckets are single-region** (no cross-region replication) and
+  **containers default to private** — set the bucket policy in the
+  Control Panel before treating `publicBaseUrl` as live.
+- **No env-var sprawl.** The factory reads only `OVH_ACCESS_KEY_ID`
+  and `OVH_SECRET_ACCESS_KEY`; everything else is constructor-only.
+
+## Testing approach
+
+Unit tests at [`../../test/ovhcloud.test.ts`](../../test/ovhcloud.test.ts)
+cover endpoint derivation from `region` (`gra`, `de`) with the
+virtual-hosted default, explicit `endpoint` and `forcePathStyle: true`
+overrides reaching the inner `S3Client` config, missing-region and
+missing-credential errors at construction, the `OVH_ACCESS_KEY_ID` /
+`OVH_SECRET_ACCESS_KEY` env-var fallbacks, `url()` returning a presigned
+GET (`X-Amz-Signature=…`, `X-Amz-Expires=3600`) by default and the
+`publicBaseUrl` short-circuit, operation delegation via
+`aws-sdk-client-mock`'s `mockClient(S3Client)` (proves `upload` and
+`exists` reach the underlying client), and the relabel test that
+`mapS3Error` with the OVHcloud messages table returns `"OVHcloud error"`
+for `Provider`.
+
+Add fixtures here rather than to `s3.test.ts` whenever a behavior
+depends on ovhcloud-specific config (endpoint host, relabel, env-var
+name); shared S3 semantics belong in
+[`../../test/s3.test.ts`](../../test/s3.test.ts).
+
+## Coding conventions
+
+- Named exports only (`ovhcloud`, `OvhcloudAdapter`,
+  `OvhcloudAdapterOptions`). Construction-time errors use
+  [`FilesError("Provider", …)`](../internal/errors.ts); operation
+  errors stay the inner S3 adapter's responsibility — no try-catch
+  rethrow in this shim.
+- Read env via [`readEnv`](../internal/env.ts); direct `process.env`
+  breaks Cloudflare Workers without `nodejs_compat`.
+- Forward optional knobs with `...(opts.x !== undefined && { x: opts.x })`
+  so unset values fall through to the inner `s3()` defaults rather than
+  being passed as explicit `undefined` — matters for booleans like
+  `forcePathStyle` where `undefined` and `false` differ to the AWS SDK.
+- Spread the inner adapter, then override only `name`, so any future
+  additions to the `Adapter` interface that `s3()` picks up flow
+  through automatically.
+- Top-level regex literals only; no emojis in source, tests, or docs.
+
+## Releases
+
+Ships with the monorepo from
+[`../../package.json`](../../package.json). Behavioral changes bump
+`files-sdk` and add a [`../../CHANGELOG.md`](../../CHANGELOG.md) entry;
+docs / test-only additions don't. The `ovhcloud` subpath is already in
+`exports` — no further wiring needed for new options.
+
+## Where to look next
+
+- Unified contract: [`../index.ts`](../index.ts); inner S3 adapter:
+  [`../s3/index.ts`](../s3/index.ts) +
+  [`../s3/AGENTS.md`](../s3/AGENTS.md).
+- Shared helpers (URL strategy, body normalization, error-mapper
+  factory): [`../internal/core.ts`](../internal/core.ts);
+  `FilesError`: [`../internal/errors.ts`](../internal/errors.ts); env
+  reader: [`../internal/env.ts`](../internal/env.ts).
+- Provider catalog (search `slug: "ovhcloud"`):
+  [`../providers/index.ts`](../providers/index.ts).
+- Docs:
+  [`../../../../apps/web/content/docs/adapters/ovhcloud.mdx`](../../../../apps/web/content/docs/adapters/ovhcloud.mdx);
+  README: [`../../README.md`](../../README.md); SKILL:
+  [`../../../../skills/files-sdk/SKILL.md`](../../../../skills/files-sdk/SKILL.md).
+- Tests: [`../../test/ovhcloud.test.ts`](../../test/ovhcloud.test.ts).

--- a/packages/files-sdk/src/ovhcloud/CLAUDE.md
+++ b/packages/files-sdk/src/ovhcloud/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/packages/files-sdk/src/pocketbase/AGENTS.md
+++ b/packages/files-sdk/src/pocketbase/AGENTS.md
@@ -1,0 +1,201 @@
+# AGENTS.md — `files-sdk/pocketbase`
+
+Guidance for coding agents working inside the `files-sdk/pocketbase`
+adapter. Every adapter implements the same `Adapter<Raw>` contract from
+[`../index.ts`](../index.ts); this file documents only the
+pocketbase-specific deviations. For the unified surface, read
+[`../../README.md`](../../README.md) and
+[`../../../../skills/files-sdk/SKILL.md`](../../../../skills/files-sdk/SKILL.md)
+first.
+
+PocketBase is a **native** adapter — it talks to the official
+`pocketbase` JS SDK directly rather than going through `s3()`. Most
+bugs land in deferred auth (superuser vs token vs public rules),
+collection/field wiring (the adapter does not create schemas), or the
+two-step read path (record lookup, then `fetch()` on `pb.files.getURL`).
+
+## Overview
+
+[PocketBase](https://pocketbase.io) via the official `pocketbase` SDK.
+Family: **self-hosted BaaS** — no object-store primitive. Files live as
+single-value file fields on collection records. The adapter maps the
+unified key/blob API onto one collection: a unique-indexed text
+`keyField` (default `"key"`) and a single-file `fileField` (default
+`"file"`).
+
+Operations use `collection().create` / `update` / `delete` /
+`getFirstListItem` / `getList` plus `pb.files.getURL` and `fetch()` for
+bytes. `signedUploadUrl()` throws — no presigned upload primitive.
+Optional peer dependency: `pocketbase`.
+
+## Directory layout
+
+```text
+packages/files-sdk/src/pocketbase/
+├── index.ts                # adapter implementation + auth + mapping
+├── AGENTS.md               # this file
+└── CLAUDE.md               # `@AGENTS.md`
+```
+
+- Tests: [`../../test/pocketbase.test.ts`](../../test/pocketbase.test.ts).
+- User docs:
+  [`../../../../apps/web/content/docs/adapters/pocketbase.mdx`](../../../../apps/web/content/docs/adapters/pocketbase.mdx).
+- Provider catalog (search `slug: "pocketbase"`):
+  [`../providers/index.ts`](../providers/index.ts).
+
+## Build, test, typecheck
+
+Run from `packages/files-sdk/`:
+
+```bash
+bun test test/pocketbase.test.ts   # adapter unit tests
+bun test                            # full SDK suite
+bun run build                       # tsup -> dist/pocketbase/
+bun run types                       # tsgo --noEmit
+```
+
+Uses **`bun test`** and **`tsgo`**. Subpath bundle:
+`dist/pocketbase/index.{js,d.ts}` per [`../../package.json`](../../package.json).
+
+## Public surface
+
+Defined in [`./index.ts`](./index.ts):
+
+- `pocketbase(opts): PocketBaseAdapter` — primary factory.
+- `PocketBaseAdapter` — `Adapter<PocketBaseClient> & { readonly collection: string }`.
+- `PocketBaseAdapterOptions` — JSDoc is source of truth (MDX `AutoTypeTable`).
+- `mapPocketBaseError(err): FilesError` — exported for tests/callers.
+
+`raw` is the `PocketBase` client; `name` is `"pocketbase"`.
+
+## Authentication / configuration
+
+**Required:** `collection` — no env fallback; missing value throws at
+construction. Provision the collection first (admin UI or migrations):
+unique-indexed text `keyField`, single-value `fileField`. The adapter
+never creates or migrates it.
+
+**Connection (one of):**
+
+1. **`client`** — pre-built `PocketBase` instance (highest precedence;
+   ignores all auth options below).
+2. **`url`** — backend origin; falls back to `POCKETBASE_URL`.
+
+**Auth (deferred to first API call):** sync factory; `ensureAuth()` runs
+once, re-runs when `authStore.isValid` is false. Failed auth clears the
+cached promise for retry.
+
+1. **`authToken`** / `POCKETBASE_AUTH_TOKEN` — `authStore.save(token, null)`.
+   **Wins** over admin email/password.
+2. **Admin email + password** / `POCKETBASE_ADMIN_*` —
+   `collection("_superusers").authWithPassword` (v0.23+ superusers).
+3. **No credentials** — unauthenticated; works when API rules allow public
+   access; protected collections return `Unauthorized`.
+
+**Optional:** `keyField`, `fileField`, `publicBaseUrl` (CDN short-circuit for
+`url()`). Env via [`readEnv`](../internal/env.ts). Catalog entry documents
+`POCKETBASE_URL` plus token vs admin credential modes.
+
+## Operation map
+
+API methods await `ensureAuth()` first (`url()` skips lookup when
+`publicBaseUrl` is set). Errors go through `mapPocketBaseError`.
+
+- `upload` — `collectStream` for `ReadableStream`; `FormData` + `Blob` only.
+  Probe by key: 404 → `create`, hit → `update`. Filename hint is the last
+  path segment of `key`; PocketBase adds its own suffix — trust `fileField`
+  on the record. **`metadata` throws** when non-empty (typed fields only;
+  use `raw` for extra columns). **`cacheControl` throws**.
+- `download` — lookup + `files.getURL` + `fetch()`. Tries `files.getToken()`
+  when authed (swallows failure for public collections). Accurate `size`;
+  `type` is always `application/octet-stream`.
+- `head` — lazy body (`kind: "lazy"`). `size` is **0** until body access —
+  record JSON has no file size/MIME. `metadata`: `{ filename, recordId }`.
+- `exists` — [`existsByProbe`](../internal/core.ts) on `getFirstListItem`.
+- `delete` — by record id; idempotent on `NotFound`.
+- `copy` — download then `create` (not atomic).
+- `list` — `getList`, `sort: keyField`, prefix via `pb.filter`. Default
+  `limit` 30; cursor is a **page number** string. Invalid cursor → `Provider`.
+- `url` — see URL behavior; `signedUploadUrl` throws (mint a short-lived
+  auth token for browser uploads instead).
+
+Filters: always `pb.filter(\`${keyField} = {:k}\`, { k })` and
+`pb.filter(\`${keyField} ~ {:p}\`, { p: \`${prefix}%\` })` — never
+hand-built escapes. `AbortSignal` via `SendOptions` on SDK calls and on
+download `fetch()`.
+
+`mapPocketBaseError` uses [`makeErrorMapper`](../internal/core.ts) with
+empty PocketBase code sets — HTTP status drives classification: 404 →
+`NotFound`, 403 → `Unauthorized`, 409 → `Conflict`, else `Provider`
+(`"PocketBase error"`). `FilesError` passthrough; download fetch 404 →
+`NotFound`.
+
+## URL behavior
+
+1. **`publicBaseUrl`** — `${base}/${encodeURIComponent(key)}`; trailing
+   slash stripped; no lookup or token.
+2. **Default** — lookup, optional `files.getToken()`, `files.getURL`.
+   Token failure swallowed for public collections.
+
+`responseContentDisposition` throws — use `?download=true` via `raw`.
+No caller-controlled `expiresIn` on file URLs.
+
+## Provider quirks worth remembering
+
+- **Schema is caller-owned** — wrong fields or missing unique index fail at
+  runtime, not construction.
+- **`UploadOptions.metadata` throws** vs read-only `StoredFile.metadata`
+  `{ filename, recordId }`. `recordId` is the PocketBase record id for
+  `raw` updates/relations — not the user key.
+- **Key vs record id** — callers use keys; delete/update resolve record ids.
+  Duplicate keys on create → `Conflict` (409).
+- **`_superusers` admin auth** — server-side only; user JWTs via `authToken`.
+- **No server-side copy** — `copy()` is egress + ingest.
+- **Page-based list** — loop `cursor` + `limit`; no folder recursion.
+- **Buffered streams** — large `ReadableStream` uploads need `raw`.
+- **Randomized filenames** — trust `metadata.filename`, not the upload hint.
+
+## Testing approach
+
+[`../../test/pocketbase.test.ts`](../../test/pocketbase.test.ts) mocks
+`pocketbase` with `FakePocketBase` + `FakeClientResponseError` (must
+extend `Error` for `instanceof ClientResponseError` checks), stubs
+`globalThis.fetch` for `/api/files/...` downloads, and mirrors one
+collection in a `Map`. Key suites:
+
+- Construction: missing `collection` / `url`; env fallbacks; `adapter.raw`
+  when `client` is passed.
+- Upload: create vs update dedupe; **`metadata` and `cacheControl` throw**.
+- Reads: download/head lazy fetch; file token vs unsigned fallback.
+- Mutations: idempotent delete; copy read-then-write; list prefix + pages.
+- Auth: admin runs once; `authToken` skips admin; promise reset on failure.
+- Errors: `mapPocketBaseError` status table; empty `fileField`; signal forward.
+
+Extend `FakePocketBase` rather than inventing new SDK shapes inline.
+
+## Coding conventions
+
+- Named exports only.
+- `FilesError("Provider", …)` at construction; `mapPocketBaseError` in catches.
+- [`readEnv`](../internal/env.ts), [`createStoredFile`](../internal/stored-file.ts),
+  shared [`normalizeBody`](../internal/core.ts) + `collectStream`.
+- `pb.filter()` for filters; `sendOpts(signal)` returns `undefined` without signal.
+
+## Releases
+
+Ships from [`../../package.json`](../../package.json). Behavioral changes
+need a version bump + [`CHANGELOG.md`](../../CHANGELOG.md) entry; docs/tests
+only do not. `pocketbase` subpath is already in `exports`.
+
+## Where to look next
+
+- Contract: [`../index.ts`](../index.ts); source: [`./index.ts`](./index.ts);
+  tests: [`../../test/pocketbase.test.ts`](../../test/pocketbase.test.ts).
+- Internals: [`../internal/core.ts`](../internal/core.ts),
+  [`../internal/errors.ts`](../internal/errors.ts),
+  [`../internal/env.ts`](../internal/env.ts),
+  [`../internal/stored-file.ts`](../internal/stored-file.ts).
+- Catalog: [`../providers/index.ts`](../providers/index.ts) (`slug: "pocketbase"`).
+- Docs: [`pocketbase.mdx`](../../../../apps/web/content/docs/adapters/pocketbase.mdx),
+  [`README`](../../README.md),
+  [`SKILL`](../../../../skills/files-sdk/SKILL.md).

--- a/packages/files-sdk/src/pocketbase/CLAUDE.md
+++ b/packages/files-sdk/src/pocketbase/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/packages/files-sdk/src/r2/AGENTS.md
+++ b/packages/files-sdk/src/r2/AGENTS.md
@@ -1,0 +1,300 @@
+# AGENTS.md — `files-sdk/r2`
+
+Guidance for coding agents working inside the `files-sdk/r2` adapter
+(the Cloudflare R2 entry point at the `files-sdk/r2` subpath). The
+unified `Adapter` contract every method conforms to lives in
+[`../index.ts`](../index.ts) — read it first. This file documents
+r2-specific deviations only.
+
+R2 is one of the most complex adapters because it ships **three**
+distinct modes from the same factory: HTTP-only (S3-compatible API,
+bundles the AWS SDK), binding-only (Workers `R2Bucket`, no AWS SDK at
+all), and hybrid (binding plus HTTP credentials, so reads/writes stay
+intra-Worker but `url()` and `signedUploadUrl()` can still mint
+presigned URLs). For the user-facing surface, see
+[`../../README.md`](../../README.md) and
+[`skills/files-sdk/SKILL.md`](../../../../skills/files-sdk/SKILL.md).
+
+## Overview
+
+`r2(opts)` returns an `Adapter<S3Client | R2Bucket>` whose shape is
+identical to every other adapter in the SDK. The deviations are
+entirely about how it dispatches behind that surface.
+
+- **HTTP mode** — wraps [`../s3/index.ts`](../s3/index.ts) with
+  Cloudflare-flavoured defaults (`region: "auto"`,
+  `forcePathStyle: true`,
+  `endpoint: https://{accountId}.r2.cloudflarestorage.com`,
+  `defaultProviderMessage: "R2 error"`). Used outside Workers.
+- **Binding mode** — implements every operation directly against the
+  `R2Bucket` binding API. No AWS SDK, no HTTP round-trip, no egress
+  fees. Used for binding-resident reads/writes inside a Worker.
+- **Hybrid mode** — binding for reads/writes, lazy s3 adapter for
+  `url()` and `signedUploadUrl()`. Triggered when `binding` plus
+  `bucket` plus the three HTTP credentials (`accountId`,
+  `accessKeyId`, `secretAccessKey`) are all present. Useful for
+  Workers that need browser-facing presigned URLs without giving up
+  the binding's I/O performance.
+
+The factory branches on `"binding" in opts`; hybrid is recognised
+inside the binding entry point by the *additional* presence of HTTP
+credentials.
+
+## Directory layout
+
+```
+packages/files-sdk/src/r2/
+└── index.ts             # r2() factory + r2FromHttp + r2FromBinding + mapR2Error + lazyS3
+```
+
+Tests live in [`../../test/r2.test.ts`](../../test/r2.test.ts), the
+user-facing docs page is
+[`apps/web/content/docs/adapters/r2.mdx`](../../../../apps/web/content/docs/adapters/r2.mdx),
+and the provider catalog entry lives in
+[`../providers/index.ts`](../providers/index.ts) under `slug: "r2"`.
+
+## Build, test, typecheck
+
+```bash
+bun test test/r2.test.ts   # just this adapter's suite
+bun test                   # full package suite
+bun run build              # tsup ESM bundle → dist/
+bun run types              # tsgo --noEmit
+```
+
+Tests use **bun test** (not vitest); type-checking uses **tsgo
+--noEmit**. Run both from `packages/files-sdk/` and keep them green
+before opening a PR.
+
+## Public surface
+
+Exports from [`./index.ts`](./index.ts):
+
+- `r2(opts: R2AdapterOptions): R2Adapter` — the factory.
+- `R2HttpOptions`, `R2BindingOptions` (encodes hybrid via optional
+  HTTP credential fields), and the union
+  `R2AdapterOptions = R2BindingOptions | R2HttpOptions`.
+- `R2Adapter = Adapter<S3Client | R2Bucket>` — `.raw` is the
+  underlying `S3Client` (HTTP/hybrid) or `R2Bucket` (binding-only).
+- `R2Bucket` — re-exported from `@cloudflare/workers-types` so
+  callers don't need a second import.
+
+## Authentication / configuration
+
+R2 has two credential modes (mirrored in
+[`../providers/index.ts`](../providers/index.ts) under `r2.env`).
+
+**HTTP mode (`R2HttpOptions`).** Required: `bucket`, `accountId`,
+`accessKeyId`, `secretAccessKey`. The latter three fall back to
+Cloudflare-specific env vars:
+
+| Field                 | Env fallback             | Required?                              |
+| --------------------- | ------------------------ | -------------------------------------- |
+| `bucket`              | —                        | Yes                                    |
+| `accountId`           | `R2_ACCOUNT_ID`          | Yes — constructor throws if missing    |
+| `accessKeyId`         | `R2_ACCESS_KEY_ID`       | Yes — constructor throws if missing    |
+| `secretAccessKey`     | `R2_SECRET_ACCESS_KEY`   | Yes — constructor throws if missing    |
+| `publicBaseUrl`       | —                        | No — switches `url()` to unsigned      |
+| `defaultUrlExpiresIn` | —                        | No — defaults to 3600 seconds          |
+
+Env reads go through [`readEnv`](../internal/env.ts), which returns
+`undefined` (rather than throwing `ReferenceError`) when `process` is
+missing — important on Workers without `nodejs_compat`. If you change
+the env-var names, update the provider catalog and user-facing docs
+in lockstep.
+
+**Binding mode (`R2BindingOptions`).** `binding: R2Bucket` is the only
+required field. Optional fields:
+
+- `publicBaseUrl?` — origin for `url()` to concatenate against.
+  Without this *and* without hybrid credentials, `url()` throws
+  `Provider` because a binding has no signing primitive.
+- `bucket?` plus `accountId?` / `accessKeyId?` / `secretAccessKey?` —
+  opt into hybrid mode. **All four** must be present to enable
+  hybrid; partial sets silently degrade to plain binding mode.
+- `defaultUrlExpiresIn?` — only consulted by the hybrid signing
+  fallback.
+
+**`defaultProviderMessage`.** Both HTTP and hybrid paths set the
+(internal) s3 option `defaultProviderMessage: "R2 error"` so unknown
+errors that bubble through the s3 mapper carry an R2-flavoured
+message instead of the default `"S3 error"`. Callers should never
+see an `"S3 error"` string from this adapter; the relabel is verified
+by a dedicated test.
+
+## Operation map
+
+The HTTP path is a thin async wrapper over the s3 adapter — every
+method does `const inner = await ensure(); return inner.<method>(…)`.
+The binding path is implemented inline against the `R2Bucket` API:
+
+| Method            | HTTP / hybrid                | Binding read/write path                                                              |
+| ----------------- | ---------------------------- | ------------------------------------------------------------------------------------ |
+| `upload`          | Inner `s3.upload`            | `bucket.put` after `normalizeForR2` shapes the body                                  |
+| `download`        | Inner `s3.download`          | `bucket.get`; `null` → `NotFound`; honours `as: "stream"`                            |
+| `head`            | Inner `s3.head`              | `bucket.head`; lazy body factory re-issues `bucket.get` on demand                    |
+| `exists`          | Inner `s3.exists`            | `bucket.head() !== null`, with `mapR2Error` classification on thrown errors          |
+| `delete`          | Inner `s3.delete`            | `bucket.delete`                                                                      |
+| `deleteMany`      | Inner `s3.deleteMany`        | Falls back to `deleteManyWithFallback` (binding has no bulk primitive)               |
+| `copy`            | Inner `s3.copy`              | Streamed `bucket.get` → `bucket.put` (no server-side copy — see "Provider quirks")   |
+| `list`            | Inner `s3.list`              | `bucket.list`; per-item lazy bodies fetch via `bucket.get`                           |
+| `url`             | See URL behavior below       | See URL behavior below                                                               |
+| `signedUploadUrl` | Inner `s3.signedUploadUrl`   | Hybrid only; throws `Provider` with guidance when no HTTP creds are present          |
+
+Body normalisation is local. `normalizeForR2` produces shapes the
+`R2Bucket.put` typing accepts (`ArrayBuffer | ReadableStream<Uint8Array>
+| string`), differing from the shared
+[`normalizeBody`](../internal/core.ts) by preserving `ArrayBuffer`
+directly rather than copying through `Uint8Array` — the Workers type
+rejects raw `Uint8Array` without an explicit copy.
+
+`mapR2Error` classifies binding errors by both `name`
+(`R2NotFoundError`, `Forbidden`, …) **and** Cloudflare's numeric
+`code`: 10002 → `NotFound`, 10004/10006 → `Unauthorized`, 10007 →
+`Conflict`; anything else falls through to `Provider`. `FilesError`
+instances pass through untouched. See the
+[Workers R2 API reference](https://developers.cloudflare.com/r2/api/workers/workers-api-reference/)
+for the canonical code list.
+
+## URL behavior
+
+`url(key, opts?)` is the most mode-sensitive method. The full matrix:
+
+| Mode         | `publicBaseUrl` | `responseContentDisposition` | Result                                                                          |
+| ------------ | --------------- | ----------------------------- | ------------------------------------------------------------------------------- |
+| HTTP         | yes             | absent                        | `${publicBaseUrl}/${encoded key}` (unsigned, no network call)                   |
+| HTTP         | yes             | present                       | Presigned `GetObject` URL with `ResponseContentDisposition` baked in            |
+| HTTP         | no              | any                           | Presigned `GetObject` URL (default `expiresIn` 3600s)                           |
+| Binding-only | yes             | absent                        | `${publicBaseUrl}/${encoded key}` (no signing performed)                        |
+| Binding-only | yes             | present                       | **Throws `Provider`** — disposition needs signing; binding can't sign           |
+| Binding-only | no              | any                           | **Throws `Provider`** with guidance to add `publicBaseUrl` or HTTP credentials  |
+| Hybrid       | yes             | absent                        | `${publicBaseUrl}/${encoded key}` (cheaper than signing, no network)            |
+| Hybrid       | yes             | present                       | Presigned URL via the lazy s3 signer (disposition forces signing)               |
+| Hybrid       | no              | any                           | Presigned URL via the lazy s3 signer (`expiresIn` defaults to 3600s)            |
+
+`signedUploadUrl(key, opts)` is simpler: HTTP and hybrid forward to
+the inner s3 adapter (PUT URL when `maxSize` is omitted, presigned
+POST when `maxSize` is set — see the contract on
+[`../index.ts`](../index.ts)); binding-only throws `Provider` with
+the same "needs HTTP credentials" guidance as `url()`.
+
+The "disposition forces signing" rule is centrally codified by
+`resolveUrlStrategy` in [`../internal/core.ts`](../internal/core.ts),
+but the binding/hybrid `url()` implements the precedence inline
+because its three-state logic doesn't fit that helper's two-state
+shape — match the same invariant when modifying it.
+
+## Lazy s3 import
+
+The s3 adapter is **not** statically imported. `lazyS3` returns a
+memoised getter that does `await import("../s3/index.js")` on first
+call. This matters because `@aws-sdk/client-s3` is large (~500 KB
+minified) — a binding-only Worker that imports `files-sdk/r2` should
+never need the AWS SDK in its bundle. Consequences:
+
+- HTTP-mode `adapter.raw` is `undefined` until the first method call
+  resolves the import (covered by a dedicated test).
+- Hybrid mode only triggers the import the first time `url()` or
+  `signedUploadUrl()` is called.
+
+Do **not** add a top-level `import { s3 } from "../s3/index.js"`
+here — bundlers won't tree-shake it back out for the binding-only
+path because the s3 module has side effects via AWS SDK init.
+
+## Provider quirks worth remembering
+
+- **No server-side copy on bindings.** `R2Bucket` exposes no atomic
+  copy primitive, so binding `copy()` does `bucket.get(from)` →
+  `bucket.put(to, obj.body, …)`. The body is streamed through `put`
+  rather than buffered (multi-GB copies would otherwise blow Worker
+  memory limits). Source/destination are not atomic — concurrent
+  mutations of `from` between the get and put are not detected.
+  Hybrid mode's HTTP signer is *not* used for copy.
+- **Binding `head()` body access is lazy.** The binding's `head` API
+  returns metadata only, so the `StoredFile` we expose installs a
+  factory that re-issues `bucket.get(key)` on demand. If the object
+  vanished between `head` and body access, the factory returns empty
+  bytes (matches the `StoredFile` contract — guarded by the
+  "lazy body returns empty bytes" test). Same applies to `list()`
+  items.
+- **Error shape.** R2 binding errors are plain objects with `name` and
+  numeric `code`, not subclasses of `Error`. `mapR2Error` reads both;
+  canonical fixtures (`{ name: "R2NotFoundError" }`, `{ code: 10_004 }`,
+  etc.) live in the test file. `FilesError` instances pass through
+  unchanged so internal throws don't get rewrapped. `bucket.list`
+  cursors are surfaced only when `truncated` is true — the adapter
+  mirrors that.
+- **`bucket` is required for hybrid signing.** A common pitfall is
+  passing `accountId` + `accessKeyId` + `secretAccessKey` but
+  forgetting `bucket`; the adapter silently degrades to plain binding
+  mode and `url()` starts throwing.
+- **`publicBaseUrl` URL-encodes path segments** via
+  [`joinPublicUrl`](../internal/core.ts) — but that only handles
+  URL-syntax encoding. Sanitising untrusted input is still on the
+  caller, per the docstring on [`../index.ts`](../index.ts).
+
+## Testing approach
+
+[`../../test/r2.test.ts`](../../test/r2.test.ts) splits into two
+top-level `describe` blocks:
+
+- **HTTP path** — uses `aws-sdk-client-mock` to stub `S3Client`
+  responses. Covers default endpoint shape
+  (`acct.r2.cloudflarestorage.com`, region `auto`), env-var
+  fallbacks, the `publicBaseUrl` short-circuit, lazy `raw`
+  materialisation, and the `"R2 error"` relabel.
+- **Workers binding path** — uses an in-memory `fakeBinding()` helper
+  (a `Map`-backed shim that mimics
+  `R2Bucket.{get,put,head,list,delete}`) and covers every binding
+  method, `mapR2Error` classification (10002 / 10004 / 10007 /
+  unknown), lazy body access on `head`/`list`, the
+  no-publicBaseUrl + no-creds throw, the disposition override forcing
+  signing, and full hybrid mode end-to-end.
+
+When adding a feature, prefer extending `fakeBinding()` over
+fabricating a new mock. The s3 path forwards to the inner adapter,
+so HTTP coverage here should stick to r2-unique behaviours — let the
+s3 suite cover the rest of the operation map.
+
+## Coding conventions
+
+- Named exports only — no default exports.
+- The factory branches on `"binding" in opts`, not on a discriminator
+  field. Don't introduce a `kind: "binding" | "http"` tag; the union
+  is structural by design.
+- Errors thrown to callers use [`FilesError`](../internal/errors.ts)
+  with one of the four `FilesErrorCode` values. `mapR2Error` is the
+  only place that translates raw binding errors — keep it that way.
+- Workers types come from `@cloudflare/workers-types`. The factory
+  accepts `R2Bucket` structurally, so callers without that dep can
+  pass a duck-typed binding.
+- Don't read `process.env` directly. Go through
+  [`readEnv`](../internal/env.ts) so the binding-only path (which can
+  run in `nodejs_compat`-less Workers) doesn't crash.
+- Don't unify `normalizeForR2` with
+  [`normalizeBody`](../internal/core.ts) without first verifying the
+  binding still accepts every input shape — the two differ
+  deliberately.
+
+## Releases
+
+Behaviour changes need a Changeset entry: `bun changeset` from the
+repo root, pick `files-sdk`. Docs-only edits (this file,
+[r2.mdx](../../../../apps/web/content/docs/adapters/r2.mdx),
+[README](../../README.md)) don't need a changeset.
+
+## Where to look next
+
+- Unified `Adapter` contract: [`../index.ts`](../index.ts).
+- Inner s3 adapter: [`../s3/index.ts`](../s3/index.ts).
+- Shared helpers and `FilesError`:
+  [`../internal/core.ts`](../internal/core.ts),
+  [`../internal/errors.ts`](../internal/errors.ts),
+  [`../internal/env.ts`](../internal/env.ts).
+- Provider catalog:
+  [`../providers/index.ts`](../providers/index.ts) under `slug: "r2"`.
+- Tests: [`../../test/r2.test.ts`](../../test/r2.test.ts).
+- User-facing docs:
+  [`apps/web/content/docs/adapters/r2.mdx`](../../../../apps/web/content/docs/adapters/r2.mdx),
+  package [README](../../README.md), high-level mental model in
+  [`skills/files-sdk/SKILL.md`](../../../../skills/files-sdk/SKILL.md).

--- a/packages/files-sdk/src/r2/CLAUDE.md
+++ b/packages/files-sdk/src/r2/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/packages/files-sdk/src/s3/AGENTS.md
+++ b/packages/files-sdk/src/s3/AGENTS.md
@@ -1,0 +1,275 @@
+# AGENTS.md — `files-sdk/s3`
+
+Guidance for coding agents working inside the S3 adapter. Every adapter in
+files-sdk implements the same `Adapter<Raw>` contract from
+[`packages/files-sdk/src/index.ts`](../index.ts); this file documents only
+the deviations and pitfalls specific to `s3`. For the unified API, the
+package-wide [README.md](../../README.md) and the agent skill at
+[`skills/files-sdk/SKILL.md`](../../../../skills/files-sdk/SKILL.md) are the
+sources of truth — read them first.
+
+`s3` is the foundational adapter. Several other S3-compatible adapters
+(`bun-s3`, `r2`, `minio`, `digitalocean-spaces`, `storj`, `hetzner`,
+`akamai`, `backblaze-b2`, `wasabi`, `scaleway`, `ovhcloud`, `idrive-e2`,
+`vultr`, `filebase`, `exoscale`, `oracle-cloud`, `ibm-cos`, `tigris`,
+`tencent`, `alibaba`, `yandex`) wrap or re-export this adapter with
+provider-friendly defaults (default endpoint, label override, signing
+mode), so behaviour changes here cascade to roughly half the catalog. Edit
+with care.
+
+## Overview
+
+AWS S3 (and any S3-compatible bucket reached over the S3 HTTP API). Family:
+**S3 / S3-compatible foundational**. The full unified surface — `upload`,
+`download`, `head`, `exists`, `delete`, `deleteMany`, `copy`, `list`,
+`url`, `signedUploadUrl` — is implemented natively against
+`@aws-sdk/client-s3`, with presigning via `@aws-sdk/s3-request-presigner`
+(GET / PUT) and `@aws-sdk/s3-presigned-post` (POST policy form).
+
+Peer dependencies (all optional, declared in the package
+[`package.json`](../../package.json)):
+
+- `@aws-sdk/client-s3`
+- `@aws-sdk/s3-presigned-post`
+- `@aws-sdk/s3-request-presigner`
+
+## Directory layout
+
+```text
+packages/files-sdk/src/s3/
+├── index.ts                # adapter implementation
+├── AGENTS.md               # this file
+└── CLAUDE.md               # `@AGENTS.md`
+```
+
+Sibling files outside this directory:
+
+- Tests: [`packages/files-sdk/test/s3.test.ts`](../../test/s3.test.ts)
+- User docs: [`apps/web/content/docs/adapters/s3.mdx`](../../../../apps/web/content/docs/adapters/s3.mdx)
+- Provider catalog entry: [`packages/files-sdk/src/providers/index.ts`](../providers/index.ts) (search for `slug: "s3"`)
+
+## Build, test, typecheck
+
+```bash
+# from packages/files-sdk/
+bun test test/s3.test.ts            # run only this adapter's tests
+bun test                            # run the whole test suite
+bun run build                       # tsup ESM bundle -> dist/s3/index.js
+bun run types                       # tsgo --noEmit (uses @typescript/native-preview)
+bun run test:coverage               # bun test --coverage
+```
+
+This package uses **`bun test`** (not vitest) and **`tsgo`** (not `tsc`) —
+both are pinned in `package.json` `devDependencies`. The per-subpath
+bundle output is `dist/s3/index.{js,d.ts}` per the `exports` map in
+[`packages/files-sdk/package.json`](../../package.json).
+
+## Public surface
+
+Defined in [`index.ts`](index.ts):
+
+- `s3(opts: S3AdapterOptions): S3Adapter` — factory (lines 182-570). The
+  one entry point most callers use.
+- `S3AdapterOptions` interface (lines 36-89) — `bucket`, `region`,
+  `endpoint`, `forcePathStyle`, `credentials`, `publicBaseUrl`,
+  `defaultUrlExpiresIn`, and the `@internal` `defaultProviderMessage`.
+- `S3Adapter` type (lines 91-93) — `Adapter<S3Client> & { readonly bucket }`
+  so callers can read the configured bucket without re-passing it.
+- `mapS3Error(err, messages?): FilesError` (lines 157-180) — exported so
+  the S3-compatible wrappers can reuse the same classification with their
+  own per-code fallback messages.
+
+## Authentication / configuration
+
+Credentials are `sdk-chain` here — files-sdk does **not** call `readEnv` for
+`AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `AWS_SESSION_TOKEN`. The
+AWS SDK's default credential chain handles them: env vars, IAM role,
+shared profile, EC2 / ECS / EKS instance metadata, SSO, etc. Callers can
+omit `credentials` entirely on those runtimes.
+
+The adapter itself only reads the region:
+
+- `opts.region` (preferred), then `AWS_REGION`, then `AWS_DEFAULT_REGION`
+  via `readEnv` (lines 183-184). Missing region throws a `FilesError`
+  with code `Provider` at construction (lines 185-190).
+
+`opts.endpoint` and `opts.forcePathStyle` are passed straight through to
+`S3Client`. Both are required by most S3-compatible services (and by
+LocalStack) — the wrappers in `digitalocean-spaces`, `wasabi`, `minio`,
+etc. set them automatically; bare `s3()` users on a non-AWS endpoint must
+pass them explicitly.
+
+## Operation map
+
+Every method goes through the local `wrapErr` mapper, which is
+`mapS3Error` by default and a relabelled variant when
+`defaultProviderMessage` is set.
+
+- `upload` — `PutObjectCommand` with body, content type, content length,
+  `Cache-Control`, and user `Metadata` from `normalizeBody`. `ReadableStream`
+  bodies have no upfront `ContentLength`; the adapter follows up with a
+  `HeadObjectCommand` to surface the authoritative size and
+  `lastModified` in the result (lines 528-539). If that head probe fails,
+  size falls back to `0` rather than rejecting the upload.
+- `download` — `GetObjectCommand`. Buffer path uses
+  `Body.transformToByteArray()`; stream path uses
+  `Body.transformToWebStream()`. The buffer path always reports the actual
+  byte length, not `ContentLength`, so the size matches what the caller
+  can read.
+- `head` — `HeadObjectCommand`. The returned `StoredFile`'s body
+  accessors lazily issue a `GetObjectCommand` if you call `text()` /
+  `arrayBuffer()` / `blob()` / `stream()` — they are not free.
+- `exists` — `existsByProbe(HeadObjectCommand, wrapErr)` from
+  `internal/core.ts`. `NotFound` returns `false`; auth and transport
+  errors propagate.
+- `delete` — `DeleteObjectCommand`.
+- `deleteMany` — native via `DeleteObjectsCommand`, chunked at
+  `S3_DELETE_BATCH_LIMIT = 1000` (lines 117, 290-322). With
+  `stopOnError: true` it falls back to per-key `DeleteObjectCommand` so
+  the "stop" point lands on a single key. If a whole `DeleteObjects`
+  batch rejects, the mapped error is attached to every key in that batch
+  (S3 doesn't tell us which keys failed at the request level).
+- `copy` — `CopyObjectCommand` server-side. `CopySource` is
+  URL-encoded defensively (`${encodeURIComponent(bucket)}/${encodeURIComponent(from)}`)
+  per the S3 docs; `Key` is passed unencoded because the SDK signs and
+  serializes it as a request parameter, not a URL value.
+- `list` — `ListObjectsV2Command`. The `cursor` field is
+  `NextContinuationToken` when `IsTruncated` is true. Per-page limit is
+  whatever the caller passes; the AWS-side default is 1000. Each item's
+  body factory issues a fresh `GetObjectCommand` on demand, just like
+  `head`.
+- `url` — `resolveUrlStrategy({ publicBaseUrl, responseContentDisposition })`
+  decides between the public path (`joinPublicUrl(publicBaseUrl, key)`)
+  and signing (`getSignedUrl(GetObjectCommand)`). Per-call `expiresIn`
+  beats `opts.defaultUrlExpiresIn`, which falls back to
+  `DEFAULT_URL_EXPIRES_IN` (3600s).
+- `signedUploadUrl` — **PUT or POST depending on `maxSize`**. With
+  `maxSize` set, returns `createPresignedPost(...)` with a
+  `content-length-range` policy (defaulting `minSize` to `1` to reject
+  empty uploads — pass `minSize: 0` if you genuinely want to allow them).
+  Without `maxSize`, returns `getSignedUrl(PutObjectCommand)`.
+
+## URL behavior
+
+- **`publicBaseUrl` precedence.** When set and `responseContentDisposition`
+  is absent, `url()` returns `${publicBaseUrl}/${encodedKey}` via
+  `joinPublicUrl`. The base tolerates a single trailing slash; the key is
+  URL-encoded segment-by-segment (so `/` stays as the path separator and
+  everything else is `encodeURIComponent`'d).
+- **Default expiry.** When signing, the per-call `expiresIn` wins;
+  otherwise the adapter's `defaultUrlExpiresIn` wins; otherwise
+  `DEFAULT_URL_EXPIRES_IN` (3600s) from `internal/core.ts`.
+- **`responseContentDisposition` always forces signing.** The relevant
+  comment in `resolveUrlStrategy` ([`internal/core.ts`](../internal/core.ts)):
+  > a permanent CDN URL has no signature in which to bind the override,
+  > and silently dropping the override is a stored-XSS regression on
+  > user-uploaded HTML/SVG. The override wins.
+  So passing this option returns a presigned URL even when
+  `publicBaseUrl` is set — the security override beats the unsigned
+  fast-path.
+- **Key encoding caveat.** `joinPublicUrl` encodes raw keys; pass them
+  raw, not pre-encoded, or you'll double-encode (`%20` → `%2520`). The
+  signing path leaves encoding to the AWS SDK.
+
+## Provider quirks worth remembering
+
+- **`DeleteObjects` caps at 1000 keys per request.** The adapter chunks
+  longer key lists into separate requests (`S3_DELETE_BATCH_LIMIT`). If
+  one batch fails wholesale, the mapped error is attached to every key
+  in that batch and the next batch still runs.
+- **`defaultProviderMessage` is `@internal`.** Sibling adapters (`r2`
+  HTTP, `minio`, `digitalocean-spaces`, `storj`, `hetzner`, `akamai`,
+  `backblaze-b2`, `wasabi`, `scaleway`, `ovhcloud`, `idrive-e2`,
+  `vultr`, `filebase`, `exoscale`, `oracle-cloud`, `ibm-cos`, `tigris`,
+  `tencent`, `alibaba`, `yandex`) pass it so unknown errors read
+  "R2 error" / "MinIO error" / etc. instead of "S3 error". Don't expose
+  it in user-facing types — leave the JSDoc `@internal` tag alone.
+- **`forcePathStyle` is required by some S3-compatible services and
+  LocalStack.** Virtual-hosted style (`https://bucket.endpoint/key`)
+  fails when the endpoint can't put the bucket in the hostname; pass
+  `forcePathStyle: true` to switch to `https://endpoint/bucket/key`.
+- **AWS credential chain handles auth.** The `credentials` field is
+  optional. On EC2 / ECS / EKS / Lambda with an attached role, omit it
+  and the SDK picks up the instance credentials. Setting `credentials`
+  explicitly disables the chain for this client.
+- **`etag` is stripped of surrounding quotes.** S3 returns ETags as
+  `"abc"` (with literal `"`); `stripEtag` (lines 95-100) removes them so
+  callers see `abc`. Stay consistent if you add new ETag-returning
+  paths — don't surface raw quoted values.
+- **`signedUploadUrl` returns a different shape per `maxSize`.** With
+  `maxSize`, `{ method: "POST", url, fields }` (multipart form). Without,
+  `{ method: "PUT", url, headers? }`. The contract types are different
+  and clients must handle both — the unified `SignedUpload` type is a
+  union, not an intersection.
+- **`responseContentDisposition` always forces signing even when
+  `publicBaseUrl` is set.** See URL behavior above. This is deliberate:
+  silently dropping the override would be a stored-XSS regression.
+- **Stream uploads do a follow-up `head()`.** `PutObject`'s response
+  doesn't carry size, and stream bodies have no upfront length. The
+  adapter does a head probe so `UploadResult.size` and `lastModified`
+  are authoritative; if the probe fails, size falls back to `0`.
+- **Error classification keys.** `S3_NOT_FOUND_CODES = { NoSuchKey,
+  NotFound }`, `S3_UNAUTH_CODES = { AccessDenied }`,
+  `S3_CONFLICT_CODES = { PreconditionFailed }`. HTTP status buckets
+  (404 / 401-403 / 409-412) provide a fallback for SDK errors that
+  drop the code string. Anything else maps to `Provider`.
+
+## Testing approach
+
+Tests in [`packages/files-sdk/test/s3.test.ts`](../../test/s3.test.ts) use
+[`aws-sdk-client-mock`](https://www.npmjs.com/package/aws-sdk-client-mock):
+`mockClient(S3Client)` plus `s3Mock.on(PutObjectCommand).resolves(...)` /
+`.rejects(...)`. The pattern covers happy-path I/O, error mapping
+(`NoSuchKey` → `NotFound`, `AccessDenied` → `Unauthorized`,
+`PreconditionFailed` → `Conflict`, default → `Provider`), presigned URL
+output (asserts on `X-Amz-Signature=`, `X-Amz-Expires=…`, and
+`response-content-disposition=`), and the `DeleteObjectsCommand`
+chunking behaviour.
+
+`bun test` is the runner. There is no vitest config in this package — do
+not add one. The shared `FakeAdapter` at
+[`packages/files-sdk/test/fake-adapter.ts`](../../test/fake-adapter.ts) is
+used by `Files`-class tests, **not** by adapter unit tests; new s3 tests
+go in `s3.test.ts` and mock the AWS SDK directly.
+
+## Coding conventions
+
+- Named exports only — no default exports.
+- Errors wrap as `FilesError` via `wrapErr` (which delegates to
+  `mapS3Error` / `buildMapS3Error`). Pass through `FilesError` instances
+  unchanged — `mapS3Error` already short-circuits on them.
+- Body normalization goes through `normalizeBody` from
+  [`internal/core.ts`](../internal/core.ts); don't branch on `Body`
+  variants in the adapter.
+- Top-level regex literals only. The only one here is the inline
+  `replaceAll(/^"+|"+$/gu, "")` in `stripEtag` — keep new patterns at
+  module scope if they grow beyond a one-shot.
+- No `process.env` outside `readEnv` from
+  [`internal/env.ts`](../internal/env.ts). The bare `process.env`
+  references in `s3.test.ts` are test-only setup/teardown, not runtime
+  reads.
+- Forward `operationOpts.signal` to the AWS client as
+  `{ abortSignal: signal }`. Tests assert on this — don't drop it.
+- Use `createStoredFile` from
+  [`internal/stored-file.ts`](../internal/stored-file.ts) for every
+  `StoredFile` you return. Don't hand-roll body accessors.
+
+## Releases
+
+The repo uses Changesets. Behavioural changes here need a changeset
+(`bunx changeset`, then commit the entry under `.changeset/`). README
+updates and AGENTS.md edits don't require one. When a public type in
+`S3AdapterOptions` or `S3Adapter` changes, also flag the dependent
+S3-compatible wrapper packages — the change usually surfaces transitively
+through their re-exports.
+
+## Where to look next
+
+- User-facing docs: [`apps/web/content/docs/adapters/s3.mdx`](../../../../apps/web/content/docs/adapters/s3.mdx)
+- Source: [`packages/files-sdk/src/s3/index.ts`](index.ts)
+- Tests: [`packages/files-sdk/test/s3.test.ts`](../../test/s3.test.ts)
+- Provider catalog entry: [`packages/files-sdk/src/providers/index.ts`](../providers/index.ts)
+- Unified Adapter contract: [`packages/files-sdk/src/index.ts`](../index.ts)
+- Shared adapter helpers: [`packages/files-sdk/src/internal/core.ts`](../internal/core.ts)
+- Package SKILL: [`skills/files-sdk/SKILL.md`](../../../../skills/files-sdk/SKILL.md)
+- Package README: [`packages/files-sdk/README.md`](../../README.md)

--- a/packages/files-sdk/src/s3/CLAUDE.md
+++ b/packages/files-sdk/src/s3/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/packages/files-sdk/src/scaleway/AGENTS.md
+++ b/packages/files-sdk/src/scaleway/AGENTS.md
@@ -1,0 +1,220 @@
+# AGENTS.md — `files-sdk/scaleway`
+
+Guidance for coding agents working on the `scaleway` adapter. The unified
+`Adapter<Raw>` contract — call shapes, `FilesError`, `UrlOptions`,
+`SignUploadOptions`, body normalization — lives in
+[`../index.ts`](../index.ts); this file only documents scaleway-specific
+behavior. `scaleway()` is a thin wrapper around [`s3()`](../s3/index.ts)
+for Scaleway Object Storage's S3-compatible API, so the operation map,
+error mapping, and presign mechanics all live in the S3 adapter — see
+[`../s3/AGENTS.md`](../s3/AGENTS.md) for primitive-level details.
+Cross-references: [`README.md`](../../README.md),
+[`SKILL.md`](../../../../skills/files-sdk/SKILL.md).
+
+## Overview
+
+A thin shim that calls `s3()` with a Scaleway endpoint, Scaleway
+credentials, and a `defaultProviderMessage` of `"Scaleway error"` so
+callers don't see `"S3 error"` from a Scaleway-typed adapter. No
+per-method code here: every operation is forwarded by spread. The only
+scaleway-specific knobs are endpoint derivation from the region code, the
+credential env-var pair (`SCW_ACCESS_KEY` / `SCW_SECRET_KEY`), and the
+error-message relabel. The returned adapter's `raw` is the underlying
+`@aws-sdk/client-s3` `S3Client` — anything the AWS SDK can do against
+Scaleway (multipart, object lock, lifecycle) is one property access away.
+
+## Directory layout
+
+```text
+packages/files-sdk/src/scaleway/
+├── index.ts                   # scaleway() factory + ScalewayAdapterOptions
+├── AGENTS.md                  # this file
+└── CLAUDE.md                  # @AGENTS.md — Claude-Code re-export
+```
+
+Tests at [`../../test/scaleway.test.ts`](../../test/scaleway.test.ts);
+user-facing docs at
+[`../../../../apps/web/content/docs/adapters/scaleway.mdx`](../../../../apps/web/content/docs/adapters/scaleway.mdx).
+
+## Build, test, typecheck
+
+Run from `packages/files-sdk`:
+
+```bash
+bun test test/scaleway.test.ts   # adapter unit tests only
+bun test                          # full SDK suite
+bun run build                     # tsup → dist/, including dist/scaleway/
+bun run types                     # tsgo --noEmit (typecheck only)
+```
+
+The `scaleway` subpath is enumerated in
+[`../../package.json`](../../package.json)'s `exports` map — keep that
+entry in sync if the file layout changes.
+
+## Public surface
+
+Exports from [`index.ts`](./index.ts):
+
+- `scaleway(opts: ScalewayAdapterOptions): ScalewayAdapter` — primary factory.
+- `ScalewayAdapter` — type alias for `Adapter<S3Client>`; `raw` is the
+  underlying AWS SDK client.
+- `ScalewayAdapterOptions` — config interface (JSDoc on every field is
+  the source of truth; the docs MDX pulls it via `AutoTypeTable`).
+
+The adapter's `name` is `"scaleway"` — set after spreading the inner adapter so it overrides `"s3"`.
+
+## Authentication / configuration
+
+Required:
+
+- `bucket` — string. **No env fallback**; pass it explicitly.
+- `region` — Scaleway region code: `fr-par` (Paris), `nl-ams`
+  (Amsterdam), or `pl-waw` (Warsaw). **No env fallback** — missing region
+  throws `FilesError("Provider", …)` at construction with the hint
+  `'Pass `region` (e.g. "fr-par").'`. The region doubles as the SigV4
+  region and drives the default endpoint host.
+- Credentials — `accessKeyId` + `secretAccessKey`, passed in or sourced
+  from `SCW_ACCESS_KEY` / `SCW_SECRET_KEY`. Missing both throws
+  `FilesError("Provider", …)`. Generate keys in the Scaleway console
+  under *Identity and Access Management → API Keys*.
+
+Optional:
+
+- `endpoint` — overrides the derived `https://s3.${region}.scw.cloud`.
+  Use for private endpoints, custom DNS, or test doubles. Scaleway routes
+  by `Host` header — the SDK prepends the bucket subdomain in
+  virtual-hosted mode.
+- `forcePathStyle` — defaults to `false`. Virtual-hosted is canonical for
+  Scaleway; flip only for proxies that demand path-style addressing.
+- `publicBaseUrl` — origin used by `url()` when set; skips signing.
+  Natural value for public-read buckets is
+  `https://${bucket}.s3.${region}.scw.cloud`; a custom domain fronting the
+  bucket also works.
+- `defaultUrlExpiresIn` — default presigned-URL expiry in seconds;
+  defaults to `3600` via `DEFAULT_URL_EXPIRES_IN` in [`../internal/core.ts`](../internal/core.ts).
+
+No `SCW_REGION` or `SCW_BUCKET` env-var fallback. The provider catalog
+entry in [`../providers/index.ts`](../providers/index.ts) (search
+`slug: "scaleway"`) declares the same two credential env vars and treats
+`bucket` / `region` as explicit config. Env lookups go through
+[`readEnv`](../internal/env.ts) so the adapter is safe to import on
+runtimes without `process` (Cloudflare Workers without `nodejs_compat`).
+
+## Operation map
+
+`scaleway()` calls `s3()` with the resolved config and spreads the
+returned adapter, overriding only `name`. The implementations of
+`upload`, `download`, `head`, `exists`, `delete`, `deleteMany`, `copy`,
+`list`, `url`, and `signedUploadUrl` all live in
+[`../s3/index.ts`](../s3/index.ts) and are inherited unchanged —
+including `deleteMany`'s 1000-key chunking, `signedUploadUrl`'s
+PUT-vs-presigned-POST split on `maxSize`, and `exists`' 404-as-`false`
+classification. Provider errors flow through `mapS3Error` with the
+Scaleway fallback table — `Provider`-coded messages read
+`"Scaleway error"` instead of `"S3 error"` while preserving any
+server-side message on the wire.
+
+## URL behavior
+
+`url(key, opts?)` follows the standard signing-adapter rules:
+
+- Default: presigned `GetObject` URL, expiring after
+  `opts.expiresIn ?? defaultUrlExpiresIn` seconds. Issued against
+  `s3.<region>.scw.cloud`.
+- With `publicBaseUrl`: returns `${publicBaseUrl}/${key}` unsigned, via
+  `joinPublicUrl` from [`../internal/core.ts`](../internal/core.ts)
+  (URL-encodes path segments).
+- With `opts.responseContentDisposition`: always signs, even when
+  `publicBaseUrl` is set — a permanent CDN URL has no signature in which
+  to bind the override, and silently dropping it would be a stored-XSS
+  regression on user-uploaded HTML/SVG. See `resolveUrlStrategy` in
+  [`../internal/core.ts`](../internal/core.ts) for the rationale.
+
+Public-read buckets are reachable at
+`https://<bucket>.s3.<region>.scw.cloud` — that's the natural
+`publicBaseUrl` value. No built-in CDN; front with Scaleway Edge Services
+or a third-party CDN if you need caching.
+
+## Provider quirks worth remembering
+
+- **Region drives the endpoint, with no env-var fallback.** Buckets live
+  in exactly one of `fr-par`, `nl-ams`, or `pl-waw`, served from
+  `s3.<region>.scw.cloud`. The `region` field is the only way in — there
+  is no `SCW_REGION` shortcut, no cross-region replication primitive, and
+  picking the wrong region fails SigV4 signing before the request reaches
+  the bucket.
+- **API keys, not IAM roles.** The S3-compatible API exposes only static
+  access keys generated under *Identity and Access Management → API
+  Keys*. No instance metadata, no role-assumption — passing
+  `accessKeyId` / `secretAccessKey` (or the env-var pair) is the only
+  auth mode.
+- **No native CDN.** `publicBaseUrl` against the bucket's own
+  `s3.<region>.scw.cloud` origin works for public-read buckets but won't
+  give you caching. Use a custom domain only when a CDN fronts the bucket.
+- **Virtual-hosted style is canonical.** Scaleway routes by Host header;
+  `forcePathStyle: true` works but is rarely needed — leave it off unless
+  a proxy demands path-style.
+
+## Testing approach
+
+Unit tests at [`../../test/scaleway.test.ts`](../../test/scaleway.test.ts)
+cover:
+
+- Endpoint derivation from `region` (`fr-par`, `nl-ams`).
+- Explicit `endpoint` and `forcePathStyle` overrides reaching the inner
+  `S3Client` config.
+- Missing-region and missing-credential errors at construction.
+- `SCW_ACCESS_KEY` / `SCW_SECRET_KEY` env-var fallbacks.
+- `url()` presign default (with `X-Amz-Expires=3600` and the
+  `s3.fr-par.scw.cloud` host) and the `publicBaseUrl` short-circuit.
+- Operation delegation via `aws-sdk-client-mock`'s `mockClient(S3Client)`
+  — proves `upload` and `exists` reach the underlying client.
+- Error relabeling: `mapS3Error` invoked with the Scaleway messages table
+  returns `"Scaleway error"` for `Provider`.
+
+Add fixtures here rather than to `s3.test.ts` whenever a behavior depends
+on the scaleway-specific config (endpoint host, relabel, env-var name);
+shared S3 semantics belong in [`../../test/s3.test.ts`](../../test/s3.test.ts).
+
+## Coding conventions
+
+- Named exports only — `scaleway`, `ScalewayAdapter`,
+  `ScalewayAdapterOptions`.
+- Construction-time errors use
+  [`FilesError("Provider", …)`](../internal/errors.ts); operation errors
+  are the inner S3 adapter's responsibility — don't try-catch and rethrow
+  in this shim.
+- Pick up environment variables via [`readEnv`](../internal/env.ts).
+  Direct `process.env` access breaks Cloudflare Workers without
+  `nodejs_compat`.
+- Forward optional knobs with `...(opts.x !== undefined && { x: opts.x })`
+  so unset values fall through to AWS-SDK defaults rather than being
+  passed as explicit `undefined`. The current factory uses this pattern
+  for `forcePathStyle`, `publicBaseUrl`, and `defaultUrlExpiresIn`.
+- Spread the inner adapter, then override only `name` — preserves any
+  future additions to the `Adapter` interface that `s3()` picks up
+  automatically.
+- Top-level regex literals only. The current file has none; keep it
+  that way unless adding a real parser.
+
+## Releases
+
+Ships with the rest of the monorepo from
+[`../../package.json`](../../package.json). Behavioral changes (new
+options, default changes, error-shape changes) bump the `files-sdk`
+version and add an entry to [`../../CHANGELOG.md`](../../CHANGELOG.md);
+docs / test-only additions don't. The `scaleway` subpath is already
+declared in `exports` — no further wiring needed for new options.
+
+## Where to look next
+
+- Unified contract & `Adapter` interface: [`../index.ts`](../index.ts).
+- Inner S3 adapter: [`../s3/index.ts`](../s3/index.ts) + [`../s3/AGENTS.md`](../s3/AGENTS.md).
+- Shared helpers (URL strategy, body normalization, error-mapper factory): [`../internal/core.ts`](../internal/core.ts).
+- `FilesError` and codes: [`../internal/errors.ts`](../internal/errors.ts).
+- Env-var reader: [`../internal/env.ts`](../internal/env.ts).
+- Provider catalog entry (search `slug: "scaleway"`): [`../providers/index.ts`](../providers/index.ts).
+- User-facing docs: [`../../../../apps/web/content/docs/adapters/scaleway.mdx`](../../../../apps/web/content/docs/adapters/scaleway.mdx).
+- Package README: [`../../README.md`](../../README.md).
+- SKILL doc: [`../../../../skills/files-sdk/SKILL.md`](../../../../skills/files-sdk/SKILL.md).
+- Tests: [`../../test/scaleway.test.ts`](../../test/scaleway.test.ts).

--- a/packages/files-sdk/src/scaleway/CLAUDE.md
+++ b/packages/files-sdk/src/scaleway/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/packages/files-sdk/src/sharepoint/AGENTS.md
+++ b/packages/files-sdk/src/sharepoint/AGENTS.md
@@ -1,0 +1,263 @@
+# AGENTS.md — `files-sdk/sharepoint`
+
+Guidance for coding agents working on the `sharepoint` adapter. The
+unified `Adapter<Raw>` contract — call shapes, `FilesError`,
+`UrlOptions`, `SignUploadOptions`, body normalization — lives in
+[`../index.ts`](../index.ts); this file documents only the
+sharepoint-specific deviations. Read [`../../README.md`](../../README.md)
+and [`../../../../skills/files-sdk/SKILL.md`](../../../../skills/files-sdk/SKILL.md)
+first for the unified surface.
+
+`sharepoint()` is a **native** Microsoft Graph adapter in the sense that
+it owns site / library / drive resolution against Graph, then delegates
+every file operation to [`onedrive()`](../onedrive/index.ts) once a
+`driveId` is known. It is not an S3 shim and not a second Graph
+implementation — behavior changes in `onedrive` cascade here, and error
+messages from the inner layer are relabeled from `"OneDrive error"` to
+`"SharePoint error"`.
+
+## Overview
+
+SharePoint document libraries via Microsoft Graph. Virtual keys map to
+real folder paths inside a document library (same path-addressable model
+as OneDrive: `/drives/{driveId}/root:/folder/file.txt`). The adapter's
+job is SharePoint-shaped targeting: turn `siteUrl`, `hostname` /
+`sitePath`, `siteId`, and optional `documentLibrary` into a concrete
+`driveId`, then hand off to `onedrive({ client, driveId, … })`.
+
+Resolution is **lazy** (auth only at construction; first method triggers
+1–2 Graph calls), **memoized** on success, and **not** cached on failure.
+
+Optional peer dependencies (declared in
+[`../../package.json`](../../package.json)):
+`@microsoft/microsoft-graph-client`, `@azure/identity`.
+
+## Directory layout
+
+```text
+packages/files-sdk/src/sharepoint/
+├── index.ts                # adapter implementation
+├── AGENTS.md               # this file
+└── CLAUDE.md               # `@AGENTS.md`
+```
+
+Siblings outside this directory: tests at
+[`../../test/sharepoint.test.ts`](../../test/sharepoint.test.ts);
+user docs at
+[`../../../../apps/web/content/docs/adapters/sharepoint.mdx`](../../../../apps/web/content/docs/adapters/sharepoint.mdx);
+catalog entry at [`../providers/index.ts`](../providers/index.ts)
+(search `slug: "sharepoint"`).
+
+## Build, test, typecheck
+
+Run from `packages/files-sdk/`:
+
+```bash
+bun test test/sharepoint.test.ts   # resolution + delegation unit tests
+bun test test/onedrive.test.ts     # inner operation map (when touching delegation)
+bun test                           # full SDK suite
+bun run build                      # tsup → dist/sharepoint/
+bun run types                      # tsgo --noEmit (typecheck only)
+```
+
+Pinned tooling: **`bun test`** (not vitest) and **`tsgo`** (not `tsc`).
+The `sharepoint` subpath is enumerated in
+[`../../package.json`](../../package.json)'s `exports` map — keep it in
+sync with the file layout.
+
+## Public surface
+
+Exports from [`./index.ts`](./index.ts):
+
+- `sharepoint(opts?: SharePointAdapterOptions): SharePointAdapter` —
+  primary factory; auth is required (throws at construction if none
+  resolves), but site / library selection can be deferred to env vars
+  and still fails on first call if missing.
+- `SharePointAdapter` — alias for
+  `Adapter<Client> & { readonly rootFolderPath }`; no `basePath` on the
+  outer adapter (that lives on the inner `onedrive` instance after
+  resolution).
+- `SharePointAdapterOptions` — config interface; JSDoc on every field is
+  the source of truth (the docs MDX pulls it via `AutoTypeTable`).
+
+The adapter's `name` is `"sharepoint"`. `raw` is the **resolver**
+`Client` (the same instance passed into `onedrive({ client, driveId })`),
+not a separate client per layer.
+
+## Authentication / configuration
+
+Auth reuses [`buildAuthProvider`](../onedrive/index.ts) from the
+onedrive module. Four explicit shapes plus env fallback, evaluated in
+**priority order** (first match wins):
+
+1. **`client: Client`** — pre-built Graph client; escape hatch for MSAL,
+   NextAuth, or a broker you already wired.
+2. **`clientCredentials: { tenantId, clientId, clientSecret }`** —
+   app-only via `@azure/identity`'s `ClientSecretCredential`. Typical for
+   unattended SharePoint access. Scoped to
+   `https://graph.microsoft.com/.default`.
+3. **`oauth: { clientId, clientSecret, refreshToken, tenantId? }`** —
+   delegated refresh-token flow (same hand-rolled credential as
+   `onedrive()`).
+4. **`accessToken: string | (() => string | Promise<string>)`** — static
+   or dynamic bearer; the adapter does not cache callables.
+
+**Env fallback:** `SHAREPOINT_ACCESS_TOKEN` → `ONEDRIVE_ACCESS_TOKEN`;
+credential triple prefers `SHAREPOINT_*` per field then `ONEDRIVE_*`.
+Missing auth throws at construction (`sharepoint: missing auth. …`).
+
+Other knobs forwarded to the inner `onedrive()` after resolution:
+
+- `rootFolderPath` — logical bucket root inside the library; must
+  already exist. Trimmed on the outer `rootFolderPath` getter (leading /
+  trailing slashes) even before resolution completes.
+- `publicByDefault` — gates `url()` and optional post-upload sharing
+  links (see [URL behavior](#url-behavior)).
+- `copyTimeoutMs` — async copy poll timeout on the inner adapter
+  (default `60_000` ms in `onedrive`).
+
+Env lookups use [`readEnv`](../internal/env.ts) for Workers-safe imports.
+
+## Site and drive resolution
+
+Pass **at most one** site selector. `driveId` bypasses site resolution
+entirely.
+
+### Site selection (required unless `driveId` is set)
+
+| Option | Env fallback | Graph call |
+| ------ | ------------ | ---------- |
+| `siteId` | `SHAREPOINT_SITE_ID` | Use as-is (Graph triple form `<host>,<guid>,<guid>`) |
+| `siteUrl` | `SHAREPOINT_SITE_URL` | Parse URL → `hostname` + `sitePath`, then lookup |
+| `hostname` + optional `sitePath` | `SHAREPOINT_HOSTNAME` | Lookup by host and path |
+
+**`siteUrl`** must parse as a URL or throws `Provider`. Lookup:
+`GET /sites/{hostname}:/{sitePath}` when path present, else
+`GET /sites/{hostname}`. Example:
+`https://contoso.sharepoint.com/sites/marketing` →
+`/sites/contoso.sharepoint.com:/sites/marketing`. Missing `id` or site
+selector throws `Provider` on first call.
+
+### Drive selection (after site, unless `driveId` is set)
+
+| Option | Env fallback | Graph call |
+| ------ | ------------ | ---------- |
+| `driveId` | `SHAREPOINT_DRIVE_ID` | Skip site + library resolution |
+| `documentLibrary` | `SHAREPOINT_DOCUMENT_LIBRARY` | `GET /sites/{siteId}/drives`, match `name` |
+| (omit library) | — | `GET /sites/{siteId}/drive` (default library) |
+
+Missing library names throw `Provider` with available drive names.
+Resolution and delegation share one `resolverClient` passed to
+`onedrive({ client, driveId, … })`.
+
+## Operation map
+
+After resolution, every method delegates to the inner `OneDriveAdapter`
+via a `call()` wrapper that relabels `FilesError` messages containing
+`"OneDrive error"` → `"SharePoint error"`. Non-`FilesError` failures and
+messages without that substring pass through unchanged.
+
+Inherited from [`onedrive`](../onedrive/index.ts) (see
+[`../onedrive/AGENTS.md`](../onedrive/AGENTS.md) for primitives):
+
+- `upload` — simple `PUT …/content` up to **250 MiB**
+  (`SIMPLE_UPLOAD_LIMIT_BYTES`); `metadata` and `cacheControl` throw.
+- `download` / `head` / `exists` / `delete` / `copy` / `list` — same
+  Graph paths and semantics as OneDrive on the resolved drive.
+- `delete` — soft delete (recycle bin), not permanent purge.
+- `copy` — async Graph copy with monitor-URL polling until
+  `copyTimeoutMs`.
+- `list` — non-recursive children listing; `prefix` filtered
+  client-side per page.
+
+SharePoint adds **no** extra operations — only resolution + relabel.
+
+## Upload sessions
+
+`signedUploadUrl()` → inner `POST …/createUploadSession`, returns
+`{ method: "PUT", url }` (Graph's pre-authenticated session URL for
+chunked `Content-Range` uploads, not an S3 presign). Use above 250 MiB
+or drop to `raw`.
+
+## URL behavior
+
+Sharing links are Graph `createLink` calls on the inner adapter — not
+signed GET URLs.
+
+- **`publicByDefault: false` (default)** — `url()` throws `Provider`
+  (inner message mentions `url()`; relabeled to SharePoint wording when
+  applicable). Use `download()` for private library items.
+- **`publicByDefault: true`** — `url()` and post-upload linking use
+  `POST {item}/createLink` with `{ scope: "anonymous", type: "view" }`,
+  returning `link.webUrl`. Subject to tenant / site link-sharing policy;
+  blocked anonymous sharing surfaces as `Unauthorized` via
+  `mapGraphError`.
+- **`expiresIn` is ignored** on share links (tenant default expiry).
+- **`responseContentDisposition` always throws** on the inner layer —
+  Graph has no Content-Disposition override on share links.
+
+## Provider quirks worth remembering
+
+- **Late site/library failures** — only auth is eager; bad `siteUrl` or
+  missing library throws on first call.
+- **`raw` before first call** — resolution has not run; use adapter
+  methods or known `driveId`.
+- **`siteId` here ≠ `onedrive({ siteId })`** — SharePoint resolves a
+  site then a library; OneDrive's option jumps to `/sites/{id}/drive`.
+- **`driveId` skips `/sites/`** — pass when you already have the
+  library drive ID.
+- **Library names** — exact match on `drive.name` from `/drives`.
+- **Delegated limits** — see
+  [`sharepoint.mdx`](../../../../apps/web/content/docs/adapters/sharepoint.mdx)
+  Limitations (250 MiB upload, soft delete, async copy, etc.).
+- **Relabel** — only `FilesError` messages containing `"OneDrive error"`.
+
+## Testing approach
+
+[`../../test/sharepoint.test.ts`](../../test/sharepoint.test.ts) fakes
+Graph via patched `Client.initWithMiddleware`. Covers resolution paths,
+env fallbacks, memoization / retry, delegation of all operations,
+`publicByDefault` / `copyTimeoutMs`, and error relabel. Add resolution
+fixtures here; onedrive tests own the auth matrix and operation map.
+
+## Coding conventions
+
+- Named exports only — `sharepoint`, `SharePointAdapter`,
+  `SharePointAdapterOptions`. No default exports.
+- Prefix construction and resolution errors with `sharepoint:` via
+  [`FilesError("Provider", …)`](../internal/errors.ts).
+- Use [`readEnv`](../internal/env.ts) for env vars — never `process.env`
+  directly.
+- Keep resolution helpers (`resolveSiteId`, `resolveDriveId`,
+  `parseSiteUrl`, `relabelError`) private; auth construction stays in
+  `buildOneDriveAuthOptions` mirroring onedrive priority.
+- When extending options, forward new onedrive knobs through the
+  `onedrive({ … })` call inside `resolve()` and document env aliases in
+  [`../providers/index.ts`](../providers/index.ts) if added.
+- Top-level regex literals only (`parseSiteUrl` uses none; `rootFolderPath`
+  getter uses `/^\/+|(?<!\/)\/+$/gu`).
+
+## Releases
+
+The repo uses Changesets. Behavioral changes need a changeset
+(`bunx changeset`, committed under `.changeset/`); new options, resolution
+logic, auth fallbacks, and error-shape changes bump `files-sdk`.
+README / AGENTS.md edits don't. Changes to
+[`../onedrive/index.ts`](../onedrive/index.ts) that affect delegated
+behavior should be called out in sharepoint release notes when user-visible.
+
+## Where to look next
+
+- Source [`./index.ts`](./index.ts); tests
+  [`../../test/sharepoint.test.ts`](../../test/sharepoint.test.ts); docs
+  [`../../../../apps/web/content/docs/adapters/sharepoint.mdx`](../../../../apps/web/content/docs/adapters/sharepoint.mdx).
+- Inner adapter [`../onedrive/index.ts`](../onedrive/index.ts) +
+  [`../onedrive/AGENTS.md`](../onedrive/AGENTS.md).
+- Provider catalog (`slug: "sharepoint"`):
+  [`../providers/index.ts`](../providers/index.ts).
+- Unified contract [`../index.ts`](../index.ts); shared helpers
+  [`../internal/core.ts`](../internal/core.ts),
+  [`../internal/errors.ts`](../internal/errors.ts),
+  [`../internal/env.ts`](../internal/env.ts); package
+  [`../../README.md`](../../README.md); SKILL
+  [`../../../../skills/files-sdk/SKILL.md`](../../../../skills/files-sdk/SKILL.md).

--- a/packages/files-sdk/src/sharepoint/CLAUDE.md
+++ b/packages/files-sdk/src/sharepoint/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/packages/files-sdk/src/storj/AGENTS.md
+++ b/packages/files-sdk/src/storj/AGENTS.md
@@ -1,0 +1,218 @@
+# AGENTS.md — `files-sdk/storj`
+
+Guidance for coding agents working inside the `files-sdk/storj` subpath.
+The unified `Adapter<Raw>` contract lives in
+[`../index.ts`](../index.ts) — this file documents only the
+storj-specific deviations. The adapter is a thin wrapper around the
+`s3()` factory pointed at Storj's S3-compatible Gateway-MT, so most
+runtime behavior is inherited from [`../s3/`](../s3/). Cross-reference
+the [README](../../README.md) and the
+[`files-sdk` skill](../../../../skills/files-sdk/SKILL.md) for
+package-wide conventions.
+
+## Overview
+
+`files-sdk/storj` exposes a single `storj()` factory: configure it with
+a bucket and Storj S3-gateway credentials, and get back an
+`Adapter<S3Client>` that talks to Storj DCS as if it were S3. Three
+things change versus a raw `s3({ ... })` call:
+
+- The endpoint defaults to `https://gateway.storjshare.io` (Gateway MT —
+  Storj's hosted multi-tenant gateway). Override with a self-hosted
+  Gateway ST URL if you run your own.
+- `forcePathStyle` defaults to `true` (the gateway routes path-style)
+  and the SigV4 signing region defaults to `us-east-1` (the gateway
+  ignores region for routing, but SigV4 requires _some_ region).
+- The inner s3 adapter's unknown-error fallback is relabeled to
+  `"Storj error"` via `defaultProviderMessage`, so callers don't see
+  `"S3 error"` from a Storj endpoint.
+
+Everything else — body normalization, URL semantics, presigned
+uploads, `deleteMany` chunking, error classification — is the s3
+adapter's behavior. Read [`../s3/index.ts`](../s3/index.ts) when
+chasing a protocol-level question.
+
+## Directory layout
+
+```
+packages/files-sdk/src/storj/
+└── index.ts         # storj() factory + StorjAdapterOptions
+```
+
+Tests live one level up at
+[`../../test/storj.test.ts`](../../test/storj.test.ts) — the package
+keeps all adapter tests in a shared `test/` directory rather than
+colocating.
+
+## Build, test, typecheck
+
+```bash
+bun test test/storj.test.ts   # focused storj suite
+bun test                      # full suite, run from packages/files-sdk
+bun run build                 # tsup ESM bundle → dist/
+bun run types                 # tsgo --noEmit
+```
+
+`build` and `types` cover the whole package; there's no per-adapter
+script. The `exports` map already lists `./storj`, so a fresh build
+picks up changes here automatically.
+
+## Public surface
+
+[`./index.ts`](./index.ts) exports three names:
+
+- `storj(opts: StorjAdapterOptions): StorjAdapter` — the factory.
+  Throws `FilesError("Provider", "storj adapter: missing credentials…")`
+  at construction time when neither option nor env var supplies the
+  S3-gateway key pair.
+- `StorjAdapterOptions` — the option type. JSDoc on each field is
+  rendered into the docs site by `<AutoTypeTable>` in
+  [`storj.mdx`](../../../../apps/web/content/docs/adapters/storj.mdx),
+  so keep those comments user-facing.
+- `StorjAdapter` — type alias for `Adapter<S3Client>`. The native
+  client is reachable via `files.raw` (typed as `S3Client`) for any
+  Storj/S3 feature the unified surface doesn't expose.
+
+The returned adapter sets `name: "storj"` so it's distinguishable from
+the underlying `s3()` instance in logs and telemetry.
+
+## Authentication / configuration
+
+| Option                | Required | Default                            | Notes                                                                                   |
+| --------------------- | -------- | ---------------------------------- | --------------------------------------------------------------------------------------- |
+| `bucket`              | yes      | —                                  | Storj bucket name. Scopes every operation.                                              |
+| `accessKeyId`         | yes\*    | `STORJ_ACCESS_KEY_ID`              | Gateway-issued S3-style key, _not_ a Storj access grant.                                |
+| `secretAccessKey`     | yes\*    | `STORJ_SECRET_ACCESS_KEY`          | Gateway-issued secret.                                                                  |
+| `endpoint`            | no       | `https://gateway.storjshare.io`    | Gateway MT (hosted). Pass a Gateway ST URL when self-hosting.                           |
+| `region`              | no       | `us-east-1`                        | Used for SigV4 signing only — the gateway ignores it for routing.                       |
+| `forcePathStyle`      | no       | `true`                             | Gateway routes path-style. Flip off only if you've fronted it with subdomain routing.   |
+| `publicBaseUrl`       | no       | —                                  | Storj Linksharing origin for unsigned reads (see [URL behavior](#url-behavior)).        |
+| `defaultUrlExpiresIn` | no       | `3600`                             | Fallback expiry, in seconds, for presigned `url()` results when `publicBaseUrl` unset.  |
+
+\* Pass explicitly or set the matching env var. The factory reads env
+via [`readEnv`](../internal/env.ts) so it stays safe on runtimes
+without a `process` global; if both are missing, construction throws
+rather than letting the inner s3 client raise on the first request.
+Options are spread conditionally into the inner `s3({ ... })` call so
+an undefined value never clobbers the s3 adapter's own default. The
+provider-catalog row in [`../providers/index.ts`](../providers/index.ts)
+declares the same env contract via the shared `s3Compatible(...)`
+helper.
+
+## Operation map
+
+`storj()` returns the inner s3 adapter verbatim, overriding only `name`
+(`return { ...inner, name: "storj" }`). Every method (`upload`,
+`download`, `head`, `exists`, `delete`, `deleteMany`, `copy`, `list`,
+`url`, `signedUploadUrl`) is the s3 implementation talking to the
+gateway. Inherited behavior worth calling out:
+
+- `deleteMany` uses S3's native `DeleteObjects` and chunks at 1000 keys
+  per request — the gateway accepts the same batch limit.
+- `exists()` distinguishes `NotFound` from auth / transport failures the
+  same way the s3 adapter does; only `NotFound` returns `false`.
+- `signedUploadUrl({ maxSize })` returns a presigned POST form with a
+  `content-length-range` policy; without `maxSize` it falls back to a
+  presigned PUT with no size limit.
+- `copy()` issues a `CopyObject` through the gateway — server-side, no
+  read-then-write roundtrip.
+
+If you need storj-specific behavior, prefer wrapping the returned
+adapter at this layer rather than forking the s3 implementation.
+
+## URL behavior
+
+`url(key, opts?)` follows the s3 adapter's two-state strategy
+(`resolveUrlStrategy` in [`../internal/core.ts`](../internal/core.ts)):
+
+- **No `publicBaseUrl`** → presigned `GetObject` against the gateway,
+  signed with the gateway's SigV4 (Storj has no native URL signer),
+  expiring after `opts.expiresIn ?? defaultUrlExpiresIn ?? 3600` seconds.
+- **`publicBaseUrl` set** → unsigned concat: `${publicBaseUrl}/${key}`.
+  For Storj, the canonical value is a Linksharing prefix like
+  `https://link.storjshare.io/raw/<accessGrant>/<bucket>` — generate
+  one with `uplink share --url <bucket>/<prefix>`. Linksharing URLs
+  are permanent and don't carry signatures.
+- **`responseContentDisposition` set** → forces the signing path even
+  when `publicBaseUrl` is configured, since a permanent Linksharing
+  URL has no signature to bind the override to.
+
+Callers are responsible for URL-encoding key segments — `joinPublicUrl`
+in `../internal/core.ts` handles encoding for both paths.
+
+## Provider quirks worth remembering
+
+- **Access keys ≠ access grants.** What Storj calls an "access grant"
+  is the satellite-issued macaroon used by `uplink`. The S3 gateway
+  expects a derived S3-style `accessKeyId` / `secretAccessKey` pair
+  registered with the gateway, which translates server-side. Don't
+  paste a grant into either field.
+- **Region is a SigV4 ritual.** `us-east-1` exists only to satisfy the
+  signer — the gateway ignores it. Override only if another tool needs
+  a matching value.
+- **Linksharing is per-access-grant.** `uplink share --url` mints a
+  prefix tied to whatever scope (`bucket`, `bucket/prefix/`,
+  read-only, expiring) you granted. Treat the URL as sensitive — anyone
+  with it can read everything that grant covers.
+- **Errors are relabeled, not reclassified.** Status codes still map
+  through the same `S3_NOT_FOUND_CODES` / `S3_UNAUTH_CODES` /
+  `S3_CONFLICT_CODES` sets in [`../s3/index.ts`](../s3/index.ts); only
+  the unknown-error fallback message changes to `"Storj error"`.
+
+## Testing approach
+
+[`../../test/storj.test.ts`](../../test/storj.test.ts) covers the
+adapter's narrow surface:
+
+- Default-config plumbing — Gateway-MT endpoint, `forcePathStyle: true`,
+  `us-east-1` region — read off the inner `S3Client`'s resolved config.
+- `region` and `endpoint` overrides flow through to the inner client.
+- Missing credentials throw at factory time with a `/credentials/`
+  message.
+- `url()` returns a presigned GET (with `X-Amz-Signature=…` and
+  `X-Amz-Expires=3600`) by default, and switches to Linksharing-style
+  concat when `publicBaseUrl` is set.
+- `Files` integration via `aws-sdk-client-mock` — `upload` and `exists`
+  go through `PutObjectCommand` and `HeadObjectCommand` like raw s3.
+- `mapS3Error` is exercised directly with the storj message table to
+  confirm the `Provider` fallback says `"Storj error"`.
+
+When adding tests, follow the same pattern: stub `S3Client` with
+`mockClient` rather than reaching for a live gateway.
+
+## Coding conventions
+
+- Named exports only (`storj`, `StorjAdapter`, `StorjAdapterOptions`).
+- All env reads go through [`readEnv`](../internal/env.ts) — don't
+  touch `process.env` directly.
+- Spread options into the inner `s3()` call conditionally
+  (`...(opts.publicBaseUrl && { publicBaseUrl: opts.publicBaseUrl })`)
+  so leaving an option `undefined` preserves the s3 adapter's default.
+- Construction-time errors throw `FilesError("Provider", …)` with a
+  message that names the adapter (`"storj adapter: …"`), matching the
+  pattern `s3()` uses for its missing-region check.
+- Keep the factory boring: it's a config translator, not a behavior
+  layer. If a storj-only quirk surfaces, prefer a flag on the inner
+  s3 adapter over branching inside `storj()`.
+
+## Releases
+
+This package ships on the repo-wide Changesets schedule. Behavioural
+changes need a changeset (`bun changeset`, pick `files-sdk`) describing
+the user-visible effect. Adapter additions are minor bumps;
+storj-specific bug fixes are patches. AGENTS.md, README, and docs-only
+edits don't need a changeset.
+
+## Where to look next
+
+- User-facing docs: [`../../../../apps/web/content/docs/adapters/storj.mdx`](../../../../apps/web/content/docs/adapters/storj.mdx)
+- Underlying primitive: [`../s3/index.ts`](../s3/index.ts) — `s3()`,
+  `S3AdapterOptions`, `mapS3Error`, default error code sets.
+- Adapter contract: [`../index.ts`](../index.ts) — `Adapter<Raw>`,
+  `UploadOptions`, `UrlOptions`, `SignUploadOptions`.
+- Shared helpers used via s3: [`../internal/core.ts`](../internal/core.ts)
+  (`resolveUrlStrategy`, `joinPublicUrl`, `normalizeBody`).
+- Error class: [`../internal/errors.ts`](../internal/errors.ts).
+- Provider catalog row: [`../providers/index.ts`](../providers/index.ts)
+  — search for `slug: "storj"`.
+- Tests: [`../../test/storj.test.ts`](../../test/storj.test.ts).

--- a/packages/files-sdk/src/storj/CLAUDE.md
+++ b/packages/files-sdk/src/storj/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/packages/files-sdk/src/supabase/AGENTS.md
+++ b/packages/files-sdk/src/supabase/AGENTS.md
@@ -1,0 +1,300 @@
+# AGENTS.md — `files-sdk/supabase`
+
+Guidance for coding agents working inside the Supabase Storage adapter.
+Every adapter implements the same `Adapter<Raw>` contract from
+[`../index.ts`](../index.ts); this file documents only
+`supabase`-specific deviations. The package-wide
+[README.md](../../README.md) and the agent skill at
+[`skills/files-sdk/SKILL.md`](../../../../skills/files-sdk/SKILL.md)
+cover the unified API — read them first.
+
+`supabase` is a **native** adapter: it talks directly to
+[Supabase Storage](https://supabase.com/docs/guides/storage) through
+`@supabase/storage-js`, not through an S3-compatible endpoint. Every
+method calls a Supabase primitive (`upload`, `download`, `list`,
+`remove`, `copy`, `info`, `getPublicUrl`, `createSignedUrl`,
+`createSignedUploadUrl`). That gives us native bulk delete, server-side
+copy, and the public/signed/CDN URL trichotomy at the cost of
+duplicating body normalization and error mapping the S3 path gets for
+free.
+
+## Overview
+
+One `StorageClient` per adapter instance; one
+`bucketRef = client.from(bucket)` per call. Buckets must already exist
+— this SDK never calls `createBucket`. Bucket visibility (public vs
+private) is a server-side property; the adapter mirrors it through
+`opts.public` so `url()` knows which primitive to mint.
+
+Peer dependency (optional, declared in
+[`../../package.json`](../../package.json)): `@supabase/storage-js`.
+`@supabase/supabase-js` is **not** required — pass a bare
+`StorageClient` or any `{ storage: StorageClient }` and the adapter
+picks the right thing.
+
+## Directory layout
+
+```text
+packages/files-sdk/src/supabase/
+├── index.ts                # adapter implementation
+├── AGENTS.md               # this file
+└── CLAUDE.md               # `@AGENTS.md`
+```
+
+Sibling files:
+
+- Tests: [`packages/files-sdk/test/supabase.test.ts`](../../test/supabase.test.ts)
+- User docs: [`apps/web/content/docs/adapters/supabase.mdx`](../../../../apps/web/content/docs/adapters/supabase.mdx)
+- Provider catalog entry: [`packages/files-sdk/src/providers/index.ts`](../providers/index.ts) (search for `slug: "supabase"`)
+
+## Build, test, typecheck
+
+```bash
+# from packages/files-sdk/
+bun test test/supabase.test.ts      # this adapter's tests
+bun test                            # full suite
+bun run build                       # tsup ESM bundle -> dist/supabase/
+bun run types                       # tsgo --noEmit
+```
+
+`bun test` (not vitest) and `tsgo` (not `tsc`) are pinned. Per-subpath
+bundle output is `dist/supabase/index.{js,d.ts}` per the `exports` map
+in [`../../package.json`](../../package.json).
+
+## Public surface
+
+Defined in [`index.ts`](./index.ts):
+
+- `supabase(opts: SupabaseAdapterOptions): SupabaseAdapter` — factory.
+- `SupabaseAdapterOptions` — `bucket`, `client`, `url`, `key`, `public`,
+  `publicBaseUrl`, `defaultUrlExpiresIn`. JSDoc on every field is the
+  source of truth; the docs MDX pulls it via `AutoTypeTable`.
+- `SupabaseAdapter` — `Adapter<StorageClient> & { readonly bucket }`.
+  `raw` is the underlying `StorageClient` (or whatever was passed via
+  `client`).
+- `mapSupabaseError(err?): FilesError` — exported for callers reusing
+  the same classification on errors pulled off `raw`. The optional
+  argument matches `@supabase/storage-js`'s `{ error: null }` shape
+  that some call sites pass straight through.
+
+## Authentication / configuration
+
+Three credential modes, in precedence order:
+
+1. **`opts.client`** — wins over everything. Accepts a `StorageClient`
+   directly or any `{ storage: StorageClient }` shape (a
+   `SupabaseClient` from `@supabase/supabase-js`). When set, **no**
+   `StorageClient` is constructed and **no** env vars are read.
+2. **`opts.url` + `opts.key`** — explicit. `url` is the project URL
+   (`https://xxxx.supabase.co`); the adapter appends `/storage/v1`,
+   strips trailing slashes, and does not duplicate the suffix when
+   already present.
+3. **Env fallbacks** — URL: `SUPABASE_URL`, then
+   `NEXT_PUBLIC_SUPABASE_URL`. Key: `SUPABASE_SERVICE_ROLE_KEY`, then
+   `SUPABASE_KEY`, then `NEXT_PUBLIC_SUPABASE_ANON_KEY`.
+
+The service-role key is required for write operations on RLS-protected
+buckets; the anon key works for public buckets and any operations RLS
+policies permit. Missing both throws `FilesError("Provider", …)` at
+construction with a message naming every env alias. `bucket` has **no
+env fallback**. Env lookups go through
+[`readEnv`](../internal/env.ts) so the adapter is safe on runtimes
+without `process` (Cloudflare Workers without `nodejs_compat`). The
+constructed client gets both `Authorization: Bearer ${key}` and
+`apikey: ${key}` headers — Supabase Storage requires both.
+
+## Operation map
+
+Every method dispatches via `bucketRef = client.from(bucket)` and routes
+errors through `mapSupabaseError`.
+
+- `upload` — `bucketRef.upload(key, data, { contentType,
+  upsert: true, cacheControl?, metadata? })`. Body runs through a
+  **local** `normalizeBody` (not the shared one) because Supabase
+  accepts `Blob` natively but ignores `FileOptions.contentType` for
+  `Blob`/`File` — those go multipart and use the Blob's own `type`.
+  When the caller passes an override `contentType` for a `Blob`, the
+  adapter drains it to a `Uint8Array` so the override sticks.
+  `ReadableStream` bodies are forwarded with `duplex: "half"`; the
+  adapter follows up with `info()` to populate authoritative
+  `size`/`etag`/`lastModified` since the upload response carries none.
+- `download` — `bucketRef.download(key)` for buffered mode,
+  `.download(key).asStream()` for streaming. Buffered mode falls back
+  to `info()` when `Blob.type` comes back empty (Supabase sometimes
+  doesn't echo Content-Type). Stream mode always issues an `info()` for
+  metadata since the stream form returns no headers. Both forward
+  `AbortSignal` via the trailing `FetchParameters` slot.
+- `head` — `bucketRef.info(key)`. No separate HEAD primitive exists;
+  `info()` is the cheapest metadata probe. The returned `StoredFile`'s
+  body accessors lazily issue a `download()` on first use.
+- `exists` — `bucketRef.info(key)` and classify the error.
+  `mapped.code === "NotFound"` returns `false`; anything else
+  (auth, transport) rethrows.
+- `delete` — `bucketRef.remove([key])`. Idempotent: empty array (not
+  an error) on missing key, matching S3/Azure's silent-on-missing.
+- `deleteMany` — **native bulk** via `bucketRef.remove(keys)` in one
+  request. No documented per-request key cap, so the whole list goes
+  through unchunked. The API surfaces only a single batch-level error
+  rather than per-key failures; on failure the mapped error is attached
+  to every input key. `stopOnError: true` falls back to
+  `deleteManyWithFallback` (sequential per-key `remove`) so the stop
+  point lands on a specific key.
+- `copy` — `bucketRef.copy(from, to)` server-side. Supabase also
+  exposes `.move(from, to)` but the unified API has no `move` — copy +
+  delete is the caller's pattern.
+- `list` — `bucketRef.list(prefix, { limit, offset })`. **Offset/limit,
+  not cursor-based.** The adapter encodes the next offset as a numeric
+  string cursor so it threads through the unified `cursor` field,
+  emitting it only when the page came back full. Non-numeric cursors
+  throw `FilesError("Provider", …)` at the boundary. Supabase returns
+  just the leaf `name` per item; the adapter re-prefixes so the
+  returned `key` round-trips through `head`/`download`/`delete`. Each
+  item's body factory issues a fresh `download()` on demand.
+- `url` — three-state strategy (see below).
+- `signedUploadUrl` — `bucketRef.createSignedUploadUrl(key,
+  { upsert: true })`. Always returns
+  `{ method: "PUT", url, headers: { "Content-Type"?, "x-upsert": "true" } }`.
+  Never POST.
+
+## URL behavior
+
+Supabase has more URL strategies than the standard two-state
+`resolveUrlStrategy` helper supports, so the adapter implements the
+precedence directly. In order:
+
+1. **`opts.responseContentDisposition` always forces signing** — even
+   when `publicBaseUrl` or `public: true` is set. Without a signature
+   there's nowhere to bind the override, and silently dropping it would
+   be a stored-XSS regression on user-uploaded HTML/SVG.
+2. **`publicBaseUrl`** — `${publicBaseUrl}/${key}` via `joinPublicUrl`
+   from [`../internal/core.ts`](../internal/core.ts). Use when a CDN
+   sits in front of the project. Skips both signing and
+   `getPublicUrl()`.
+3. **`public: true`** — `bucketRef.getPublicUrl(key)`. Permanent,
+   unsigned URL at the project's storage origin. The adapter can't
+   verify bucket visibility from the client; setting `public: true` on
+   a private bucket means reads 4xx.
+4. **Default (private)** — `bucketRef.createSignedUrl(key, expiresIn,
+   { download? })`. `expiresIn` falls through per-call →
+   `opts.defaultUrlExpiresIn` → `DEFAULT_URL_EXPIRES_IN` (3600s).
+   `responseContentDisposition` binds as the Supabase API's `download`
+   option (their name, not ours).
+
+## Provider quirks worth remembering
+
+- **Bucket visibility is server-side, not per-key.** Supabase exposes
+  no client API to detect public-vs-private; the adapter mirrors the
+  bucket flag through `opts.public` and trusts the caller. Get it
+  wrong and reads 4xx.
+- **`signedUploadUrl` ignores `expiresIn`.** Supabase fixes the TTL at
+  2 hours server-side and offers no per-URL override. The field is
+  accepted (the unified contract requires it) but silently dropped.
+- **`maxSize` on `signedUploadUrl` throws.** No `content-length-range`
+  equivalent — no way to enforce a max upload size at the URL level.
+  The adapter throws `FilesError("Provider", …)` rather than silently
+  no-op (same honest-API stance Azure takes for the same gap). Enforce
+  caps via the bucket-level file size limit in the Supabase dashboard
+  or at a gateway in front of the signed URL.
+- **Blob uploads with an override `contentType` are drained.** Supabase
+  sends `Blob`/`File` as multipart and uses the Blob's own `type` for
+  the part. The adapter drains to a `Uint8Array` when an override
+  differs, so the caller's `contentType` always wins.
+- **`ReadableStream` uploads need `duplex: "half"`.** Set automatically
+  when `data instanceof ReadableStream`; without it undici refuses to
+  upload streams. Stream uploads also do a follow-up `info()` for
+  size/etag/lastModified since the upload response carries none.
+- **`list()` returns leaf names, not full keys.** The adapter
+  re-prefixes them so the returned `key` round-trips through every
+  other method. Watch this if you add new list paths.
+- **`info()` may not exist on older deployments.** Every non-essential
+  `info()` call goes through `safeInfo`, which swallows both errors
+  and exceptions; downstream value falls back to `0` /
+  `"application/octet-stream"` rather than failing the call.
+- **`etag` is stripped of surrounding quotes** (Supabase returns
+  `"abc"` with literal `"`; `stripEtag` removes them, matching S3).
+- **`metadata` round-trips best-effort.** The SDK threads
+  `FileOptions.metadata` through, but the API may or may not echo it
+  back via `info()`/`list()`. Don't rely on it for anything the bucket
+  can't reconstruct from key + body.
+- **RLS sits between the API and the bucket.** Even with the service
+  role, RLS policies on `storage.objects` apply (usually bypassed when
+  the service-role key is configured). Anon-key callers need matching
+  policies for every operation — including `list`, which surfaces as a
+  SELECT on `storage.objects`. RLS denials surface as `Unauthorized`.
+- **Error classification keys.** `SUPABASE_NOT_FOUND_CODES =
+  { NotFound, NoSuchKey }`, `SUPABASE_UNAUTH_CODES = { InvalidJWT,
+  Unauthorized, AccessDenied, InvalidKey }`, `SUPABASE_CONFLICT_CODES =
+  { Duplicate, AlreadyExists }`. HTTP status buckets (404 / 401-403 /
+  409-412) provide a fallback. `extract` prefers the string
+  `statusCode` (the server's code name); a numeric `statusCode` is
+  treated as the HTTP status.
+
+## Testing approach
+
+Tests in [`../../test/supabase.test.ts`](../../test/supabase.test.ts)
+use `mock.module("@supabase/storage-js", ...)` to swap in a
+`StorageClientStub` plus a hand-built `bucketRef` of `bun:test` mocks
+(one per primitive). The pattern covers construction precedence
+(explicit `client` skips both `StorageClient` construction and env
+reads; `/storage/v1` suffix handling; trailing-slash stripping), body
+handling for every `Body` variant including `Blob` with and without
+override and `ReadableStream` with `duplex: "half"`, the three-state
+`url()` strategy plus the `responseContentDisposition`-forces-signing
+rule on both `publicBaseUrl` and `public: true` configs, `list()`
+cursor encode/decode and re-prefixing, `deleteMany` native bulk vs
+`stopOnError` per-key fallback, `signedUploadUrl` PUT shape and the
+`maxSize`-throws guard, error mapping for every classified code, and
+`AbortSignal` forwarding via `FetchParameters` on `download` /
+stream-download / `list`.
+
+`bun test` is the runner — no vitest config. The shared `FakeAdapter`
+at [`../../test/fake-adapter.ts`](../../test/fake-adapter.ts) is for
+`Files`-class tests, **not** adapter unit tests; new supabase tests
+mock `@supabase/storage-js` directly.
+
+## Coding conventions
+
+- Named exports only — no default exports.
+- Errors wrap as `FilesError` via `mapSupabaseError`; pass through
+  existing `FilesError` instances unchanged (the mapper short-circuits
+  on them). Construction-time errors use
+  [`FilesError("Provider", …)`](../internal/errors.ts) with a message
+  that names the env-var aliases. Don't throw raw `Error` from the
+  factory.
+- Read env via [`readEnv`](../internal/env.ts); direct `process.env`
+  breaks Cloudflare Workers without `nodejs_compat`.
+- Body normalization is **local** to this adapter (`normalizeBody`
+  inside `index.ts`), not the shared `internal/core.ts` one — the
+  local version preserves `Blob`-vs-bytes distinctions Supabase cares
+  about. Don't replace it without re-checking the Blob `contentType`
+  override semantics.
+- Forward `operationOpts.signal` via the trailing `FetchParameters`
+  slot on `download` and `list` (the only two primitives that accept
+  it). Other primitives have no signal slot — surfacing one without a
+  way to propagate it would be misleading.
+- Use `createStoredFile` from
+  [`internal/stored-file.ts`](../internal/stored-file.ts) for every
+  `StoredFile` you return. Don't hand-roll body accessors.
+- `safeInfo` is the right escape hatch for any `info()` call where a
+  failure shouldn't block the operation. Don't try-catch around
+  `info()` ad-hoc; extend `safeInfo` instead.
+
+## Releases
+
+The repo uses Changesets. Behavioural changes here need a changeset
+(`bunx changeset`); README / AGENTS.md edits don't. When a public type
+in `SupabaseAdapterOptions` or `SupabaseAdapter` changes, also flag the
+provider catalog entry in
+[`../providers/index.ts`](../providers/index.ts) — env-var aliases and
+peer deps are duplicated there for the discovery surface.
+
+## Where to look next
+
+- Source: [`./index.ts`](./index.ts); tests: [`../../test/supabase.test.ts`](../../test/supabase.test.ts).
+- User-facing docs: [`apps/web/content/docs/adapters/supabase.mdx`](../../../../apps/web/content/docs/adapters/supabase.mdx).
+- Provider catalog entry: [`../providers/index.ts`](../providers/index.ts) (search `slug: "supabase"`).
+- Unified `Adapter` contract: [`../index.ts`](../index.ts).
+- Shared helpers (URL strategy, error-mapper factory, delete-many
+  fallback): [`../internal/core.ts`](../internal/core.ts).
+- `FilesError`: [`../internal/errors.ts`](../internal/errors.ts); env reader: [`../internal/env.ts`](../internal/env.ts).
+- Package SKILL: [`../../../../skills/files-sdk/SKILL.md`](../../../../skills/files-sdk/SKILL.md); README: [`../../README.md`](../../README.md).

--- a/packages/files-sdk/src/supabase/CLAUDE.md
+++ b/packages/files-sdk/src/supabase/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/packages/files-sdk/src/tencent/AGENTS.md
+++ b/packages/files-sdk/src/tencent/AGENTS.md
@@ -1,0 +1,219 @@
+# AGENTS.md — `files-sdk/tencent`
+
+Guidance for coding agents working inside the `tencent` adapter. The
+unified `Adapter<Raw>` contract (call shapes, `FilesError`,
+`UrlOptions`, `SignUploadOptions`, body normalization) lives in
+[`../index.ts`](../index.ts); this file documents only the
+tencent-specific deviations. `tencent()` is a thin wrapper around
+[`s3()`](../s3/index.ts) for Tencent Cloud Object Storage (COS)'s
+S3-compatible API — see [`../s3/AGENTS.md`](../s3/AGENTS.md) for
+operation, error, and presign primitives. Cross-references:
+[`README.md`](../../README.md),
+[`SKILL.md`](../../../../skills/files-sdk/SKILL.md).
+
+## Overview
+
+A thin shim that calls `s3()` with a COS endpoint, Tencent credentials,
+and a `defaultProviderMessage` of `"Tencent Cloud error"` so callers
+don't see `"S3 error"` from a Tencent-typed adapter. No per-method code
+here — every operation is forwarded by spread. The only
+tencent-specific knobs are endpoint derivation from the region code,
+the credential env-var pair, and the error-message relabel. The
+returned adapter's `raw` is the underlying `@aws-sdk/client-s3`
+`S3Client`; anything the AWS SDK can do against COS (multipart,
+server-side copy, lifecycle) is one property access away.
+
+## Directory layout
+
+```text
+packages/files-sdk/src/tencent/
+├── index.ts                   # tencent() factory + TencentAdapterOptions
+├── AGENTS.md                  # this file
+└── CLAUDE.md                  # @AGENTS.md — Claude-Code re-export
+```
+
+Tests at [`../../test/tencent.test.ts`](../../test/tencent.test.ts);
+user-facing docs at
+[`../../../../apps/web/content/docs/adapters/tencent.mdx`](../../../../apps/web/content/docs/adapters/tencent.mdx).
+
+## Build, test, typecheck
+
+Run from `packages/files-sdk`:
+
+```bash
+bun test test/tencent.test.ts   # adapter unit tests only
+bun test                        # full SDK suite
+bun run build                   # tsup → dist/, including dist/tencent/
+bun run types                   # tsgo --noEmit (typecheck only)
+```
+
+The `tencent` subpath is enumerated in
+[`../../package.json`](../../package.json)'s `exports` map — keep that
+entry in sync if the file layout changes.
+
+## Public surface
+
+Exports from [`index.ts`](./index.ts):
+
+- `tencent(opts: TencentAdapterOptions): TencentAdapter` — primary factory.
+- `TencentAdapter` — type alias for `Adapter<S3Client>`.
+- `TencentAdapterOptions` — config interface; JSDoc on every field is
+  the source of truth and feeds the docs MDX via `AutoTypeTable`.
+
+The adapter's `name` is `"tencent"` (set after spreading the inner
+adapter, so it overrides `s3()`'s `"s3"`).
+
+## Authentication / configuration
+
+Required:
+
+- `bucket` — string, **must include the `-<appid>` suffix** (e.g.
+  `uploads-1250000000`). COS namespaces bucket names globally by
+  `<name>-<appid>`; the bare name yields `NoSuchBucket` on first
+  request. No env fallback.
+- `region` — COS region code (`ap-guangzhou`, `ap-shanghai`,
+  `ap-beijing`, `ap-singapore`, `na-siliconvalley`, `eu-frankfurt`, …;
+  full list on `TencentAdapterOptions.region`). Doubles as the SigV4
+  region. No env fallback — missing region throws at construction.
+- Credentials — `accessKeyId` + `secretAccessKey`, or
+  `TENCENT_SECRET_ID` / `TENCENT_SECRET_KEY` env vars. Missing both
+  throws. Env-var names follow Tencent console terminology (SecretId /
+  SecretKey).
+
+Optional: `endpoint` (overrides the derived
+`https://cos.${region}.myqcloud.com` — use for VPC private endpoints,
+COS Accelerate, or test doubles); `forcePathStyle` (defaults to
+`false`; virtual-hosted is canonical for COS, flip only for proxies
+that demand path-style); `publicBaseUrl` (origin used by `url()` when
+set, skipping signing — natural values are
+`https://${bucket}.cos.${region}.myqcloud.com` for public-read buckets
+or a CDN domain bound to the bucket); `defaultUrlExpiresIn` (default
+presigned-URL expiry in seconds, defaults to `3600` via
+`DEFAULT_URL_EXPIRES_IN` in [`../internal/core.ts`](../internal/core.ts)).
+
+The provider catalog entry in
+[`../providers/index.ts`](../providers/index.ts) (search
+`slug: "tencent"`) declares the same env contract via the shared
+`s3Compatible(...)` helper. Env lookups go through
+[`readEnv`](../internal/env.ts) so the adapter is safe to import on
+runtimes without `process` (Cloudflare Workers without `nodejs_compat`).
+
+## Operation map
+
+`tencent()` calls `s3()` with the resolved config and spreads the
+returned adapter, overriding only `name`. `upload`, `download`, `head`,
+`exists`, `delete`, `deleteMany`, `copy`, `list`, `url`, and
+`signedUploadUrl` all live in [`../s3/index.ts`](../s3/index.ts) and
+are inherited unchanged — including `deleteMany`'s 1000-key chunking,
+`signedUploadUrl`'s PUT-vs-presigned-POST split on `maxSize`, and
+`exists`' 404-as-`false` classification. Provider errors flow through
+`mapS3Error` with the Tencent fallback table — `Provider`-coded
+messages read `"Tencent Cloud error"` instead of `"S3 error"` while
+preserving any server-side message on the wire.
+
+## URL behavior
+
+`url(key, opts?)` follows the standard signing-adapter rules:
+
+- Default: presigned `GetObject` URL, expiring after
+  `opts.expiresIn ?? defaultUrlExpiresIn` seconds, signed with SigV4
+  against `cos.${region}.myqcloud.com`.
+- With `publicBaseUrl`: returns `${publicBaseUrl}/${key}` unsigned, via
+  `joinPublicUrl` from [`../internal/core.ts`](../internal/core.ts)
+  (URL-encodes path segments).
+- With `opts.responseContentDisposition`: always signs, even when
+  `publicBaseUrl` is set — a permanent CDN URL has no signature in
+  which to bind the override. See `resolveUrlStrategy` in
+  [`../internal/core.ts`](../internal/core.ts).
+
+Tencent Cloud CDN can be bound to a COS bucket origin; the natural
+`publicBaseUrl` value is that CDN domain rather than the raw bucket
+origin.
+
+## Provider quirks worth remembering
+
+- **AppId-suffixed bucket names.** COS namespaces buckets globally by
+  `<name>-<appid>` (e.g. `uploads-1250000000`). The adapter passes
+  `opts.bucket` through verbatim; callers who paste the bare name from
+  a console screen get `NoSuchBucket` on the first request. There is
+  no auto-derivation — the adapter does not know your AppId.
+- **Endpoint host is `cos.<region>.myqcloud.com`, not `s3.…`.** A
+  bucket in `ap-guangzhou` lives at `cos.ap-guangzhou.myqcloud.com`.
+  Region doubles as the SigV4 region — picking the wrong one fails
+  signing before the request reaches the bucket.
+- **Buckets are single-region** and immutable after create; cross-region
+  replication is a separate console feature, not a runtime knob.
+- **No instance-role credential chain.** The COS S3-compatible surface
+  has no metadata-service equivalent; static `SecretId` / `SecretKey`
+  (generated under *Cloud Access Management → API Keys*) are the only
+  auth path, and the construction-time check enforces it.
+- **Errors are relabeled, not reclassified.** Status codes still map
+  through the same `S3_NOT_FOUND_CODES` / `S3_UNAUTH_CODES` /
+  `S3_CONFLICT_CODES` sets in [`../s3/index.ts`](../s3/index.ts); only
+  the unknown-error fallback changes to `"Tencent Cloud error"`.
+
+## Testing approach
+
+Unit tests at [`../../test/tencent.test.ts`](../../test/tencent.test.ts)
+cover:
+
+- Endpoint derivation from `region` (`ap-guangzhou`, `na-siliconvalley`),
+  explicit `endpoint` and `forcePathStyle` overrides reaching the inner
+  `S3Client` config.
+- Missing-region and missing-credential errors at construction;
+  `TENCENT_SECRET_ID` / `TENCENT_SECRET_KEY` env-var fallbacks.
+- `url()` presign default (asserts on `X-Amz-Signature=`,
+  `X-Amz-Expires=3600`, and the `cos.<region>.myqcloud.com` host) and
+  the `publicBaseUrl` short-circuit.
+- Operation delegation via `aws-sdk-client-mock`'s `mockClient(S3Client)`
+  — proves `upload` and `exists` reach the underlying client.
+- `mapS3Error` returns `"Tencent Cloud error"` for `Provider` when
+  invoked with the Tencent messages table.
+
+Add fixtures here rather than to `s3.test.ts` whenever a behavior
+depends on tencent-specific config (endpoint host, relabel, env-var
+name, AppId-suffix bucket); shared S3 semantics belong in
+[`../../test/s3.test.ts`](../../test/s3.test.ts).
+
+## Coding conventions
+
+- Named exports only — `tencent`, `TencentAdapter`,
+  `TencentAdapterOptions`. No default exports.
+- Construction-time errors use
+  [`FilesError("Provider", …)`](../internal/errors.ts); operation
+  errors are the inner S3 adapter's job — don't try-catch and rethrow
+  in this shim.
+- Pick up environment variables via [`readEnv`](../internal/env.ts) —
+  direct `process.env` access breaks Cloudflare Workers without
+  `nodejs_compat`.
+- Forward optional knobs with `...(opts.x !== undefined && { x: opts.x })`
+  so unset values fall through to AWS-SDK defaults instead of being
+  passed as explicit `undefined`.
+- Spread the inner adapter and override only `name` — preserves any
+  future `Adapter`-interface additions that `s3()` picks up. Top-level
+  regex literals only (the current file has none).
+
+## Releases
+
+Ships with the rest of the monorepo from
+[`../../package.json`](../../package.json). Behavioral changes (new
+options, default changes, error-shape changes) bump the `files-sdk`
+version and add an entry to [`../../CHANGELOG.md`](../../CHANGELOG.md);
+pure docs / test-only additions don't. The `tencent` subpath is already
+declared in `exports` — no further wiring needed.
+
+## Where to look next
+
+- Unified contract: [`../index.ts`](../index.ts).
+- Inner S3 adapter: [`../s3/index.ts`](../s3/index.ts) +
+  [`../s3/AGENTS.md`](../s3/AGENTS.md).
+- Shared helpers: [`../internal/core.ts`](../internal/core.ts);
+  `FilesError`: [`../internal/errors.ts`](../internal/errors.ts); env
+  reader: [`../internal/env.ts`](../internal/env.ts).
+- Provider catalog (search `slug: "tencent"`):
+  [`../providers/index.ts`](../providers/index.ts).
+- User docs:
+  [`../../../../apps/web/content/docs/adapters/tencent.mdx`](../../../../apps/web/content/docs/adapters/tencent.mdx).
+- Package README: [`../../README.md`](../../README.md); SKILL:
+  [`../../../../skills/files-sdk/SKILL.md`](../../../../skills/files-sdk/SKILL.md);
+  tests: [`../../test/tencent.test.ts`](../../test/tencent.test.ts).

--- a/packages/files-sdk/src/tencent/CLAUDE.md
+++ b/packages/files-sdk/src/tencent/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/packages/files-sdk/src/tigris/AGENTS.md
+++ b/packages/files-sdk/src/tigris/AGENTS.md
@@ -1,0 +1,220 @@
+# AGENTS.md — `files-sdk/tigris`
+
+Guidance for coding agents working on the `tigris` adapter. The unified
+`Adapter<Raw>` contract — call shapes, `FilesError`, `UrlOptions`,
+`SignUploadOptions`, body normalization — lives in
+[`../index.ts`](../index.ts); this file documents only the tigris-specific
+deviations. `tigris()` is a thin wrapper around [`s3()`](../s3/index.ts) for
+[Tigris Data](https://www.tigrisdata.com)'s globally-distributed S3-compatible
+API, so the operation map, presign mechanics, and error mapping live in the
+S3 adapter — see [`../s3/AGENTS.md`](../s3/AGENTS.md) for primitive-level
+details. Cross-references: [`../../README.md`](../../README.md),
+[`../../../../skills/files-sdk/SKILL.md`](../../../../skills/files-sdk/SKILL.md).
+
+## Overview
+
+A thin shim that calls `s3()` with the Tigris global endpoint, Tigris
+credentials, an `"auto"` SigV4 region default, and a `defaultProviderMessage`
+of `"Tigris error"` so callers don't see `"S3 error"` from a Tigris-typed
+adapter. No per-method code: every operation is forwarded by spread. Three
+things differ from a raw `s3({ ... })` call:
+
+- The endpoint defaults to a **single global host**
+  `https://fly.storage.tigris.dev` — Tigris is a globally-distributed object
+  store and routes each request to the nearest region automatically. No
+  region-derived hostname to compute.
+- `region` defaults to `"auto"` (not `us-east-1`). SigV4 requires *some*
+  region for signing, but Tigris ignores it for routing.
+- `forcePathStyle` defaults to `false` — virtual-hosted
+  (`<bucket>.fly.storage.tigris.dev`) is canonical and matches the AWS SDK's
+  own default.
+
+Everything else — body normalization, presigned uploads, `deleteMany`
+chunking, error classification, `publicBaseUrl`-vs-sign precedence — is s3
+adapter behavior. `raw` is the underlying `S3Client`; any AWS SDK feature
+against Tigris is one property access away.
+
+## Directory layout
+
+```text
+packages/files-sdk/src/tigris/
+├── AGENTS.md   # this file
+├── CLAUDE.md   # @AGENTS.md indirection
+└── index.ts    # tigris() factory + TigrisAdapterOptions
+```
+
+Tests: [`../../test/tigris.test.ts`](../../test/tigris.test.ts). User docs:
+[`../../../../apps/web/content/docs/adapters/tigris.mdx`](../../../../apps/web/content/docs/adapters/tigris.mdx). Provider catalog:
+[`../providers/index.ts`](../providers/index.ts) under `slug: "tigris"`.
+
+## Build, test, typecheck
+
+```bash
+# from packages/files-sdk
+bun test test/tigris.test.ts   # focused tigris suite (fast inner loop)
+bun test                        # full package suite
+bun run build                   # tsup ESM bundle → dist/, including dist/tigris/
+bun run types                   # tsgo --noEmit (typecheck only)
+```
+
+The `tigris` subpath is in [`../../package.json`](../../package.json)'s
+`exports` map — keep it in sync if the file layout changes. Changes to
+[`../s3/index.ts`](../s3/index.ts) ripple here; run the full suite before
+pushing s3-adjacent edits.
+
+## Public surface
+
+Exports from [`./index.ts`](./index.ts):
+
+- `tigris(opts: TigrisAdapterOptions): TigrisAdapter` — primary factory.
+  Throws `FilesError("Provider", "tigris adapter: missing credentials…")`
+  when neither option nor env var supplies the access-key pair. Returned
+  adapter sets `name: "tigris"`, overriding the inner s3 adapter's `"s3"`.
+- `TigrisAdapter` — type alias for `Adapter<S3Client>`. `.raw` is the
+  underlying AWS SDK client.
+- `TigrisAdapterOptions` — config interface. JSDoc on every field is the
+  source of truth; the docs MDX pulls it via `<AutoTypeTable>`, so keep
+  those comments user-facing.
+
+## Authentication / configuration
+
+Required:
+
+- `bucket` — string. **No env fallback**; pass it explicitly.
+- Credentials — `accessKeyId` + `secretAccessKey`, passed in or sourced from
+  `TIGRIS_ACCESS_KEY_ID` / `TIGRIS_SECRET_ACCESS_KEY`. Missing both throws
+  `FilesError("Provider", …)` at construction.
+
+Optional:
+
+- `endpoint` — overrides `https://fly.storage.tigris.dev`. Use for
+  pinned-region testing, a private deployment, or a test double.
+- `region` — defaults to `"auto"`. Used only for SigV4 signing; Tigris routes
+  globally and ignores it. Unusual among S3-compatible adapters (wasabi,
+  backblaze-b2, storj, hetzner, akamai, digitalocean-spaces all require
+  one) — the single global endpoint makes region a pure signing ritual, so
+  the factory leaves it optional. The catalog row in
+  [`../providers/index.ts`](../providers/index.ts) likewise lists only
+  `bucket` in `config`.
+- `forcePathStyle` — defaults to `false`. Virtual-hosted is canonical; flip
+  only for proxies that demand path-style.
+- `publicBaseUrl` — origin used by `url()` when set; skips signing. Natural
+  value for a public-read bucket is `https://${bucket}.fly.storage.tigris.dev`,
+  or a custom domain bound to the bucket.
+- `defaultUrlExpiresIn` — default presigned-URL expiry in seconds. Defaults
+  to `3600` via `DEFAULT_URL_EXPIRES_IN` in
+  [`../internal/core.ts`](../internal/core.ts).
+
+## Operation map
+
+`tigris()` calls `s3()` with the resolved config and spreads the returned
+adapter, overriding only `name`. `upload`, `download`, `head`, `exists`,
+`delete`, `deleteMany`, `copy`, `list`, `url`, and `signedUploadUrl` all live
+in [`../s3/index.ts`](../s3/index.ts) and are inherited unchanged — including
+`deleteMany`'s 1000-key chunking, `signedUploadUrl`'s PUT-vs-presigned-POST
+split on `maxSize`, `exists`' 404-as-`false` classification, and the
+streaming-upload follow-up `HeadObject`. Provider errors flow through
+`mapS3Error` with the Tigris fallback table — `Provider`-coded messages read
+`"Tigris error"` instead of `"S3 error"` while preserving any server-side
+message on the wire.
+
+## URL behavior
+
+`url(key, opts?)` follows the standard signing-adapter rules
+(`resolveUrlStrategy` in [`../internal/core.ts`](../internal/core.ts)):
+
+- **No `publicBaseUrl`** → presigned `GetObject` against the global endpoint,
+  signed with SigV4 against the configured (or `"auto"`) region, expiring
+  after `opts.expiresIn ?? defaultUrlExpiresIn ?? 3600` seconds.
+- **`publicBaseUrl` set** → unsigned concat `${publicBaseUrl}/${key}` via
+  `joinPublicUrl` (URL-encodes path segments).
+- **`opts.responseContentDisposition` set** → always forces signing, even
+  when `publicBaseUrl` is configured. A permanent CDN URL has no signature
+  to bind the override to, and dropping it silently would be a stored-XSS
+  regression on user-uploaded HTML/SVG. Invariant lives in
+  `resolveUrlStrategy`, not here.
+
+## Provider quirks worth remembering
+
+- **Regionless by design.** Tigris exposes one global hostname and routes
+  each request to the nearest region. The `region` knob is purely a SigV4
+  ritual — picking the "wrong" one doesn't fail signing the way it does on
+  AWS or Wasabi, because Tigris doesn't bind buckets to regions in the
+  signing path.
+- **Endpoint origins.** Tigris started life as a Fly.io storage product,
+  which is why the canonical host is `fly.storage.tigris.dev` and bucket
+  subdomains read `<bucket>.fly.storage.tigris.dev`.
+- **Access keys** are generated in the Tigris console or via the Fly CLI
+  (`fly storage create`). Both flows produce the same S3-style `accessKeyId`
+  / `secretAccessKey` the AWS SDK expects.
+- **Errors are relabeled, not reclassified.** Status codes still map through
+  `S3_NOT_FOUND_CODES` / `S3_UNAUTH_CODES` / `S3_CONFLICT_CODES` in
+  [`../s3/index.ts`](../s3/index.ts); only the unknown-error fallback
+  changes to `"Tigris error"`. Tests pin the relabel — update the assertion
+  when the wording changes.
+
+## Testing approach
+
+Unit tests at [`../../test/tigris.test.ts`](../../test/tigris.test.ts) cover
+the adapter's narrow surface:
+
+- Default-config plumbing — global endpoint, `"auto"` region,
+  `forcePathStyle: false` — read off the inner `S3Client`'s resolved config.
+- `region` and `endpoint` overrides flow through to the inner client (and
+  the endpoint stays unchanged when only `region` is overridden, proving
+  region doesn't drive the host); `forcePathStyle: true` pass-through.
+- Missing-credentials throw at construction and `TIGRIS_ACCESS_KEY_ID` /
+  `TIGRIS_SECRET_ACCESS_KEY` env-var fallback.
+- `url()` returns a presigned GET (`X-Amz-Signature=…`, `X-Amz-Expires=3600`,
+  host `fly.storage.tigris.dev`) by default, and switches to unsigned concat
+  when `publicBaseUrl` is set.
+- `Files` integration via `aws-sdk-client-mock` — `upload` and `exists`
+  exercise `PutObjectCommand` and `HeadObjectCommand` like raw s3.
+- `mapS3Error` invoked directly with the tigris messages table to confirm
+  the `Provider` fallback says `"Tigris error"`.
+
+Add fixtures here whenever behavior depends on tigris-specific config
+(global endpoint, `"auto"` region, env-var name, relabel); shared S3
+semantics belong in [`../../test/s3.test.ts`](../../test/s3.test.ts). Mock
+the SDK and reset between assertions; never hit real Tigris.
+
+## Coding conventions
+
+- Named exports only — `tigris`, `TigrisAdapter`, `TigrisAdapterOptions`.
+- The factory is pure: no module-level state, no I/O at import. Env reads
+  happen inside the factory via `readEnv`
+  ([`../internal/env.ts`](../internal/env.ts)) so Cloudflare Workers (no
+  `process`) can still import the module. Construction-time errors throw
+  [`FilesError("Provider", "tigris adapter: …")`](../internal/errors.ts) so
+  sibling S3-compatible adapters stay distinguishable in logs.
+- Forward optional knobs with `...(opts.x !== undefined && { x: opts.x })`
+  so unset values fall through to the s3 default. Spread the inner adapter
+  and override only `name` — preserves future additions to the `Adapter`
+  interface.
+- Type-only imports from `@aws-sdk/client-s3` (**optional** peer dep, see
+  [`../../package.json`](../../package.json)); the runtime client is
+  constructed inside `s3()`.
+
+## Releases
+
+Ships as `files-sdk` on a single version line via the repo-wide Changesets
+schedule. Behavioral changes — default endpoint or region,
+`defaultProviderMessage` text, env-var names, option renames — need a
+changeset (`bun changeset`); tigris-specific bug fixes are patches.
+AGENTS.md, CLAUDE.md, and docs-only edits don't. The `tigris` subpath is
+already declared in `exports`.
+
+## Where to look next
+
+- Unified contract: [`../index.ts`](../index.ts).
+- Inner s3 adapter: [`../s3/index.ts`](../s3/index.ts) +
+  [`../s3/AGENTS.md`](../s3/AGENTS.md).
+- Shared helpers: [`../internal/core.ts`](../internal/core.ts),
+  [`../internal/errors.ts`](../internal/errors.ts),
+  [`../internal/env.ts`](../internal/env.ts).
+- Provider catalog (search `slug: "tigris"`):
+  [`../providers/index.ts`](../providers/index.ts).
+- User docs:
+  [`../../../../apps/web/content/docs/adapters/tigris.mdx`](../../../../apps/web/content/docs/adapters/tigris.mdx).
+- Package README + SKILL: [`../../README.md`](../../README.md),
+  [`../../../../skills/files-sdk/SKILL.md`](../../../../skills/files-sdk/SKILL.md).

--- a/packages/files-sdk/src/tigris/CLAUDE.md
+++ b/packages/files-sdk/src/tigris/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/packages/files-sdk/src/uploadthing/AGENTS.md
+++ b/packages/files-sdk/src/uploadthing/AGENTS.md
@@ -1,0 +1,242 @@
+# AGENTS.md — `files-sdk/uploadthing`
+
+Guidance for coding agents working on the `uploadthing` adapter
+([UploadThing](https://uploadthing.com), exposed at the
+`files-sdk/uploadthing` subpath). The unified `Adapter<Raw>` contract
+— call shapes, `FilesError`, `UrlOptions`, `SignUploadOptions`, body
+normalization — lives in [`../index.ts`](../index.ts); read it first.
+This file documents only uploadthing-specific behavior.
+Cross-references: [`../../README.md`](../../README.md),
+[`../../../../skills/files-sdk/SKILL.md`](../../../../skills/files-sdk/SKILL.md).
+
+## Overview
+
+This is a **native** adapter — no inner `s3()` shim. Every operation is
+implemented against [`uploadthing/server`](https://docs.uploadthing.com)
+(`UTApi`, `UTFile`) plus `fetch` for reads where UploadThing has no
+metadata or body API. The adapter decodes `UPLOADTHING_TOKEN` at
+construction (base64 JSON of `{ apiKey, appId, regions? }`) so
+`url()` can synthesize the public CDN host (`https://{appId}.ufs.sh/f/…`)
+and `signedUploadUrl()` can HMAC-sign UFS ingest PUT URLs without an API
+round trip.
+
+The central identity model: **your key is UploadThing's `customId`.**
+`UTApi` is constructed with `defaultKeyType: "customId"`, so
+`deleteFiles`, `generateSignedURL`, and uploads route by the caller's
+key. UploadThing still assigns an opaque internal `fileKey` per object;
+you normally never see it. Files uploaded out-of-band without a
+`customId` surface their internal key on `list()` — treat that as
+legacy/orphan data, not the adapter's contract.
+
+`uploadthing(opts)` returns `Adapter<UTApi>`. `raw` is the `UTApi`
+instance (`files.raw.uploadFiles`, `files.raw.listFiles`, …).
+
+Peer dep: [`uploadthing`](https://www.npmjs.com/package/uploadthing),
+pinned at `^7` in [`../../package.json`](../../package.json). Shared
+plumbing: [`../internal/core.ts`](../internal/core.ts)
+(`deleteManyWithFallback`, `existsByProbe`, `DEFAULT_URL_EXPIRES_IN`),
+[`../internal/stored-file.ts`](../internal/stored-file.ts),
+[`../internal/errors.ts`](../internal/errors.ts),
+[`../internal/env.ts`](../internal/env.ts).
+
+## Directory layout
+
+```text
+packages/files-sdk/src/uploadthing/
+├── index.ts          # uploadthing() factory + UploadThingAdapterOptions
+├── AGENTS.md         # this file
+└── CLAUDE.md         # `@AGENTS.md` — Claude-Code re-export
+```
+
+Sibling files: tests at
+[`../../test/uploadthing.test.ts`](../../test/uploadthing.test.ts);
+user-facing docs at
+[`../../../../apps/web/content/docs/adapters/uploadthing.mdx`](../../../../apps/web/content/docs/adapters/uploadthing.mdx);
+subpath export at `exports["./uploadthing"]` in
+[`../../package.json`](../../package.json).
+
+## Build, test, typecheck
+
+Run from `packages/files-sdk/`:
+
+```bash
+bun test test/uploadthing.test.ts   # this adapter only
+bun test                             # full SDK suite
+bun run build                        # tsup ESM → dist/uploadthing/
+bun run types                        # tsgo --noEmit
+```
+
+This package uses **`bun test`** (not vitest) and **`tsgo`** (not
+`tsc`); both are pinned in [`../../package.json`](../../package.json).
+
+## Public surface
+
+Exports from [`./index.ts`](./index.ts):
+
+- `uploadthing(opts?: UploadThingAdapterOptions): UploadThingAdapter` —
+  primary factory. `opts` is optional in the type, but you must pass
+  `token` or set `UPLOADTHING_TOKEN`; otherwise construction throws.
+- `UploadThingAdapter = Adapter<UTApi>`. `raw` is the `UTApi` client.
+- `UploadThingAdapterOptions` — JSDoc on every field is the source of
+  truth; the docs MDX pulls it via `AutoTypeTable`.
+
+The adapter's `name` is `"uploadthing"`.
+
+## Authentication / configuration
+
+Required:
+
+- **`token`** — UploadThing API token, or `UPLOADTHING_TOKEN` via
+  [`readEnv`](../internal/env.ts). Must be valid base64 decoding to JSON
+  with string `apiKey` and `appId`. Malformed tokens throw
+  `FilesError("Provider", …)` at construction (not on first API call).
+
+Optional (fixed at construction unless noted):
+
+| Option                 | Default        | Role                                                                 |
+| ---------------------- | -------------- | -------------------------------------------------------------------- |
+| `acl`                  | `"public-read"` | `"public-read"` → CDN URLs; `"private"` → `generateSignedURL` for reads. |
+| `slug`                 | —              | File-router slug; **required for `signedUploadUrl()`** (`x-ut-slug`). Server `upload()` does not need it. |
+| `defaultUrlExpiresIn`  | `3600`         | Signed download TTL when `acl` is `"private"` (UploadThing caps at 7 days). |
+| `downloadTimeoutMs`    | `300_000`      | Bounds `fetch` for `head`, `download`, lazy bodies; `0` disables timeout. |
+| `region`               | first token region or `"sea1"` | Ingest host for `signedUploadUrl()` (`{region}.ingest.uploadthing.com`). |
+
+There is no bucket name — UploadThing is app-scoped via `appId`. The
+provider catalog entry in [`../providers/index.ts`](../providers/index.ts)
+(search `slug: "uploadthing"`) declares only `UPLOADTHING_TOKEN`.
+
+## Operation map
+
+Errors flow through `mapUploadThingError` / `classifyUploadThingError`:
+HTTP status first (`404 → NotFound`, `401/403 → Unauthorized`,
+`409 → Conflict`), then message/code substrings; existing `FilesError`
+instances pass through unchanged.
+
+| Method            | Implementation                                                                                                                                 |
+| ----------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| `upload`          | `bodyToBlob` → `UTFile` with `customId: key`, `utapi.uploadFiles` (single-file overload), `acl` from config. Streams are buffered first.     |
+| `download`        | `resolveFetchUrl` → `fetch` (GET). Public: `https://{appId}.ufs.sh/f/{key}`; private: `utapi.generateSignedURL(key, { keyType: "customId" })`. |
+| `head`            | HEAD on resolved URL → `createStoredFile` with lazy GET body factory. No UploadThing metadata API.                                             |
+| `exists`          | `existsByProbe` wrapping HEAD on resolved URL.                                                                                                 |
+| `delete`          | `utapi.deleteFiles(key)` — idempotent upstream.                                                                                                |
+| `deleteMany`      | **Native bulk:** `utapi.deleteFiles(keys)` in one call unless `stopOnError`, then per-key via `deleteManyWithFallback`. Whole-request failure maps the same error to every key. |
+| `copy`            | `download(from, { as: "stream" })` then `upload(to, stream)` — not atomic; egress + ingest cost.                                             |
+| `list`            | `utapi.listFiles({ limit, offset })`; `cursor` is numeric offset as string. `prefix` filtered **client-side on the page only**.                |
+| `url`             | Public: CDN URL; private: `generateSignedURL`. See [URL behavior](#url-behavior).                                                              |
+| `signedUploadUrl` | UFS presigned PUT: random path `fileKey`, `x-ut-custom-id` = user key, HMAC-SHA256 signature via Web Crypto. See [Signed upload](#signed-upload). |
+
+Non-obvious behaviours backed by tests:
+
+- **`upload` uses `basename(key)` as the UT file name** while `customId`
+  stays the full key (`avatars/abc.png` → name `abc.png`).
+- **`etag` on upload** comes from UploadThing's `fileHash`, not HTTP ETag.
+- **`list` items** use `type: "application/octet-stream"` always; size and
+  `lastModified` come from `listFiles`, not HEAD.
+- **`download` merges caller `signal` with timeout** via `AbortSignal.any`
+  when both are set.
+
+## URL behavior
+
+- **`acl: "public-read"` (default):** `url()` returns
+  `https://{appId}.ufs.sh/f/{encodeURIComponent(key)}` with no API call.
+- **`acl: "private"`:** `url()` calls `utapi.generateSignedURL` with
+  `keyType: "customId"`; `opts.expiresIn` overrides `defaultUrlExpiresIn`.
+- **`opts.responseContentDisposition` always throws `Provider`.**
+  UploadThing has no Content-Disposition override on CDN or signed URLs —
+  same security rationale as [`../vercel-blob/`](../vercel-blob/AGENTS.md).
+
+## Signed upload
+
+`signedUploadUrl(key, opts)` builds a **PUT** URL against
+`https://{region}.ingest.uploadthing.com/{randomFileKey}` with query
+params documented by UploadThing (`expires`, `x-ut-identifier`,
+`x-ut-file-name`, `x-ut-custom-id`, `x-ut-acl`, optional `x-ut-file-type`,
+`x-ut-file-size`, `x-ut-slug`). The signature is
+`hmac-sha256=<hex>` over the full URL (without the signature param),
+using `apiKey` from the decoded token — implemented with Web Crypto so
+the adapter runs on Node 18+, Workers, Bun, and Deno without `node:crypto`.
+
+The random path segment is **not** your logical key; routing after upload
+uses `x-ut-custom-id`. Set `slug` to the file-router route name —
+UploadThing enforces file type/size via router config, not the advisory
+`maxSize` query param alone. Server-side `upload()` does not use `slug`.
+
+## Provider quirks worth remembering
+
+- **Keys vs UploadThing file keys.** Callers pass logical keys; the
+  adapter stores them as `customId`. UploadThing's opaque `key` field
+  exists internally and appears in `list()` only when `customId` is null.
+- **No user metadata.** `UploadOptions.metadata` does not round-trip —
+  UploadThing has no user-metadata primitive; `head()` / `list()` never
+  return `metadata` (see `UploadOptions` JSDoc in [`../index.ts`](../index.ts)).
+- **No server-side copy or HEAD API.** `copy()` and `head()` use
+  download/re-upload and HTTP HEAD on the file URL respectively.
+- **`list` prefix is page-local.** Filtering happens after
+  `listFiles` returns a page; a narrow prefix can under-return if matching
+  keys span pages.
+- **Stream uploads buffer entirely** in `bodyToBlob` — UploadThing's
+  `uploadFiles` requires a `Blob`; large streams need application-level
+  chunking or the presigned PUT path.
+- **`deleteMany` bulk semantics.** One `deleteFiles(keys)` call; on
+  failure every key gets the same mapped error (no per-key partial success
+  from the API). Use `stopOnError: true` for sequential per-key deletes.
+- **`delete` is idempotent** upstream — missing keys still succeed.
+
+## Testing approach
+
+Tests in [`../../test/uploadthing.test.ts`](../../test/uploadthing.test.ts)
+mock `uploadthing/server` via `mock.module(...)`, then dynamically import
+the adapter. `globalThis.fetch` is stubbed for CDN/signed URL reads.
+Coverage includes:
+
+- Token validation at construction (missing, non-base64, non-JSON,
+  missing `apiKey`/`appId`).
+- `upload` → `uploadFiles` with `customId`, ACL, all `Body` shapes,
+  `result.error` and thrown errors classified.
+- `download` / `head` / `exists` public vs private URL resolution, 404
+  mapping, timeout/signal behavior, lazy bodies.
+- `delete` / `deleteMany` bulk and `stopOnError` fallback.
+- `copy` re-upload path; `list` cursor, prefix filter, lazy item bodies.
+- `url` public CDN, private signed URL, `responseContentDisposition` throw.
+- `signedUploadUrl` PUT params, HMAC verification, `slug` and `region`.
+
+Default test token: base64 `{"apiKey":"sk_test","appId":"myapp","regions":["sea1"]}`.
+
+## Coding conventions
+
+- Named exports only — `uploadthing`, `UploadThingAdapter`,
+  `UploadThingAdapterOptions`, `UploadThingClient`. No default exports.
+- Construction-time token errors use `FilesError("Provider", …)`;
+  operation errors go through `mapUploadThingError`.
+- Read env via [`readEnv`](../internal/env.ts) — not raw `process.env`.
+- Use `createStoredFile` for every `StoredFile`; lazy factories should
+  call `resolveFetchUrl` + `fetchWithTimeout`.
+- Call `utapi.uploadFiles` with a **single** `UTFile` (not an array) so
+  TypeScript infers `UploadFileResult` rather than an array overload.
+- Keep HMAC/signing on Web Crypto — do not import `node:crypto`.
+- Top-level regex literals only (`classifyUploadThingError` patterns).
+
+## Releases
+
+Ships with the monorepo from [`../../package.json`](../../package.json).
+Behavioural changes bump `files-sdk` and need a Changesets entry; pure
+docs / test additions do not. The `uploadthing` subpath is already in
+`exports` — no extra wiring for new options.
+
+## Where to look next
+
+- Source: [`./index.ts`](./index.ts); tests:
+  [`../../test/uploadthing.test.ts`](../../test/uploadthing.test.ts).
+- Unified contract: [`../index.ts`](../index.ts); shared helpers:
+  [`../internal/core.ts`](../internal/core.ts),
+  [`../internal/stored-file.ts`](../internal/stored-file.ts),
+  [`../internal/errors.ts`](../internal/errors.ts),
+  [`../internal/env.ts`](../internal/env.ts).
+- Provider catalog (search `slug: "uploadthing"`):
+  [`../providers/index.ts`](../providers/index.ts).
+- User-facing docs:
+  [`../../../../apps/web/content/docs/adapters/uploadthing.mdx`](../../../../apps/web/content/docs/adapters/uploadthing.mdx).
+- README: [`../../README.md`](../../README.md); SKILL:
+  [`../../../../skills/files-sdk/SKILL.md`](../../../../skills/files-sdk/SKILL.md).
+- Upstream: [UploadThing docs](https://docs.uploadthing.com),
+  [uploading files (UFS presign)](https://docs.uploadthing.com/uploading-files).

--- a/packages/files-sdk/src/uploadthing/CLAUDE.md
+++ b/packages/files-sdk/src/uploadthing/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/packages/files-sdk/src/vercel-blob/AGENTS.md
+++ b/packages/files-sdk/src/vercel-blob/AGENTS.md
@@ -1,0 +1,310 @@
+# AGENTS.md — `files-sdk/vercel-blob`
+
+Guidance for coding agents working on the `vercel-blob` adapter
+([Vercel Blob](https://vercel.com/storage/blob), exposed at the
+`files-sdk/vercel-blob` subpath). The unified `Adapter<Raw>` contract
+every method conforms to lives in [`../index.ts`](../index.ts); read it
+first. This file documents only vercel-blob-specific deviations.
+Cross-references: [`../../README.md`](../../README.md),
+[`../../../../skills/files-sdk/SKILL.md`](../../../../skills/files-sdk/SKILL.md).
+
+## Overview
+
+This is a **native** adapter — no inner `s3()` shim, no AWS SDK. Every
+operation is implemented directly against `@vercel/blob`'s top-level
+namespace (`blob.put`, `blob.head`, `blob.get`, `blob.list`, `blob.del`,
+`blob.copy`). Two axes interact with `url()`, `download()`, and the
+storeId fast path in non-obvious ways: public vs private blobs
+(`access`) and OIDC vs read-write-token authentication.
+
+`vercelBlob(opts)` returns an `Adapter<typeof blob>`. `raw` is the
+`@vercel/blob` namespace itself, so the escape hatch is the entire SDK
+(`files.raw.handleUpload(...)`, `files.raw.list({ mode: "folded" })`,
+etc.). The factory resolves credentials at construction time, captures
+the chosen access mode, and threads everything through a shared
+`BlobAuthOptions` object spread into every `blob.*` call site.
+Construction fails fast on misconfiguration so anonymous calls that
+401 at runtime are impossible to reach.
+
+Peer dep:
+[`@vercel/blob`](https://www.npmjs.com/package/@vercel/blob), pinned at
+`^2.4.0` in [`../../package.json`](../../package.json) — the first
+version that ships the OIDC options. Shared plumbing lives in
+[`../internal/`](../internal/) (`core.ts`, `stored-file.ts`,
+`errors.ts`, `env.ts`).
+
+## Directory layout
+
+```text
+packages/files-sdk/src/vercel-blob/
+├── index.ts          # vercelBlob() factory + VercelBlobAdapterOptions
+├── AGENTS.md         # this file
+└── CLAUDE.md         # `@AGENTS.md` — Claude-Code re-export
+```
+
+Sibling files: tests at
+[`../../test/vercel-blob.test.ts`](../../test/vercel-blob.test.ts);
+user-facing docs at
+[`../../../../apps/web/content/docs/adapters/vercel-blob.mdx`](../../../../apps/web/content/docs/adapters/vercel-blob.mdx);
+subpath export at `exports["./vercel-blob"]` in
+[`../../package.json`](../../package.json).
+
+## Build, test, typecheck
+
+Run from `packages/files-sdk/`:
+
+```bash
+bun test test/vercel-blob.test.ts   # this adapter only
+bun test                             # full SDK suite
+bun run build                        # tsup ESM → dist/vercel-blob/
+bun run types                        # tsgo --noEmit
+```
+
+This package uses **`bun test`** (not vitest) and **`tsgo`** (not
+`tsc`); both are pinned in [`../../package.json`](../../package.json).
+
+## Public surface
+
+Exports from [`./index.ts`](./index.ts):
+
+- `vercelBlob(opts?: VercelBlobAdapterOptions): VercelBlobAdapter` —
+  primary factory. `opts` is typed as optional, but in practice you
+  must either set credentials env vars or pass them explicitly; an
+  unconfigured factory throws at construction.
+- `VercelBlobAdapter = Adapter<VercelBlobClient>` where
+  `VercelBlobClient = typeof blob`. `raw` is the `@vercel/blob`
+  namespace, so callers reach for `files.raw.put(...)`,
+  `files.raw.handleUpload(...)`, etc. for features outside the unified
+  API.
+- `VercelBlobAdapterOptions` — JSDoc on every field is the source of
+  truth; the docs MDX pulls it via `AutoTypeTable`.
+
+The adapter's `name` is `"vercel-blob"`.
+
+## Authentication / configuration
+
+Credential resolution mirrors the upstream `@vercel/blob` SDK so
+callers can swap between the two without surprises (see `vercelBlob()`
+body, ~lines 244-274 of [`./index.ts`](./index.ts)):
+
+1. Explicit `opts.token` (read-write or client token) — wins over OIDC.
+2. OIDC: `oidcToken` + `storeId` (option or env). **Both** must resolve.
+3. Explicit `opts.oidcToken` with no resolvable `storeId` → throws. A
+   caller who passed `oidcToken` is asking for OIDC; we refuse to
+   silently swap to `BLOB_READ_WRITE_TOKEN`.
+4. `BLOB_READ_WRITE_TOKEN` env var.
+5. Anything else throws `FilesError("Provider", …)` at construction.
+
+Env vars (read via [`readEnv`](../internal/env.ts), so the adapter is
+safe to import on runtimes without `process` — Workers without
+`nodejs_compat`, etc.):
+
+| Var                     | Purpose                                                               |
+| ----------------------- | --------------------------------------------------------------------- |
+| `BLOB_READ_WRITE_TOKEN` | Long-lived RW token. Fallback when no OIDC config is found.           |
+| `VERCEL_OIDC_TOKEN`     | Vercel OIDC token. Auto-injected on Vercel deployments.               |
+| `BLOB_STORE_ID`         | Store id. Accepted as `store_<id>` or `<id>`; the prefix is stripped. |
+
+OIDC is the **recommended** mode on Vercel: tokens rotate automatically
+so a static secret can't leak from the codebase or environment. Off
+Vercel (or in frameworks like Vite that don't load `.env.local` into
+`process.env`), pass `oidcToken` and `storeId` explicitly — the adapter
+would otherwise silently fall back to the RW token.
+
+`access: "public" | "private"` (defaults to `"public"`) is fixed at
+construction; a single `Files` instance is unambiguously one mode or
+the other. If you need both, instantiate two adapters.
+
+Other knobs (full JSDoc on the option interface):
+
+- `addRandomSuffix` — defaults to `false`, **diverging from Vercel's
+  own default of `true`**. Predictable keys are the dominant SDK
+  assumption; the upstream default would silently mangle caller-supplied
+  pathnames.
+- `allowOverwrite` — defaults to `true` so predictable keys actually
+  work (Vercel rejects same-pathname uploads otherwise). Trade-off:
+  `upload(key, …)` clobbers any existing object at `key`. Set to
+  `false` for create-only semantics and handle the resulting `Conflict`.
+- `downloadTimeoutMs` — bounds public-URL fetches and lazy bodies from
+  `head()` / `list()`. Defaults to 300 000 ms (5 minutes); pass `0` to
+  disable.
+
+## Operation map
+
+Every method spreads `BlobAuthOptions` (`{ token }` or
+`{ oidcToken, storeId }`) into the underlying call. Errors flow
+through `mapBlobError`, which classifies on HTTP status first
+(`404 → NotFound`, `401/403 → Unauthorized`, `409/412 → Conflict`,
+otherwise `Provider`) and falls back to error-name substring matching
+when the underlying fetch error doesn't surface a status — `name`
+matching catches `BlobNotFoundError` and friends even when the
+transport doesn't carry an HTTP status.
+
+| Method            | Implementation                                                                                                                                                                       |
+| ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `upload`          | `blob.put(key, body, …)` with `access`, `addRandomSuffix`, `allowOverwrite`, `contentType`, `cacheControlMaxAge` parsed from `opts.cacheControl`.                                    |
+| `download`        | Public: `blob.head` + `fetch(url)` with timeout. Private: `blob.head` + `blob.get(key, { access: "private", … })` for an authenticated stream.                                       |
+| `head`            | `blob.head(key, …)` → `createStoredFile`. Maps `pathname → key`, `contentType → type` (default `application/octet-stream`), `uploadedAt.getTime() → lastModified`, `etag`, `size`.   |
+| `exists`          | `existsByProbe(blob.head, mapBlobError)`. `NotFound` → `false`; everything else propagates.                                                                                          |
+| `delete`          | `blob.del(key, …)`.                                                                                                                                                                  |
+| `copy`            | `blob.copy(from, to, …)` with `access`, `addRandomSuffix`, `allowOverwrite`. Server-side, no body transfer.                                                                          |
+| `list`            | `blob.list({ prefix, limit, cursor, … })`. The `cursor` field is opaque — pass `result.cursor` back unmodified on the next page. Each item gets a lazy body factory that mirrors `head`. |
+| `url`             | See [URL behavior](#url-behavior).                                                                                                                                                   |
+| `signedUploadUrl` | **Throws `Provider`.** Vercel Blob has no presigned-upload primitive — browser uploads go through `handleUpload()` from `@vercel/blob/client`.                                       |
+
+A few non-obvious behaviours called out by tests:
+
+- **Stream uploads do a follow-up `blob.head`.** `blob.put`'s response
+  has no `size`, and stream bodies have no upfront length, so the
+  adapter consults `head` for authoritative `size` and `lastModified`.
+  Known-size bodies (`string`, `Uint8Array`, `ArrayBuffer`,
+  `ArrayBufferView`, `Blob`) skip the extra round trip.
+- **`download` always issues a `blob.head` first** to populate metadata;
+  only then is the body fetched (public path) or streamed (private path).
+- **Private downloads never touch `fetch()`.** Lazy bodies on private
+  `head()` / `list()` results route through `blob.get`, so a
+  misconfigured public URL can't leak unauthenticated 401s. Public-path
+  lazy bodies also honour `downloadTimeoutMs` so a hung CDN can't pin
+  the whole call.
+
+## URL behavior
+
+`url(key, opts?)` is the most adapter-specific method:
+
+- **Private blobs always throw `Provider`.** The `url` field that
+  `blob.head` / `blob.list` return for private blobs requires
+  authentication to fetch — handing it out from `url()` would silently
+  break the "permanent public URL" contract by returning links that
+  always 401. Use `download()` instead. The private check runs *before*
+  the storeId fast path, so a `vercel_blob_rw_<id>_…` token can't
+  override it.
+- **`opts.responseContentDisposition` always throws `Provider`** (public
+  *and* private). Vercel Blob has no signing primitive, so there is no
+  way to bind a `Content-Disposition` override. Silently dropping it
+  would be a stored-XSS regression on user-uploaded HTML or scripted
+  SVG (see `UrlOptions` in [`../index.ts`](../index.ts)). The error
+  message points to using a different provider for untrusted content.
+- **`opts.expiresIn` is ignored** on public blobs. The CDN URL is
+  permanent — there is no signing mechanism in which to encode an
+  expiry.
+- **StoreId fast path.** When a `storeId` is known (option,
+  `BLOB_STORE_ID` env, or derived from a `vercel_blob_rw_<id>_…` token)
+  **and** `addRandomSuffix` is `false`, `url()` synthesises
+  `https://<storeId>.public.blob.vercel-storage.com/<encoded-key>` via
+  [`joinPublicUrl`](../internal/core.ts) without any network call. Keys
+  are URL-encoded segment-by-segment; pass them raw.
+- **Fallback path.** When the fast-path conditions don't hold, `url()`
+  falls back to `blob.head(key)` and returns `result.url`; missing
+  `url` throws `Provider`.
+
+The token parser (`deriveStoreIdFromToken`) is intentionally
+conservative: it requires the exact `vercel_blob_rw_` prefix and an
+alphanumeric segment of ≥8 characters. If Vercel ever inserts a
+version segment (`vercel_blob_rw_v2_<id>_…`), shortens the storeId, or
+changes the separator, the candidate fails the shape check and the
+adapter falls back to `head()` — never to a URL pointing at someone
+else's store. Both regressions have dedicated tests.
+
+## Provider quirks worth remembering
+
+- **No metadata primitive.** `UploadOptions.metadata` is silently
+  dropped; `head()` / `list()` return `metadata: undefined` regardless
+  of what was passed at upload time. Caveat is documented on
+  `UploadOptions` in [`../index.ts`](../index.ts).
+- **No object-level `cacheControl` string.** `blob.put` only accepts a
+  numeric `cacheControlMaxAge`. The adapter parses `max-age=<n>` out of
+  the caller-supplied string and forwards just the number; the rest
+  (`public`, `s-maxage`, `stale-while-revalidate`, …) is dropped
+  silently. For full control, configure caching on the store itself.
+- **`signedUploadUrl()` throws by design.** Client-side uploads go
+  through `handleUpload()` from `@vercel/blob/client` — that package
+  implements the upload-token mechanism. Don't fake it with a PUT URL;
+  Vercel doesn't accept anonymous PUTs against the blob host.
+- **`addRandomSuffix` flips the upstream default.** Vercel ships `true`;
+  the adapter defaults to `false` so `upload(key, …)` keeps the
+  caller-supplied pathname. Under OIDC, `BLOB_STORE_ID` is the way to
+  opt into the URL fast path — the token parser refuses to guess from
+  unfamiliar token shapes.
+- **Private `blob.get` may resolve to `null` or a non-200 `statusCode`.**
+  Both are treated as `NotFound` so we never hand back a `StoredFile`
+  with a null stream — guarded by a dedicated test.
+
+## Testing approach
+
+Tests in [`../../test/vercel-blob.test.ts`](../../test/vercel-blob.test.ts)
+mock `@vercel/blob` directly via `mock.module(...)`, then dynamically
+import the adapter so the mocked module is in scope. Coverage areas:
+
+- Construction-time credential resolution: missing creds, partial OIDC
+  env, explicit `oidcToken` without `storeId`, explicit `token` beating
+  OIDC, OIDC env beating `BLOB_READ_WRITE_TOKEN`.
+- Operation delegation: every call site (`put`, `head`, `del`, `copy`,
+  `list`, `get`) passes auth options through and forwards `abortSignal`.
+- URL synthesis: storeId fast path with predictable keys, special-char
+  encoding, and all four fallbacks (unfamiliar token shape,
+  `addRandomSuffix: true`, `store_<id>` form, no derivable id).
+- Private mode: `access` propagates to `put` / `copy`, body reads route
+  through `blob.get`, `url()` throws even when the storeId fast path
+  would otherwise apply, `download` maps `null` / `404` / `403`
+  correctly.
+- Error surfaces: `signedUploadUrl` mentions `handleUpload`,
+  `responseContentDisposition` throws with a security-rationale
+  message, upload errors classify by HTTP status, name-based fallback
+  for `BlobNotFoundError`. Timeout: `download` passes an `AbortSignal`
+  derived from `downloadTimeoutMs`; `downloadTimeoutMs: 0` disables it.
+
+The fetch mock routes URLs containing `/missing` to a 404 — useful for
+forcing the public-fetch path to fail without breaking the `head()`
+mock. The `beforeEach` block clears `VERCEL_OIDC_TOKEN` /
+`BLOB_STORE_ID` from `process.env` so RW-token tests don't pick them
+up from the host shell.
+
+## Coding conventions
+
+- Named exports only — `vercelBlob`, `VercelBlobAdapter`,
+  `VercelBlobAdapterOptions`, `VercelBlobClient`. No default exports.
+- Wrap every `blob.*` call in try/catch that funnels through
+  `mapBlobError`. `FilesError` instances pass through unchanged.
+- Pick up env vars via [`readEnv`](../internal/env.ts). Direct
+  `process.env` access breaks Workers without `nodejs_compat`.
+- Use `createStoredFile` from
+  [`../internal/stored-file.ts`](../internal/stored-file.ts) for every
+  `StoredFile`. The lazy-body factory is the only place you should be
+  deciding between `fetch` and `blob.get`.
+- Forward `operationOpts.signal` to the SDK as
+  `{ abortSignal: signal }`. The download path uses
+  `withTimeoutSignal` to merge it with the configured timeout — keep
+  that helper local to this file.
+- Top-level regex literals only. `STORE_ID_RE` is the existing pattern;
+  follow the same shape if you add others.
+- Don't expand the URL fast path to `addRandomSuffix: true` — the
+  pathname is unknowable in advance, so any synthesised URL would
+  point at a different object.
+
+## Releases
+
+The repo uses Changesets. Behavioural changes need a changeset
+(`bunx changeset`, then commit under `.changeset/`). The
+[`vercel-blob-oidc.md`](../../../../.changeset/vercel-blob-oidc.md)
+entry is a good template for credential-resolution changes — it
+documents the new env vars, the resolution order, the peer dep floor
+bump, and the URL fast-path behaviour in one paragraph. Pure docs /
+test changes don't need a changeset. The `vercel-blob` subpath is
+already declared in [`../../package.json`](../../package.json) — no
+further wiring needed for new options.
+
+## Where to look next
+
+- Source: [`./index.ts`](./index.ts); tests:
+  [`../../test/vercel-blob.test.ts`](../../test/vercel-blob.test.ts).
+- Unified contract: [`../index.ts`](../index.ts); shared helpers in
+  [`../internal/`](../internal/).
+- User-facing docs:
+  [`../../../../apps/web/content/docs/adapters/vercel-blob.mdx`](../../../../apps/web/content/docs/adapters/vercel-blob.mdx).
+- Provider catalog (search `slug: "vercel-blob"`):
+  [`../providers/index.ts`](../providers/index.ts).
+- README: [`../../README.md`](../../README.md); SKILL:
+  [`../../../../skills/files-sdk/SKILL.md`](../../../../skills/files-sdk/SKILL.md);
+  OIDC changeset:
+  [`../../../../.changeset/vercel-blob-oidc.md`](../../../../.changeset/vercel-blob-oidc.md);
+  upstream: [`@vercel/blob`](https://www.npmjs.com/package/@vercel/blob).

--- a/packages/files-sdk/src/vercel-blob/CLAUDE.md
+++ b/packages/files-sdk/src/vercel-blob/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/packages/files-sdk/src/vultr/AGENTS.md
+++ b/packages/files-sdk/src/vultr/AGENTS.md
@@ -1,0 +1,220 @@
+# AGENTS.md — `files-sdk/vultr`
+
+Guidance for coding agents working inside the `vultr` adapter. The
+unified `Adapter<Raw>` contract — call shapes, `FilesError`,
+`UrlOptions`, `SignUploadOptions`, body normalization — lives in
+[`../index.ts`](../index.ts); this file documents only the
+vultr-specific deviations. `vultr()` is a thin wrapper around
+[`s3()`](../s3/index.ts) for Vultr Object Storage's S3-compatible API,
+so the operation map, error mapping, and presign mechanics live in
+the S3 adapter — see [`../s3/AGENTS.md`](../s3/AGENTS.md) for
+primitive-level details. Cross-references:
+[`README.md`](../../README.md),
+[`SKILL.md`](../../../../skills/files-sdk/SKILL.md).
+
+## Overview
+
+`vultr(opts)` returns an `Adapter<S3Client>`. It builds an `S3Client`
+via the shared `s3()` factory with four Vultr-specific overrides:
+endpoint defaults to `https://${region}.vultrobjects.com` (Vultr
+routes by Host header; the AWS SDK prepends the bucket subdomain);
+credential env fallback reads `VULTR_ACCESS_KEY_ID` /
+`VULTR_SECRET_ACCESS_KEY`; provider-error label is rewritten from
+`"S3 error"` to `"Vultr error"`; and the returned adapter's `name` is
+`"vultr"`, overriding `s3()`'s `"s3"`. Everything else — error
+mapping, signing, presigned POST forms, bulk delete chunking, the
+`publicBaseUrl` short-circuit, `exists()`'s 404-as-`false`
+classification — is inherited unchanged.
+
+## Directory layout
+
+```
+packages/files-sdk/src/vultr/
+├── index.ts        # vultr() factory + VultrAdapterOptions
+├── AGENTS.md       # this file
+└── CLAUDE.md       # @AGENTS.md — Claude-Code re-export
+```
+
+Tests at [`../../test/vultr.test.ts`](../../test/vultr.test.ts);
+user-facing docs at
+[`../../../../apps/web/content/docs/adapters/vultr.mdx`](../../../../apps/web/content/docs/adapters/vultr.mdx);
+provider-catalog entry under `slug: "vultr"` in
+[`../providers/index.ts`](../providers/index.ts).
+
+## Build, test, typecheck
+
+Run from `packages/files-sdk`:
+
+```bash
+bun test test/vultr.test.ts   # focused adapter tests
+bun test                       # whole SDK suite
+bun run build                  # tsup ESM bundle → dist/vultr/
+bun run types                  # tsgo --noEmit (typecheck only)
+```
+
+`tsgo` (typescript-go) — not `tsc`. The `vultr` subpath is enumerated
+in [`../../package.json`](../../package.json)'s `exports` map — keep
+it in sync. Tests use `bun:test` and `aws-sdk-client-mock` to stub
+the underlying `S3Client`.
+
+## Public surface
+
+Exports from [`index.ts`](./index.ts):
+
+- `vultr(opts: VultrAdapterOptions): VultrAdapter` — primary factory.
+- `VultrAdapter` — type alias for `Adapter<S3Client>`. `raw` is the
+  underlying `@aws-sdk/client-s3` client; reach for it for behaviour
+  the unified API doesn't model (multipart, lifecycle, bucket policy).
+- `VultrAdapterOptions` — config interface; JSDoc on every field is
+  the source of truth (docs MDX pulls it via `AutoTypeTable`).
+
+The factory sets `name: "vultr"` after spreading the inner adapter.
+
+## Authentication / configuration
+
+Required:
+
+- `bucket` — string. **No env fallback**; pass explicitly. Vultr
+  routes by Host header.
+- `region` — Vultr region code (`ewr`, `sjc`, `ams`, `blr`, `del`,
+  `sgp`, `lux`). **No env fallback** — missing region throws
+  `FilesError("Provider", …)` at construction. Drives the default
+  endpoint host and doubles as the SigV4 region.
+- Credentials — `accessKeyId` + `secretAccessKey`, passed in or
+  sourced from `VULTR_ACCESS_KEY_ID` / `VULTR_SECRET_ACCESS_KEY`.
+  Missing both throws `FilesError("Provider", …)`.
+
+Optional: `endpoint` (overrides
+`https://${region}.vultrobjects.com`); `forcePathStyle` (defaults to
+`false`, virtual-hosted is canonical); `publicBaseUrl` (origin used
+by `url()` when set, skipping signing — natural value is
+`https://${bucket}.${region}.vultrobjects.com` for public-ACL buckets
+or a custom CNAME); `defaultUrlExpiresIn` (presigned-URL expiry,
+defaults to `3600` via `DEFAULT_URL_EXPIRES_IN` in
+[`../internal/core.ts`](../internal/core.ts)).
+
+There is no `VULTR_REGION` or `VULTR_BUCKET` convention. The
+provider-catalog entry under `slug: "vultr"` in
+[`../providers/index.ts`](../providers/index.ts) mirrors this. Env
+lookups go through [`readEnv`](../internal/env.ts) so the adapter is
+safe to import on runtimes without `process` (Cloudflare Workers
+without `nodejs_compat`).
+
+## Operation map
+
+`vultr()` calls `s3()` and spreads the returned adapter, overriding
+only `name`. Every method (`upload`, `download`, `head`, `exists`,
+`delete`, `deleteMany`, `copy`, `list`, `url`, `signedUploadUrl`) is
+the inner `s3()` implementation unchanged — including `deleteMany`'s
+1000-key chunking, `signedUploadUrl`'s PUT-vs-presigned-POST split on
+`maxSize`, and `exists`' 404-as-`false` classification. Provider
+errors flow through `mapS3Error` with the Vultr fallback table; the
+upstream message survives when present.
+
+## URL behavior
+
+`url(key, opts?)` follows the standard signing-adapter rules:
+
+- Default: presigned `GetObject` URL, expiring after
+  `opts.expiresIn ?? defaultUrlExpiresIn` seconds (default `3600`).
+- With `publicBaseUrl`: returns `${publicBaseUrl}/${key}` unsigned via
+  `joinPublicUrl` from [`../internal/core.ts`](../internal/core.ts)
+  (URL-encodes path segments — pass raw keys, not pre-encoded ones).
+- With `opts.responseContentDisposition`: always signs, even when
+  `publicBaseUrl` is set — a permanent URL has no signature in which
+  to bind the override, and silently dropping it would be a stored-XSS
+  regression on user-uploaded HTML/SVG. See `resolveUrlStrategy` in
+  [`../internal/core.ts`](../internal/core.ts) for the rationale.
+
+Vultr has no built-in CDN, so `publicBaseUrl` is rare — typical
+deployments leave it unset and let every read flow through a presigned URL.
+
+## Provider quirks worth remembering
+
+- **Region codes are short and drive everything.** Three lower-case
+  letters, no `-1` suffix. The same value drives both the endpoint
+  host (`https://${region}.vultrobjects.com`) and the SigV4 region,
+  so a wrong region fails signing before reaching the cluster. Don't
+  substitute AWS-style names.
+- **No native CDN.** `publicBaseUrl` is only useful with public-ACL
+  buckets (natural value
+  `https://${bucket}.${region}.vultrobjects.com/${key}`) or an
+  external CDN (Cloudflare, Bunny, …).
+- **Wire-compatible with S3, not feature-parity.** Object Lock and
+  versioning are absent — `raw` calls for them fail at the wire.
+- **Static credentials only.** Access keys come from the Vultr portal
+  under Object Storage → your subscription → Overview. No IAM-role
+  equivalent.
+
+## Testing approach
+
+[`../../test/vultr.test.ts`](../../test/vultr.test.ts) covers the
+wrapper-specific behaviour:
+
+- **Endpoint derivation.** Region drives the default host
+  (`ewr.vultrobjects.com`, `ams.vultrobjects.com`); explicit
+  `endpoint` overrides; `forcePathStyle` defaults to `false` and an
+  explicit `true` is forwarded.
+- **Credential resolution.** Explicit options win;
+  `VULTR_ACCESS_KEY_ID` / `VULTR_SECRET_ACCESS_KEY` are the
+  fallbacks; missing region or credentials throw at construction.
+- **URL strategy.** Default `url()` signs (`X-Amz-Signature=`,
+  `X-Amz-Expires=3600`, `ewr.vultrobjects.com`); `publicBaseUrl`
+  short-circuits to plain `${base}/${key}`.
+- **Delegation.** `upload` and `exists` go through
+  `aws-sdk-client-mock`'s `mockClient(S3Client)` to catch wrapper
+  regressions (dropping `defaultProviderMessage` or `endpoint`).
+- **Error relabelling.** `mapS3Error` with the Vultr messages table
+  returns `"Vultr error"` for `Provider`.
+
+Add wrapper-specific fixtures here; shared S3 semantics belong in
+[`../../test/s3.test.ts`](../../test/s3.test.ts).
+
+## Coding conventions
+
+- Named exports only — `vultr`, `VultrAdapter`, `VultrAdapterOptions`.
+- Construction-time errors use
+  [`FilesError("Provider", …)`](../internal/errors.ts); runtime errors
+  are the inner S3 adapter's responsibility — don't try-catch and
+  rethrow in this shim.
+- Read environment via [`readEnv`](../internal/env.ts) — direct
+  `process.env` breaks Cloudflare Workers without `nodejs_compat`.
+- Forward optional knobs with
+  `...(opts.x !== undefined && { x: opts.x })` so unset values fall
+  through to AWS-SDK defaults rather than explicit `undefined`.
+- Spread the inner adapter, then override only `name` — preserves any
+  future additions to the `Adapter` interface that `s3()` picks up.
+
+## Releases
+
+Ships with the rest of `files-sdk` from
+[`../../package.json`](../../package.json). Behavioural changes bump
+the `files-sdk` version and add an entry to
+[`../../CHANGELOG.md`](../../CHANGELOG.md); docs / test-only
+additions don't. When adding an option: extend `VultrAdapterOptions`
+with JSDoc naming any env fallback and default, thread it into
+`s3({...})` with `...(opt !== undefined && { opt })`, mirror
+user-visible env vars in
+[`../providers/index.ts`](../providers/index.ts), and add a
+wrapper-level test.
+
+## Where to look next
+
+- Source / tests: [`./index.ts`](./index.ts),
+  [`../../test/vultr.test.ts`](../../test/vultr.test.ts)
+- Inner S3 adapter (almost all behaviour lives here):
+  [`../s3/index.ts`](../s3/index.ts) +
+  [`../s3/AGENTS.md`](../s3/AGENTS.md)
+- Unified `Adapter<Raw>` contract: [`../index.ts`](../index.ts)
+- Shared helpers (`joinPublicUrl`, `resolveUrlStrategy`,
+  `makeErrorMapper`, `existsByProbe`):
+  [`../internal/core.ts`](../internal/core.ts)
+- `FilesError` / `FilesErrorCode`:
+  [`../internal/errors.ts`](../internal/errors.ts);
+  env-var reader: [`../internal/env.ts`](../internal/env.ts)
+- Provider-catalog entry (search `slug: "vultr"`):
+  [`../providers/index.ts`](../providers/index.ts)
+- User-facing docs:
+  [`../../../../apps/web/content/docs/adapters/vultr.mdx`](../../../../apps/web/content/docs/adapters/vultr.mdx)
+- Package README: [`../../README.md`](../../README.md); integration
+  skill: [`../../../../skills/files-sdk/SKILL.md`](../../../../skills/files-sdk/SKILL.md)

--- a/packages/files-sdk/src/vultr/CLAUDE.md
+++ b/packages/files-sdk/src/vultr/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/packages/files-sdk/src/wasabi/AGENTS.md
+++ b/packages/files-sdk/src/wasabi/AGENTS.md
@@ -1,0 +1,220 @@
+# AGENTS.md — `files-sdk/wasabi`
+
+Guidance for coding agents working on the `wasabi` adapter. The unified
+`Adapter` contract — call shapes, `FilesError`, `UrlOptions`,
+`SignUploadOptions`, body normalization — lives in
+[`../index.ts`](../index.ts); this file only documents wasabi-specific
+behavior. `wasabi()` is a thin wrapper around [`s3()`](../s3/index.ts)
+for [Wasabi Hot Cloud Storage](https://wasabi.com)'s S3-compatible API,
+so the operation map, error mapping, and presign mechanics live in the
+S3 adapter — see [`../s3/AGENTS.md`](../s3/AGENTS.md) for primitive-level
+details. Cross-references: [`README.md`](../../README.md),
+[`SKILL.md`](../../../../skills/files-sdk/SKILL.md).
+
+## Overview
+
+A thin shim that calls `s3()` with a Wasabi endpoint, Wasabi credentials,
+and a `defaultProviderMessage` of `"Wasabi error"` so callers don't see
+`"S3 error"` from a Wasabi-typed adapter. No per-method code here: every
+operation is forwarded by spread. The only wasabi-specific knobs are
+endpoint derivation from the region code, the credential env-var pair,
+and the error-message relabel. The returned adapter's `raw` is the
+underlying `@aws-sdk/client-s3` `S3Client` — anything the AWS SDK can do
+against Wasabi (multipart, object lock, lifecycle rules) is one property
+access away.
+
+## Directory layout
+
+```
+packages/files-sdk/src/wasabi/
+├── index.ts                   # wasabi() factory + WasabiAdapterOptions
+├── AGENTS.md                  # this file
+└── CLAUDE.md                  # @AGENTS.md — Claude-Code re-export
+```
+
+Tests at [`../../test/wasabi.test.ts`](../../test/wasabi.test.ts);
+user-facing docs at
+[`../../../../apps/web/content/docs/adapters/wasabi.mdx`](../../../../apps/web/content/docs/adapters/wasabi.mdx).
+
+## Build, test, typecheck
+
+Run from `packages/files-sdk`:
+
+```bash
+bun test test/wasabi.test.ts   # adapter unit tests only
+bun test                        # full SDK suite
+bun run build                   # tsup → dist/, including dist/wasabi/
+bun run types                   # tsgo --noEmit (typecheck only)
+```
+
+The `wasabi` subpath is enumerated in
+[`../../package.json`](../../package.json)'s `exports` map — keep that
+entry in sync if the file layout changes.
+
+## Public surface
+
+Exports from [`index.ts`](./index.ts):
+
+- `wasabi(opts: WasabiAdapterOptions): WasabiAdapter` — primary factory.
+- `WasabiAdapter` — type alias for `Adapter<S3Client>`. `raw` is the
+  underlying AWS SDK client.
+- `WasabiAdapterOptions` — config interface (JSDoc on every field is
+  the source of truth; the docs MDX pulls it via `AutoTypeTable`).
+
+The adapter's `name` is `"wasabi"` (set after spreading the inner
+adapter, so it overrides the S3 adapter's `"s3"`).
+
+## Authentication / configuration
+
+Required:
+
+- `bucket` — string. **No env fallback**; pass it explicitly.
+- `region` — Wasabi region code (`us-east-1`, `eu-central-1`,
+  `ap-northeast-1`, … — see the JSDoc on `WasabiAdapterOptions.region`
+  for the full list). Names mirror AWS but the endpoints are Wasabi's
+  own. **No env fallback** — missing region throws
+  `FilesError("Provider", …)` at construction.
+- Credentials — `accessKeyId` + `secretAccessKey`, passed in or sourced
+  from `WASABI_ACCESS_KEY_ID` / `WASABI_SECRET_ACCESS_KEY`. Missing both
+  throws `FilesError("Provider", …)`.
+
+Optional:
+
+- `endpoint` — overrides the derived `https://s3.${region}.wasabisys.com`.
+  Use for VPC endpoints, region-private DNS, or test doubles.
+- `forcePathStyle` — defaults to `false`. Virtual-hosted is canonical
+  for Wasabi; only flip this for proxies that demand path-style.
+- `publicBaseUrl` — origin used by `url()` when set; skips signing.
+  Natural value when used is
+  `https://${bucket}.s3.${region}.wasabisys.com` for public-read
+  buckets, or a custom CNAME fronting the bucket.
+- `defaultUrlExpiresIn` — default presigned-URL expiry in seconds.
+  Defaults to `3600` via `DEFAULT_URL_EXPIRES_IN` in
+  [`../internal/core.ts`](../internal/core.ts).
+
+There is no `WASABI_REGION` or `WASABI_BUCKET` env-var fallback. The
+provider catalog entry in [`../providers/index.ts`](../providers/index.ts)
+(search `slug: "wasabi"`) declares the same two credential env vars and
+treats `bucket` / `region` as explicit config. Env lookups go through
+[`readEnv`](../internal/env.ts) so the adapter is safe to import on
+runtimes without `process` (Cloudflare Workers without `nodejs_compat`).
+
+## Operation map
+
+`wasabi()` calls `s3()` with the resolved config and spreads the
+returned adapter, overriding only `name`. The implementations of
+`upload`, `download`, `head`, `exists`, `delete`, `deleteMany`, `copy`,
+`list`, `url`, and `signedUploadUrl` all live in
+[`../s3/index.ts`](../s3/index.ts) and are inherited unchanged —
+including `deleteMany`'s 1000-key chunking, `signedUploadUrl`'s
+PUT-vs-presigned-POST split on `maxSize`, and `exists`' 404-as-`false`
+classification. Provider errors flow through `mapS3Error` with the
+Wasabi fallback table — `Provider`-coded messages read `"Wasabi error"`
+instead of `"S3 error"` while preserving any server-side message on the
+wire.
+
+## URL behavior
+
+`url(key, opts?)` follows the standard signing-adapter rules:
+
+- Default: presigned `GetObject` URL, expiring after
+  `opts.expiresIn ?? defaultUrlExpiresIn` seconds.
+- With `publicBaseUrl`: returns `${publicBaseUrl}/${key}` unsigned, via
+  `joinPublicUrl` from [`../internal/core.ts`](../internal/core.ts)
+  (URL-encodes path segments).
+- With `opts.responseContentDisposition`: always signs, even when
+  `publicBaseUrl` is set — a permanent CDN URL has no signature in which
+  to bind the override, and silently dropping it would be a stored-XSS
+  regression on user-uploaded HTML/SVG. See `resolveUrlStrategy` in
+  [`../internal/core.ts`](../internal/core.ts) for the rationale.
+
+Wasabi has no built-in CDN, so the common configuration leaves
+`publicBaseUrl` unset and lets every read flow through a presigned URL.
+
+## Provider quirks worth remembering
+
+- **Region names mirror AWS, endpoints don't.** A bucket in `us-east-1`
+  lives at `s3.us-east-1.wasabisys.com`, not the AWS origin. The region
+  also doubles as the SigV4 region — pick the wrong one and signatures
+  fail before the request reaches the bucket.
+- **Buckets are single-region.** Pick at create time; there is no
+  cross-region replication primitive in the Wasabi console.
+- **No native CDN.** `publicBaseUrl` is rare for Wasabi — set it only
+  when you've put a CDN (Cloudflare, Bunny, …) in front of the bucket
+  manually.
+- **90-day minimum storage duration (billing only).** Objects deleted
+  before 90 days are still billed for the remainder. Wasabi billing
+  rule, not SDK behavior — `delete()` still removes the object
+  immediately. Worth surfacing to users planning high-churn workloads.
+- **No egress fees** in normal use. Doesn't change the API surface but
+  shifts the cost math against S3/R2 for read-heavy workloads.
+- **Access keys** are generated in the Wasabi console under *Access
+  Keys*. No IAM-role equivalent — static credentials are the only
+  auth mode the S3-compatible API exposes.
+
+## Testing approach
+
+Unit tests at [`../../test/wasabi.test.ts`](../../test/wasabi.test.ts)
+cover:
+
+- Endpoint derivation from `region` (`us-east-1`, `eu-central-1`).
+- Explicit `endpoint` and `forcePathStyle` overrides reaching the inner
+  `S3Client` config.
+- Missing-region and missing-credential errors at construction.
+- `WASABI_ACCESS_KEY_ID` / `WASABI_SECRET_ACCESS_KEY` env-var fallbacks.
+- `url()` presign default and `publicBaseUrl` short-circuit.
+- Operation delegation via `aws-sdk-client-mock`'s `mockClient(S3Client)`
+  — proves `upload` and `exists` reach the underlying client.
+- Error relabeling: `mapS3Error` invoked with the Wasabi messages table
+  returns `"Wasabi error"` for `Provider`.
+
+Add fixtures here rather than to `s3.test.ts` whenever a behavior depends
+on the wasabi-specific config (endpoint host, relabel, env-var name);
+shared S3 semantics belong in
+[`../../test/s3.test.ts`](../../test/s3.test.ts).
+
+## Coding conventions
+
+- Named exports only — `wasabi`, `WasabiAdapter`, `WasabiAdapterOptions`.
+- Construction-time errors use
+  [`FilesError("Provider", …)`](../internal/errors.ts); operation errors
+  are the inner S3 adapter's responsibility — don't try-catch and
+  rethrow in this shim.
+- Pick up environment variables via [`readEnv`](../internal/env.ts).
+  Direct `process.env` access breaks Cloudflare Workers without
+  `nodejs_compat`.
+- Forward optional knobs with `...(opts.x !== undefined && { x: opts.x })`
+  so unset values fall through to AWS-SDK defaults rather than being
+  passed as explicit `undefined`.
+- Spread the inner adapter, then override only `name` — preserves any
+  future additions to the `Adapter` interface that `s3()` picks up
+  automatically.
+- Top-level regex literals only. The current file has none; keep it
+  that way unless adding a real parser.
+
+## Releases
+
+Ships with the rest of the monorepo from
+[`../../package.json`](../../package.json). Behavioral changes (new
+options, default changes, error-shape changes) bump the `files-sdk`
+version and add an entry to [`../../CHANGELOG.md`](../../CHANGELOG.md);
+pure docs / test-only additions don't. The `wasabi` subpath is already
+declared in `exports` — no further wiring needed for new options.
+
+## Where to look next
+
+- Unified contract & `Adapter` interface: [`../index.ts`](../index.ts).
+- Inner S3 adapter: [`../s3/index.ts`](../s3/index.ts) +
+  [`../s3/AGENTS.md`](../s3/AGENTS.md).
+- Shared helpers (URL strategy, body normalization, error-mapper
+  factory): [`../internal/core.ts`](../internal/core.ts).
+- `FilesError` and codes: [`../internal/errors.ts`](../internal/errors.ts).
+- Env-var reader: [`../internal/env.ts`](../internal/env.ts).
+- Provider catalog entry (search `slug: "wasabi"`):
+  [`../providers/index.ts`](../providers/index.ts).
+- User-facing docs:
+  [`../../../../apps/web/content/docs/adapters/wasabi.mdx`](../../../../apps/web/content/docs/adapters/wasabi.mdx).
+- Package README: [`../../README.md`](../../README.md).
+- SKILL doc:
+  [`../../../../skills/files-sdk/SKILL.md`](../../../../skills/files-sdk/SKILL.md).
+- Tests: [`../../test/wasabi.test.ts`](../../test/wasabi.test.ts).

--- a/packages/files-sdk/src/wasabi/CLAUDE.md
+++ b/packages/files-sdk/src/wasabi/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/packages/files-sdk/src/yandex/AGENTS.md
+++ b/packages/files-sdk/src/yandex/AGENTS.md
@@ -1,0 +1,220 @@
+# AGENTS.md — `files-sdk/yandex`
+
+Guidance for coding agents working on the `yandex` adapter. The unified
+`Adapter` contract — call shapes, `FilesError`, `UrlOptions`,
+`SignUploadOptions`, body normalization — lives in
+[`../index.ts`](../index.ts); this file only documents yandex-specific
+behavior. `yandex()` is a thin wrapper around [`s3()`](../s3/index.ts)
+for [Yandex Object Storage](https://yandex.cloud/en/services/storage)'s
+S3-compatible API, so the operation map, error mapping, and presign
+mechanics live in the S3 adapter — see
+[`../s3/AGENTS.md`](../s3/AGENTS.md) for primitive-level details. Cross-refs:
+[`README.md`](../../README.md),
+[`SKILL.md`](../../../../skills/files-sdk/SKILL.md).
+
+## Overview
+
+A thin shim that calls `s3()` with Yandex's fixed global endpoint
+(`https://storage.yandexcloud.net`), a SigV4 region default of
+`"ru-central1"`, Yandex credentials, and a `defaultProviderMessage` of
+`"Yandex Cloud error"` so callers don't see `"S3 error"` from a
+Yandex-typed adapter. No per-method code; every operation is forwarded
+by spreading the inner adapter. The only yandex-specific knobs are the
+fixed endpoint, the region default, the credential env-var pair, and
+the error-message relabel. The returned adapter's `raw` is the
+underlying `@aws-sdk/client-s3` `S3Client` — anything the AWS SDK can
+do against Yandex Object Storage (multipart, versioning, lifecycle
+rules, static-website hosting) is one property access away.
+
+## Directory layout
+
+```text
+packages/files-sdk/src/yandex/
+├── index.ts                   # yandex() factory + YandexAdapterOptions
+├── AGENTS.md                  # this file
+└── CLAUDE.md                  # @AGENTS.md — Claude Code re-export
+```
+
+Tests at [`../../test/yandex.test.ts`](../../test/yandex.test.ts); user-facing
+docs at [`../../../../apps/web/content/docs/adapters/yandex.mdx`](../../../../apps/web/content/docs/adapters/yandex.mdx).
+
+## Build, test, typecheck
+
+Run from `packages/files-sdk`:
+
+```bash
+bun test test/yandex.test.ts   # adapter unit tests only
+bun test                       # full SDK suite
+bun run build                  # tsup → dist/, including dist/yandex/
+bun run types                  # tsgo --noEmit (typecheck only)
+```
+
+The `yandex` subpath is enumerated in
+[`../../package.json`](../../package.json)'s `exports` map — keep that
+entry in sync if the file layout changes.
+
+## Public surface
+
+Exports from [`index.ts`](./index.ts):
+
+- `yandex(opts: YandexAdapterOptions): YandexAdapter` — primary factory.
+- `YandexAdapter` — alias for `Adapter<S3Client>`. `raw` is the
+  underlying AWS SDK client.
+- `YandexAdapterOptions` — config interface (JSDoc on every field is
+  the source of truth; the docs MDX pulls it via `AutoTypeTable`).
+
+The adapter's `name` is `"yandex"`, set after spreading the inner
+adapter so it overrides `"s3"`.
+
+## Authentication / configuration
+
+Required:
+
+- `bucket` — string. **No env fallback**; pass it explicitly.
+- Credentials — `accessKeyId` + `secretAccessKey`, passed in or sourced
+  from `YANDEX_ACCESS_KEY_ID` / `YANDEX_SECRET_ACCESS_KEY`. Missing
+  both throws `FilesError("Provider", …)` at construction. Generate
+  static key pairs in the Yandex Cloud console for a service account
+  with `storage.editor` (or `storage.viewer` for read-only bots).
+
+Optional:
+
+- `endpoint` — defaults to `https://storage.yandexcloud.net`. Yandex
+  serves a single global endpoint and routes internally; only override
+  for a private deployment, proxy, or test double.
+- `region` — defaults to `"ru-central1"`. SigV4-only; the endpoint is
+  fixed, so the label drives signing but never routing. Leave the
+  default unless you have a reason to change it.
+- `forcePathStyle` — defaults to `false`. Virtual-hosted is canonical
+  for Yandex Object Storage.
+- `publicBaseUrl` — origin used by `url()` when set; skips signing.
+  Natural value is `https://${bucket}.storage.yandexcloud.net`, or a
+  custom CNAME bound to the bucket via the Yandex console.
+- `defaultUrlExpiresIn` — presigned-URL expiry in seconds. Defaults to
+  `3600` via `DEFAULT_URL_EXPIRES_IN`
+  ([`../internal/core.ts`](../internal/core.ts)).
+
+There is no `YANDEX_REGION`, `YANDEX_ENDPOINT`, or `YANDEX_BUCKET`
+fallback. The provider catalog entry in
+[`../providers/index.ts`](../providers/index.ts) (search
+`slug: "yandex"`) declares the same two credential env vars and treats
+`bucket` as explicit config — region is omitted because the adapter
+defaults it. Env lookups go through [`readEnv`](../internal/env.ts) so
+the adapter is safe on runtimes without `process` (Cloudflare Workers
+without `nodejs_compat`).
+
+## Operation map
+
+`yandex()` calls `s3()` with the resolved config and spreads the
+returned adapter, overriding only `name`. `upload`, `download`,
+`head`, `exists`, `delete`, `deleteMany`, `copy`, `list`, `url`, and
+`signedUploadUrl` all live in [`../s3/index.ts`](../s3/index.ts) and
+are inherited unchanged — including `deleteMany`'s 1000-key chunking,
+`signedUploadUrl`'s PUT-vs-presigned-POST split on `maxSize`, and
+`exists`' 404-as-`false` classification. Provider errors flow through
+`mapS3Error` with the Yandex fallback table — `Provider`-coded
+messages read `"Yandex Cloud error"` while preserving any server-side
+message on the wire.
+
+## URL behavior
+
+`url(key, opts?)` follows the standard signing-adapter rules:
+
+- Default: presigned `GetObject` URL, expiring after
+  `opts.expiresIn ?? defaultUrlExpiresIn` seconds. Host is always
+  `storage.yandexcloud.net` (or your override).
+- With `publicBaseUrl`: returns `${publicBaseUrl}/${key}` unsigned, via
+  `joinPublicUrl` (URL-encodes path segments).
+- With `opts.responseContentDisposition`: always signs, even when
+  `publicBaseUrl` is set — a permanent CDN URL has no signature in
+  which to bind the override, and silently dropping it would be a
+  stored-XSS regression on user-uploaded HTML/SVG. See
+  `resolveUrlStrategy` in [`../internal/core.ts`](../internal/core.ts).
+
+Yandex has no built-in CDN, so most configurations leave `publicBaseUrl`
+unset and sign every read.
+
+## Provider quirks worth remembering
+
+- **Single global endpoint.** Unlike Wasabi, Scaleway, or OVH, Yandex
+  serves all traffic from `storage.yandexcloud.net` and routes
+  internally. `region` is signing-only — overriding it does not change
+  the host, and `test/yandex.test.ts` pins this invariant.
+- **`ru-central1` is the only public signing region today.** The
+  default works for every bucket in the public service; only override
+  for a private deployment with a different SigV4 label.
+- **Service-account static keys, no IAM-role analog.** Generate static
+  access keys for a service account in the Yandex Cloud console — the
+  S3-compatible API has no short-lived instance-metadata path.
+- **Russia-regulated service.** Data lives in Russian datacenters;
+  weigh data-residency and sanctions exposure before pointing user
+  data here. Worth flagging when reviewing the adapter choice.
+- **Custom domains for public reads.** Yandex lets you bind a CNAME to
+  a public bucket. When configured, set `publicBaseUrl` to the custom
+  origin and `url()` will skip signing.
+
+## Testing approach
+
+Unit tests at [`../../test/yandex.test.ts`](../../test/yandex.test.ts)
+cover:
+
+- Defaults: `storage.yandexcloud.net` over `https:`, `ru-central1`
+  region, `forcePathStyle: false`.
+- Region override flows to the inner `S3Client` without changing the
+  endpoint host; `endpoint` and `forcePathStyle: true` overrides reach
+  the inner client.
+- Missing-credential error at construction; `YANDEX_ACCESS_KEY_ID` /
+  `YANDEX_SECRET_ACCESS_KEY` env-var fallbacks.
+- `url()` presign default (signature present, `X-Amz-Expires=3600`,
+  host = `storage.yandexcloud.net`) and `publicBaseUrl` short-circuit.
+- Operation delegation via `aws-sdk-client-mock`'s
+  `mockClient(S3Client)` — `upload` and `exists` reach the underlying
+  client and `exists` returns `false` on a 404.
+- Error relabeling: `mapS3Error` with the Yandex messages table
+  returns `"Yandex Cloud error"` for `Provider`.
+
+Add fixtures here for yandex-specific config (fixed endpoint,
+`ru-central1` default, relabel, env-var names); shared S3 semantics
+belong in [`../../test/s3.test.ts`](../../test/s3.test.ts).
+
+## Coding conventions
+
+- Named exports only — `yandex`, `YandexAdapter`, `YandexAdapterOptions`.
+- Construction-time errors use
+  [`FilesError("Provider", …)`](../internal/errors.ts); operation
+  errors are the inner S3 adapter's responsibility — don't try-catch
+  and rethrow here.
+- Read env vars via [`readEnv`](../internal/env.ts); direct `process.env`
+  breaks Cloudflare Workers without `nodejs_compat`.
+- Forward optional knobs with
+  `...(opts.x !== undefined && { x: opts.x })` so unset values fall
+  through to AWS-SDK defaults instead of being passed as explicit
+  `undefined`.
+- Spread the inner adapter, then override only `name` — future
+  additions to the `Adapter` interface that `s3()` picks up are
+  inherited automatically. Top-level regex literals only.
+
+## Releases
+
+Ships with the rest of the monorepo from
+[`../../package.json`](../../package.json). Behavioral changes (new
+options, default changes, error-shape changes) bump `files-sdk` and
+add an entry to [`../../CHANGELOG.md`](../../CHANGELOG.md); docs /
+test-only additions don't. The `yandex` subpath is already declared
+in `exports`.
+
+## Where to look next
+
+- Unified contract: [`../index.ts`](../index.ts).
+- Inner S3 adapter: [`../s3/index.ts`](../s3/index.ts),
+  [`../s3/AGENTS.md`](../s3/AGENTS.md).
+- Shared helpers: [`../internal/core.ts`](../internal/core.ts),
+  [`../internal/errors.ts`](../internal/errors.ts),
+  [`../internal/env.ts`](../internal/env.ts).
+- Provider catalog (search `slug: "yandex"`):
+  [`../providers/index.ts`](../providers/index.ts).
+- User docs:
+  [`../../../../apps/web/content/docs/adapters/yandex.mdx`](../../../../apps/web/content/docs/adapters/yandex.mdx).
+- README, SKILL, tests: [`../../README.md`](../../README.md),
+  [`../../../../skills/files-sdk/SKILL.md`](../../../../skills/files-sdk/SKILL.md),
+  [`../../test/yandex.test.ts`](../../test/yandex.test.ts).

--- a/packages/files-sdk/src/yandex/CLAUDE.md
+++ b/packages/files-sdk/src/yandex/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
Adds `AGENTS.md` and `CLAUDE.md` (`@AGENTS.md` re-export) beside each of the 40 storage adapter entry points under `packages/files-sdk/src/<adapter>/`, following the same pattern as Chat SDK adapter packages.

- **s3** — foundational adapter guide other S3 shims reference
- **r2 / bun-s3** — binding, HTTP, hybrid, and Bun-native variants
- **S3-compatible shims** — regional and hosted providers that wrap `s3()`
- **Native cloud blob** — GCS, Azure, Vercel Blob, Netlify Blobs, Supabase
- **File providers** — Dropbox, Google Drive, OneDrive, Box, SharePoint
- **Specialty** — Bunny Storage, Appwrite, Cloudinary, UploadThing, PocketBase, Firebase Storage, Convex, local `fs`

Docs-only; no runtime or API changes.