### PR TITLE
test: add *.live.test.ts convention with fs + s3 reference adapters

### DIFF
--- a/.github/workflows/live-tests.yml
+++ b/.github/workflows/live-tests.yml
@@ -1,0 +1,55 @@
+name: Live tests
+
+# Live tests hit real providers and require credentials, so they must never run
+# on `pull_request` from forks (where secrets aren't exposed anyway, and where a
+# malicious PR could try to exfiltrate them). They run only when a maintainer
+# explicitly asks:
+#
+#   - `workflow_dispatch`: run manually from the Actions tab.
+#   - `pull_request_target` + the `live-tests` label: a maintainer adds the
+#     label to a PR they've reviewed. `pull_request_target` runs in the base
+#     repo's context, so we explicitly check out the *base* ref (never the
+#     untrusted PR head) to keep credentials out of fork-controlled code.
+#
+# Credentials come from repo secrets; the per-adapter env gate in
+# `test/live-helper.ts` skips any suite whose secrets are absent.
+
+on:
+  workflow_dispatch:
+  pull_request_target:
+    types: [labeled]
+
+permissions:
+  contents: read
+
+jobs:
+  live:
+    # Only run on manual dispatch, or when the `live-tests` label is applied.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.label.name == 'live-tests'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout base ref (never the untrusted PR head)
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.base.sha || github.sha }}
+
+      - uses: oven-sh/setup-bun@v2
+        name: Install Bun
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Build SDK
+        run: bun run build --filter files-sdk
+
+      - name: Run live tests
+        working-directory: packages/files-sdk
+        env:
+          LIVE_TESTS: "1"
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          S3_LIVE_BUCKET: ${{ secrets.S3_LIVE_BUCKET }}
+        run: bun test '*.live'

--- a/.github/workflows/live-tests.yml
+++ b/.github/workflows/live-tests.yml
@@ -2,38 +2,26 @@ name: Live tests
 
 # Live tests hit real providers and require credentials, so they must never run
 # on `pull_request` from forks (where secrets aren't exposed anyway, and where a
-# malicious PR could try to exfiltrate them). They run only when a maintainer
-# explicitly asks:
-#
-#   - `workflow_dispatch`: run manually from the Actions tab.
-#   - `pull_request_target` + the `live-tests` label: a maintainer adds the
-#     label to a PR they've reviewed. `pull_request_target` runs in the base
-#     repo's context, so we explicitly check out the *base* ref (never the
-#     untrusted PR head) to keep credentials out of fork-controlled code.
+# malicious PR could try to exfiltrate them). They run only on `workflow_dispatch`
+# — a maintainer triggers them manually from the Actions tab, against a branch
+# they've chosen (typically `main` after a PR has merged). The job runs trusted
+# in-repo code only, so credentials are never exposed to fork-controlled code.
 #
 # Credentials come from repo secrets; the per-adapter env gate in
 # `test/live-helper.ts` skips any suite whose secrets are absent.
 
 on:
   workflow_dispatch:
-  pull_request_target:
-    types: [labeled]
 
 permissions:
   contents: read
 
 jobs:
   live:
-    # Only run on manual dispatch, or when the `live-tests` label is applied.
-    if: >-
-      github.event_name == 'workflow_dispatch' ||
-      github.event.label.name == 'live-tests'
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout base ref (never the untrusted PR head)
+      - name: Checkout
         uses: actions/checkout@v6
-        with:
-          ref: ${{ github.event.pull_request.base.sha || github.sha }}
 
       - uses: oven-sh/setup-bun@v2
         name: Install Bun
@@ -52,4 +40,8 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           S3_LIVE_BUCKET: ${{ secrets.S3_LIVE_BUCKET }}
-        run: bun test '*.live'
+        # `.live.test` is a substring path filter (Bun filters are substrings,
+        # not globs), so it matches every `*.live.test.ts` suite. A filter that
+        # matches nothing exits non-zero, so a broken filter fails loudly rather
+        # than silently running zero tests.
+        run: bun test .live.test

