### PR TITLE
Fix CLI lazy provider imports

### DIFF
--- a/.changeset/cli-lazy-provider-imports.md
+++ b/.changeset/cli-lazy-provider-imports.md
@@ -1,0 +1,5 @@
+---
+"files-sdk": patch
+---
+
+Fix the CLI eagerly importing optional provider peer dependencies. The bundler previously inlined the registry's lazily-imported provider modules into `dist/cli/index.js`, hoisting their external imports (e.g. `@netlify/blobs`) to the top level — so `files --help` crashed with `ERR_MODULE_NOT_FOUND` unless every optional peer was installed. The build now emits shared chunks so the registry's `await import(...)` calls stay genuinely dynamic: provider-independent commands run without any optional peers installed, and a missing peer only surfaces when its provider is actually selected.

--- a/packages/files-sdk/scripts/build.ts
+++ b/packages/files-sdk/scripts/build.ts
@@ -1,8 +1,9 @@
 #!/usr/bin/env bun
 import { watch as fsWatch } from "node:fs";
 // Build the package: JS via Bun's bundler, .d.ts via tsgo, then mirror the docs.
-// Replaces tsup. Bun bundles each entry (no shared chunks, externals stay
-// external); tsgo emits per-file declarations into the same dist/ tree.
+// Replaces tsup. Bun bundles entries with shared chunks enabled so dynamic
+// imports stay lazy; externals stay external. tsgo emits per-file declarations
+// into the same dist/ tree.
 import { rm } from "node:fs/promises";
 import { resolve } from "node:path";
 
