### PR TITLE
Sync package.json version to published 1.5.0

### DIFF
--- a/packages/files-sdk/package.json
+++ b/packages/files-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "files-sdk",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Unified storage SDK for object/blob backends.",
   "homepage": "https://github.com/haydenbleasel/files-sdk#readme",
   "bugs": {


### PR DESCRIPTION
## Problem

PR #44 ("Version Packages") proposes releasing **1.5.0**, but 1.5.0 is already live on npm.

Root cause: `packages/files-sdk/package.json` was inadvertently reverted from `1.5.0` to `1.4.0` in 26989e0 ("Serve docs from npm package") while adding `docs` to the `files` array — even though 1.5.0 had already been published via PR #41.

Changesets only reads `package.json` (it has no knowledge of npm), so it sees the base as 1.4.0 + accumulated minor changesets and computes 1.5.0 again.

## Fix

Realign `package.json` with the actual published version (1.5.0). Once merged, changesets will recompute PR #44 as **1.6.0** (1.5.0 + minor), matching the intended next release.