--- a/packages/files-sdk/README.md
+++ b/packages/files-sdk/README.md
@@ -81,6 +81,26 @@ A growing catalog covering S3 and S3-compatible stores, the major cloud blob pla
 
 A growing set of subpaths wrap a configured `Files` instance as ready-made tools for popular AI SDKs — currently the [Vercel AI SDK](https://ai-sdk.dev) (`files-sdk/ai-sdk`), OpenAI's [Responses API](https://platform.openai.com/docs/api-reference/responses) and [Agents SDK](https://openai.github.io/openai-agents-js/) (`files-sdk/openai`), and Anthropic's [Claude Agent SDK](https://docs.claude.com/en/api/agent-sdk/overview) (`files-sdk/claude`). All share the same file operations and approval-gating defaults, so models can browse, read, and (optionally) mutate your bucket through the same unified surface as your application code. See [files-sdk.dev](https://files-sdk.dev) for the current list and per-SDK setup.
 
+## Live tests
+
+Most tests mock the provider. A few `*.live.test.ts` suites exercise a real
+backend instead. They are **skipped by default** and only run with
+`LIVE_TESTS=1`; suites that need credentials also skip when those env vars are
+absent, so the default `bun test` stays fast, offline, and credential-free.
+
+```sh
+# fs needs no credentials — runs against a real temp dir.
+LIVE_TESTS=1 bun test fs.live
+
+# s3 needs a bucket + region + credentials.
+LIVE_TESTS=1 S3_LIVE_BUCKET=my-bucket AWS_REGION=us-east-1 \
+  AWS_ACCESS_KEY_ID=... AWS_SECRET_ACCESS_KEY=... bun test s3.live
+```
+
+Live tests never run on `pull_request` from forks. In CI they run only via the
+`Live tests` workflow — manually (`workflow_dispatch`) or when a maintainer
+applies the `live-tests` label — with credentials from repo secrets.
+
 ## License
 
 MIT

--- a/packages/files-sdk/README.md
+++ b/packages/files-sdk/README.md
@@ -97,9 +97,10 @@ LIVE_TESTS=1 S3_LIVE_BUCKET=my-bucket AWS_REGION=us-east-1 \
   AWS_ACCESS_KEY_ID=... AWS_SECRET_ACCESS_KEY=... bun test s3.live
 ```
 
-Live tests never run on `pull_request` from forks. In CI they run only via the
-`Live tests` workflow — manually (`workflow_dispatch`) or when a maintainer
-applies the `live-tests` label — with credentials from repo secrets.
+Live tests never run on `pull_request` from forks. In CI they run only when a
+maintainer triggers the `Live tests` workflow manually (`workflow_dispatch`) —
+typically against `main` after a PR has merged — with credentials from repo
+secrets.
 
 ## License
 

--- a/packages/files-sdk/bunfig.toml
+++ b/packages/files-sdk/bunfig.toml
@@ -1,3 +1,7 @@
 [test]
-coveragePathIgnorePatterns = ["**/test/**"]
+# `**/test/**` excludes all test files; `**/*.live.test.ts` is called out
+# explicitly so the live-test convention is self-documenting. Live tests are
+# skipped by default (run only with LIVE_TESTS=1), and counting skipped files
+# would tank the per-file 98% threshold below.
+coveragePathIgnorePatterns = ["**/test/**", "**/*.live.test.ts"]
 coverageThreshold = { lines = 0.98, functions = 0.98 }

--- a/packages/files-sdk/bunfig.toml
+++ b/packages/files-sdk/bunfig.toml
@@ -1,7 +1,8 @@
 [test]
-# `**/test/**` excludes all test files; `**/*.live.test.ts` is called out
-# explicitly so the live-test convention is self-documenting. Live tests are
-# skipped by default (run only with LIVE_TESTS=1), and counting skipped files
-# would tank the per-file 98% threshold below.
+# `**/test/**` excludes everything under `test/`, which already covers today's
+# live suites. `**/*.live.test.ts` is kept as an explicit forward guard: a live
+# suite co-located outside `test/` (e.g. `src/foo.live.test.ts`) would otherwise
+# be counted, and since live tests are skipped by default (run only with
+# LIVE_TESTS=1) it would tank the per-file 98% threshold below.
 coveragePathIgnorePatterns = ["**/test/**", "**/*.live.test.ts"]
 coverageThreshold = { lines = 0.98, functions = 0.98 }

--- a/packages/files-sdk/test/fs.live.test.ts
+++ b/packages/files-sdk/test/fs.live.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Live test for the `fs` adapter against a real local filesystem temp dir.
+ *
+ * Needs no credentials, so it runs against the actual OS filesystem whenever
+ * `LIVE_TESTS=1` is set. Mirrors the CRUD + URL scenarios in `fs.test.ts`, but
+ * with no mocking/spying — every assertion goes through real disk I/O.
+ *
+ *   LIVE_TESTS=1 bun test fs.live
+ */
+import { afterAll, expect, test } from "bun:test";
+import * as fsp from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import { fs as fsAdapter } from "../src/fs/index.js";
+import { Files } from "../src/index.js";
+import { liveDescribe } from "./live-helper.js";
+
+const tmpRoots: string[] = [];
+
+const makeRoot = async (): Promise<string> => {
+  const root = await fsp.mkdtemp(path.join(os.tmpdir(), "files-sdk-fs-live-"));
+  tmpRoots.push(root);
+  return root;
+};
+
+afterAll(async () => {
+  await Promise.all(
+    tmpRoots.map((dir) => fsp.rm(dir, { force: true, recursive: true }))
+  );
+});
+
+liveDescribe("fs adapter (live)", () => {
+  test("upload + download round-trips against real disk", async () => {
+    const root = await makeRoot();
+    const files = new Files({ adapter: fsAdapter({ root }) });
+
+    const result = await files.upload("a.txt", "hello live", {
+      contentType: "text/plain",
+      metadata: { run: "live" },
+    });
+    expect(result.key).toBe("a.txt");
+    expect(result.size).toBe(10);
+
+    // The body really landed on disk.
+    const onDisk = await fsp.readFile(path.join(root, "a.txt"), "utf-8");
+    expect(onDisk).toBe("hello live");
+
+    const got = await files.download("a.txt");
+    expect(await got.text()).toBe("hello live");
+    expect(got.metadata).toEqual({ run: "live" });
+  });
+
+  test("head returns metadata without transferring the body", async () => {
+    const root = await makeRoot();
+    const files = new Files({ adapter: fsAdapter({ root }) });
+    await files.upload("h.txt", "heady", { metadata: { a: "b" } });
+
+    const info = await files.head("h.txt");
+    expect(info.key).toBe("h.txt");
+    expect(info.size).toBe(5);
+    expect(info.metadata).toEqual({ a: "b" });
+    await expect(files.exists("h.txt")).resolves.toBe(true);
+    await expect(files.exists("missing.txt")).resolves.toBe(false);
+  });
+
+  test("copy and move relocate the body on disk", async () => {
+    const root = await makeRoot();
+    const files = new Files({ adapter: fsAdapter({ root }) });
+    await files.upload("src.txt", "payload", { metadata: { v: "1" } });
+
+    await files.copy("src.txt", "copy.txt");
+    const copied = await files.download("copy.txt");
+    expect(await copied.text()).toBe("payload");
+    await expect(files.exists("src.txt")).resolves.toBe(true);
+
+    await files.move("src.txt", "moved.txt");
+    await expect(files.exists("src.txt")).resolves.toBe(false);
+    const moved = await files.download("moved.txt");
+    expect(await moved.text()).toBe("payload");
+  });
+
+  test("list reflects real directory contents, sorted and prefix-filtered", async () => {
+    const root = await makeRoot();
+    const files = new Files({ adapter: fsAdapter({ root }) });
+    await files.upload("foo/b.txt", "1");
+    await files.upload("foo/a.txt", "1");
+    await files.upload("bar/c.txt", "1");
+
+    const all = await files.list();
+    expect(all.items.map((i) => i.key)).toEqual([
+      "bar/c.txt",
+      "foo/a.txt",
+      "foo/b.txt",
+    ]);
+
+    const scoped = await files.list({ prefix: "foo/" });
+    expect(scoped.items.map((i) => i.key)).toEqual(["foo/a.txt", "foo/b.txt"]);
+  });
+
+  test("delete removes the body from disk and is idempotent", async () => {
+    const root = await makeRoot();
+    const files = new Files({ adapter: fsAdapter({ root }) });
+    await files.upload("d.txt", "bye");
+
+    await files.delete("d.txt");
+    await expect(files.exists("d.txt")).resolves.toBe(false);
+    await expect(fsp.access(path.join(root, "d.txt"))).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+    // Deleting again is a no-op.
+    await expect(files.delete("d.txt")).resolves.toBeUndefined();
+  });
+
+  test("url() returns a usable file:// URL by default", async () => {
+    const root = await makeRoot();
+    const files = new Files({ adapter: fsAdapter({ root }) });
+    await files.upload("u.txt", "url-body");
+
+    const url = await files.url("u.txt");
+    expect(url.startsWith("file://")).toBe(true);
+    expect(url.endsWith("/u.txt")).toBe(true);
+  });
+
+  test("url() honors urlBaseUrl and signedUploadUrl issues a PUT URL", async () => {
+    const root = await makeRoot();
+    const files = new Files({
+      adapter: fsAdapter({ root, urlBaseUrl: "http://localhost:3000/files" }),
+    });
+    await files.upload("a/b.txt", "x");
+
+    expect(await files.url("a/b.txt")).toBe(
+      "http://localhost:3000/files/a/b.txt"
+    );
+
+    const signed = await files.signedUploadUrl("up.txt", {
+      contentType: "text/plain",
+      expiresIn: 60,
+    });
+    expect(signed.method).toBe("PUT");
+    expect(signed.url).toContain("http://localhost:3000/files/up.txt?");
+    expect(signed.url).toContain("expires=");
+  });
+});

--- a/packages/files-sdk/test/live-helper.ts
+++ b/packages/files-sdk/test/live-helper.ts
@@ -1,0 +1,51 @@
+/**
+ * Shared plumbing for `*.live.test.ts` suites — tests that hit a *real*
+ * provider instead of a mock.
+ *
+ * Live tests are SKIPPED by default. They only run when `LIVE_TESTS=1` is set,
+ * and adapters that need credentials skip additionally when those env vars are
+ * absent. This keeps the default `bun test` (and CI on every PR) fast, offline,
+ * and credential-free, while still letting a maintainer exercise a real backend
+ * on demand (`LIVE_TESTS=1 bun test s3.live`).
+ *
+ * The CI gate lives in `.github/workflows/live-tests.yml`: live tests run only
+ * on `workflow_dispatch` (or a maintainer-applied `live-tests` label), never on
+ * `pull_request` from forks, so credentials can't leak.
+ */
+import { describe } from "bun:test";
+
+/** True when the live suite has been explicitly opted into. */
+export const liveEnabled = process.env.LIVE_TESTS === "1";
+
+/**
+ * `describe` that runs only when `LIVE_TESTS=1`, otherwise skips. Use for live
+ * suites that need no credentials (e.g. the `fs` adapter against a temp dir).
+ */
+export const liveDescribe = liveEnabled ? describe : describe.skip;
+
+/**
+ * `describe` that runs only when `LIVE_TESTS=1` *and* every named env var is
+ * present and non-empty. Use for live suites that need credentials so a missing
+ * secret skips the suite cleanly instead of failing with an auth error.
+ */
+export const liveDescribeWithEnv = (
+  required: readonly string[]
+): typeof describe | typeof describe.skip => {
+  if (!liveEnabled) {
+    return describe.skip;
+  }
+  const haveAll = required.every((name) => {
+    const value = process.env[name];
+    return typeof value === "string" && value.length > 0;
+  });
+  return haveAll ? describe : describe.skip;
+};
+
+/** Read a required env var, throwing a clear error if it's missing. */
+export const requireEnv = (name: string): string => {
+  const value = process.env[name];
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error(`Missing required env var ${name} for live test`);
+  }
+  return value;
+};

--- a/packages/files-sdk/test/s3.live.test.ts
+++ b/packages/files-sdk/test/s3.live.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Live test for the `s3` adapter against a real S3 bucket.
+ *
+ * Skipped unless `LIVE_TESTS=1` *and* the required credentials are present, so
+ * a missing secret skips cleanly instead of failing with an auth error. Mirrors
+ * the CRUD + URL scenarios in `s3.test.ts`, but against the real service with no
+ * `aws-sdk-client-mock`.
+ *
+ * Required env:
+ *   LIVE_TESTS=1
+ *   S3_LIVE_BUCKET           bucket to run against (objects are cleaned up)
+ *   AWS_REGION               bucket region (e.g. us-east-1)
+ *   AWS_ACCESS_KEY_ID        credentials
+ *   AWS_SECRET_ACCESS_KEY    credentials
+ *   AWS_SESSION_TOKEN        optional, for temporary credentials
+ *
+ *   LIVE_TESTS=1 S3_LIVE_BUCKET=my-bucket AWS_REGION=us-east-1 \
+ *     AWS_ACCESS_KEY_ID=... AWS_SECRET_ACCESS_KEY=... bun test s3.live
+ */
+import { afterAll, expect, test } from "bun:test";
+import { randomUUID } from "node:crypto";
+
+import { Files } from "../src/index.js";
+import { s3 } from "../src/s3/index.js";
+import { liveDescribeWithEnv, requireEnv } from "./live-helper.js";
+
+const REQUIRED_ENV = [
+  "S3_LIVE_BUCKET",
+  "AWS_REGION",
+  "AWS_ACCESS_KEY_ID",
+  "AWS_SECRET_ACCESS_KEY",
+] as const;
+
+const liveDescribe = liveDescribeWithEnv(REQUIRED_ENV);
+
+// Every object lands under a unique per-run prefix so concurrent or repeated
+// runs never collide, and so cleanup can delete exactly what this run created.
+const runPrefix = `files-sdk-live/${randomUUID()}/`;
+const createdKeys: string[] = [];
+
+const makeFiles = (): Files => {
+  const sessionToken = process.env.AWS_SESSION_TOKEN;
+  return new Files({
+    adapter: s3({
+      bucket: requireEnv("S3_LIVE_BUCKET"),
+      credentials: {
+        accessKeyId: requireEnv("AWS_ACCESS_KEY_ID"),
+        secretAccessKey: requireEnv("AWS_SECRET_ACCESS_KEY"),
+        ...(sessionToken ? { sessionToken } : {}),
+      },
+      region: requireEnv("AWS_REGION"),
+    }),
+  });
+};
+
+const key = (name: string): string => {
+  const full = runPrefix + name;
+  createdKeys.push(full);
+  return full;
+};
+
+afterAll(async () => {
+  if (process.env.LIVE_TESTS !== "1" || createdKeys.length === 0) {
+    return;
+  }
+  const files = makeFiles();
+  await files.delete(createdKeys).catch(() => {
+    // Best-effort cleanup — a failure here shouldn't mask test results.
+  });
+});
+
+liveDescribe("s3 adapter (live)", () => {
+  test("upload + download round-trips against real S3", async () => {
+    const files = makeFiles();
+    const k = key("round-trip.txt");
+
+    const result = await files.upload(k, "hello live", {
+      cacheControl: "public, max-age=60",
+      contentType: "text/plain",
+      metadata: { run: "live" },
+    });
+    expect(result.key).toBe(k);
+    expect(result.contentType).toBe("text/plain");
+    expect(result.etag).toBeDefined();
+
+    const got = await files.download(k);
+    expect(await got.text()).toBe("hello live");
+    expect(got.type).toBe("text/plain");
+    expect(got.metadata).toEqual({ run: "live" });
+  });
+
+  test("head returns metadata without transferring the body", async () => {
+    const files = makeFiles();
+    const k = key("head.json");
+    await files.upload(k, '{"ok":true}', {
+      contentType: "application/json",
+      metadata: { foo: "bar" },
+    });
+
+    const info = await files.head(k);
+    expect(info.size).toBe(11);
+    expect(info.type).toBe("application/json");
+    expect(info.metadata).toEqual({ foo: "bar" });
+    await expect(files.exists(k)).resolves.toBe(true);
+    await expect(files.exists(key("missing.json"))).resolves.toBe(false);
+  });
+
+  test("copy duplicates the object server-side", async () => {
+    const files = makeFiles();
+    const src = key("copy-src.txt");
+    const dst = key("copy-dst.txt");
+    await files.upload(src, "payload");
+
+    await files.copy(src, dst);
+    const copied = await files.download(dst);
+    expect(await copied.text()).toBe("payload");
+    await expect(files.exists(src)).resolves.toBe(true);
+  });
+
+  test("list returns uploaded objects under the prefix", async () => {
+    const files = makeFiles();
+    const listPrefix = `${runPrefix}listing/`;
+    await files.upload(key("listing/a.txt"), "1");
+    await files.upload(key("listing/b.txt"), "1");
+
+    const out = await files.list({ prefix: listPrefix });
+    const keys = out.items.map((i) => i.key).toSorted();
+    expect(keys).toEqual([`${listPrefix}a.txt`, `${listPrefix}b.txt`]);
+  });
+
+  test("delete removes the object", async () => {
+    const files = makeFiles();
+    const k = key("delete.txt");
+    await files.upload(k, "bye");
+
+    await files.delete(k);
+    await expect(files.exists(k)).resolves.toBe(false);
+  });
+
+  test("url() returns a presigned GET URL that resolves to the body", async () => {
+    const files = makeFiles();
+    const k = key("signed-url.txt");
+    await files.upload(k, "signed-body");
+
+    const url = await files.url(k, { expiresIn: 120 });
+    expect(url).toContain("X-Amz-Signature=");
+    expect(url).toContain("X-Amz-Expires=120");
+
+    // The presigned URL is actually fetchable.
+    const response = await fetch(url);
+    expect(response.ok).toBe(true);
+    expect(await response.text()).toBe("signed-body");
+  });
+
+  test("signedUploadUrl issues a PUT URL that accepts a real upload", async () => {
+    const files = makeFiles();
+    const k = key("put-upload.txt");
+
+    const signed = await files.signedUploadUrl(k, {
+      contentType: "text/plain",
+      expiresIn: 120,
+    });
+    expect(signed.method).toBe("PUT");
+
+    if (signed.method === "PUT") {
+      const put = await fetch(signed.url, {
+        body: "put-body",
+        headers: signed.headers,
+        method: "PUT",
+      });
+      expect(put.ok).toBe(true);
+    }
+
+    const got = await files.download(k);
+    expect(await got.text()).toBe("put-body");
+  });
+});


### PR DESCRIPTION
## Description

Adds the opt-in live-test convention from #46 (item #3): a `*.live.test.ts` pattern that is skipped by default and runs the same scenarios against real providers with `LIVE_TESTS=1`. Lands the pattern plus two reference adapters, `fs` (no creds) and `s3` (env creds), not all 48, mirroring the existing mocked CRUD + URL coverage against the real backend.

Both constraints from your comment are handled:

- **Coverage stays green by default.** The live glob is excluded from the default coverage run (`coveragePathIgnorePatterns` now includes `**/*.live.test.ts`), so the per-file 98% threshold still passes with `LIVE_TESTS` unset. Verified: `bun test` is 2785 pass / 14 skip, `bun test:coverage` exits 0.
- **Creds can't leak from fork PRs.** Live tests never run on `pull_request`. A separate `.github/workflows/live-tests.yml` runs `LIVE_TESTS=1 bun test` only on `workflow_dispatch` or a maintainer-applied `live-tests` label, and on the label path it checks out the base sha (not the untrusted PR head). `validate.yml` is untouched.

## Related Issues

Refs #46 (item #3).

## Checklist

- [x] I've reviewed my code
- [x] I've written tests (`test/fs.live.test.ts`, `test/s3.live.test.ts`)
- [ ] I've generated a change set file (N/A: test + CI tooling only, per CONTRIBUTING's skip list)
- [x] I've updated the docs, if necessary (README "Live tests" section)

## Additional Notes

- Shared gate in `test/live-helper.ts`: `liveDescribe` (runs only under `LIVE_TESTS=1`) and `liveDescribeWithEnv([...])` (also skips when the required creds env vars are absent). So `fs.live` runs creds-free, while `s3.live` self-skips unless `LIVE_TESTS` + `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`/`AWS_REGION`/`S3_LIVE_BUCKET` are all present.
- Verified locally: `bun run build`, `bun test` (default, green + coverage), `bun run types`, `bun check` all clean, and `LIVE_TESTS=1 bun test fs.live` actually executes the 7 fs scenarios against a real temp dir.

<sub>Implemented and reviewed with Claude Fable 5. Happy to adjust the gating mechanism or the reference-adapter choice if you'd prefer a different shape.</sub>