@@ -40,7 +41,7 @@ const buildJs = async () => {
     outdir: dist,
     root: srcDir,
     sourcemap: "linked",
-    splitting: false,
+    splitting: true,
     target: "node",
   });
   if (!result.success) {

--- a/packages/files-sdk/test/build-output.test.ts
+++ b/packages/files-sdk/test/build-output.test.ts
@@ -1,0 +1,60 @@
+import { expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+
+import pkg from "../package.json" with { type: "json" };
+
+// Regression guard for #67: the published CLI bundle must never statically
+// import an optional peer dependency. The registry lazy-loads providers via
+// `await import(...)`, but a bundler config change (e.g. `splitting: false`)
+// can inline those modules and hoist their external imports to the top level,
+// making `files --help` crash unless every optional peer is installed. This
+// walks the transitive *static* import graph of dist/cli/index.js — dynamic
+// imports are exactly the lazy boundary, so they're not followed.
+
+const distDir = resolve(import.meta.dirname, "../dist");
+
+const optionalPeers = Object.entries(pkg.peerDependenciesMeta ?? {})
+  .filter(([, meta]) => (meta as { optional?: boolean }).optional)
+  .map(([name]) => name);
+
+/** Collect every external specifier reachable from `entry` via static imports. */
+const staticExternals = (entry: string): Set<string> => {
+  const transpiler = new Bun.Transpiler({ loader: "js" });
+  const visited = new Set<string>();
+  const externals = new Set<string>();
+  const queue = [entry];
+  while (queue.length > 0) {
+    const file = queue.pop();
+    if (!file || visited.has(file)) {
+      continue;
+    }
+    visited.add(file);
+    // The CLI entry starts with a shebang, which the transpiler rejects.
+    const source = readFileSync(file, "utf-8").replace(/^#![^\n]*\n/u, "");
+    for (const imp of transpiler.scanImports(source)) {
+      if (imp.kind !== "import-statement") {
+        continue;
+      }
+      if (imp.path.startsWith(".")) {
+        queue.push(resolve(dirname(file), imp.path));
+      } else {
+        externals.add(imp.path);
+      }
+    }
+  }
+  return externals;
+};
+
+test("CLI bundle never statically imports an optional peer dependency (#67)", () => {
+  // Sanity: an empty list would make the assertion below pass vacuously.
+  expect(optionalPeers.length).toBeGreaterThan(0);
+
+  const externals = staticExternals(resolve(distDir, "cli/index.js"));
+  const offenders = optionalPeers.filter((peer) =>
+    [...externals].some(
+      (specifier) => specifier === peer || specifier.startsWith(`${peer}/`)
+    )
+  );
+  expect(offenders).toEqual([]);
+});

--- a/packages/files-sdk/test/build-output.test.ts
+++ b/packages/files-sdk/test/build-output.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 
 import pkg from "../package.json" with { type: "json" };
@@ -12,7 +12,12 @@ import pkg from "../package.json" with { type: "json" };
 // walks the transitive *static* import graph of dist/cli/index.js — dynamic
 // imports are exactly the lazy boundary, so they're not followed.
 
-const distDir = resolve(import.meta.dirname, "../dist");
+// The cold-start build (tsgo included) can take a while on CI runners.
+const COLD_BUILD_TIMEOUT_MS = 120_000;
+
+const pkgRoot = resolve(import.meta.dirname, "..");
+const distDir = resolve(pkgRoot, "dist");
+const cliBundle = resolve(distDir, "cli/index.js");
 
 const optionalPeers = Object.entries(pkg.peerDependenciesMeta ?? {})
   .filter(([, meta]) => (meta as { optional?: boolean }).optional)
@@ -46,15 +51,33 @@ const staticExternals = (entry: string): Set<string> => {
   return externals;
 };
 
-test("CLI bundle never statically imports an optional peer dependency (#67)", () => {
-  // Sanity: an empty list would make the assertion below pass vacuously.
-  expect(optionalPeers.length).toBeGreaterThan(0);
+test(
+  "CLI bundle never statically imports an optional peer dependency (#67)",
+  () => {
+    // CI's test job runs `bun test` on a fresh checkout without building, so
+    // produce dist/ with the real build script when the bundle is absent —
+    // the guard must scan output of the actual build config, not a replica.
+    if (!existsSync(cliBundle)) {
+      const proc = Bun.spawnSync(["bun", "scripts/build.ts"], {
+        cwd: pkgRoot,
+        stderr: "pipe",
+        stdout: "pipe",
+      });
+      if (!proc.success) {
+        throw new Error(`build failed:\n${proc.stderr.toString()}`);
+      }
+    }
 
-  const externals = staticExternals(resolve(distDir, "cli/index.js"));
-  const offenders = optionalPeers.filter((peer) =>
-    [...externals].some(
-      (specifier) => specifier === peer || specifier.startsWith(`${peer}/`)
-    )
-  );
-  expect(offenders).toEqual([]);
-});
+    // Sanity: an empty list would make the assertion below pass vacuously.
+    expect(optionalPeers.length).toBeGreaterThan(0);
+
+    const externals = staticExternals(cliBundle);
+    const offenders = optionalPeers.filter((peer) =>
+      [...externals].some(
+        (specifier) => specifier === peer || specifier.startsWith(`${peer}/`)
+      )
+    );
+    expect(offenders).toEqual([]);
+  },
+  COLD_BUILD_TIMEOUT_MS
+);


### PR DESCRIPTION
## Summary

- enable Bun build splitting for `files-sdk` so CLI dynamic provider imports remain lazy in the published output
- update the build script comment to document why shared chunks are enabled

This prevents `files --help` and other provider-independent CLI paths from eagerly resolving optional peer dependencies such as `@netlify/blobs`.

Fixes #67.

## Verification

- `bun run build` in `packages/files-sdk`
- `bun test test/cli.test.ts test/cli-registry.test.ts` in `packages/files-sdk`
- `bun run types` in `packages/files-sdk`
- `bun test` in `packages/files-sdk`
- pre-commit hook: `ultracite check`, `turbo run types`, `turbo run test`, `turbo run build --filter files-sdk`
- local tarball smoke test: installed `files-sdk-1.8.0.tgz` into a clean temp project without `@netlify/blobs`; `node node_modules/.bin/files --help` succeeds, while selecting `--provider netlify-blobs` fails only then with the missing optional peer error.