### PR TITLE
Update redirects and footer links to point to the new overview page

### DIFF
--- a/apps/web/components/sections/footer.tsx
+++ b/apps/web/components/sections/footer.tsx
@@ -1,7 +1,7 @@
 import Link from "next/link";
 
 const PROJECT_LINKS = [
-  { href: "/docs", label: "Docs" },
+  { href: "/overview", label: "Docs" },
   { href: "/adapters", label: "Adapters" },
   { href: "/api", label: "API" },
   { href: "/cli", label: "CLI" },

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -6,6 +6,11 @@ const withMDX = createMDX();
 const nextConfig: NextConfig = {
   redirects: () => [
     {
+      destination: "/overview",
+      permanent: true,
+      source: "/docs",
+    },
+    {
       destination: "/adapters/s3",
       permanent: false,
       source: "/adapters",


### PR DESCRIPTION
## Description

Fixes the footer "Docs" link, which pointed to `/docs` and returned a 404 on production.

Docs are served at root paths (`/overview`, `/api`, etc.) via Fumadocs with `baseUrl: "/"`, so `/docs` was never a valid route. This PR:

- Updates the footer "Docs" link to `/overview` (getting-started hub)
- Adds a permanent redirect from `/docs` → `/overview` for bookmarks and external links

## Related Issues

<!-- Closes #<issue_number> -->

N/A

## Checklist

- [x] I've reviewed my code
- [ ] I've written tests
- [ ] I've generated a change set file
- [ ] I've updated the docs, if necessary

## Screenshots (if applicable)

Current prod:

<img width="1328" height="1895" alt="CleanShot 2026-05-25 at 11  30 40@2x" src="https://github.com/user-attachments/assets/0e49b3db-be57-461d-bb5e-c16ca5403aaa" />


## Additional Notes

- Footer "API" still points to `/api`; hero/final-CTA "Read the docs" links are unchanged.
- No package or docs content changes, so no changeset or MDX updates needed.