### PR TITLE
Add a Neon object storage adapter

### DIFF
--- a/.changeset/neon-adapter.md
+++ b/.changeset/neon-adapter.md
@@ -1,0 +1,5 @@
+---
+"files-sdk": minor
+---
+
+Add a `neon` adapter at `files-sdk/neon` for [Neon](https://neon.com) branchable object storage over its S3-compatible API. A thin wrapper around the S3 adapter — errors relabelled, with path-style addressing on by default because Neon requires it (the wildcard TLS cert covers a single subdomain level, occupied by the branch id, so the bucket name travels in the request path). It reads the standard `AWS_*` variables that `neon dev` / `neon env pull` inject for the linked branch — `endpoint` from `AWS_ENDPOINT_URL_S3`, region from `AWS_REGION` (then `NEON_STORAGE_REGION`, then `us-east-1`), and credentials through the AWS SDK chain (`AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`) — so inside a Neon Function or after an env pull it works from env alone: `neon({ bucket: "images" })`. Catalogued in `files-sdk/providers` and exposed through the CLI.

--- a/apps/web/content/docs/adapters/neon.mdx
+++ b/apps/web/content/docs/adapters/neon.mdx
@@ -41,7 +41,7 @@ await files.upload("avatars/abc.png", file, { contentType: "image/png" });
 const url = await files.url("avatars/abc.png", { expiresIn: 300 });
 ```
 
-Path-style addressing is **required**: Neon's wildcard TLS certificate covers a single subdomain level (`*.storage.<suffix>`), which the branch id occupies, so the bucket name must travel in the request path. The adapter sets `forcePathStyle: true` by default - leave it on.
+Path-style addressing is **required**: Neon's wildcard TLS certificate covers a single subdomain level (`*.storage.<suffix>`), which the branch id occupies, so the bucket name must travel in the request path. The adapter always uses path-style addressing.
 
 ## Options
 

--- a/apps/web/content/docs/adapters/neon.mdx
+++ b/apps/web/content/docs/adapters/neon.mdx
@@ -1,0 +1,66 @@
+---
+title: Neon
+description: Neon branchable object storage via the S3-compatible API. neon dev / neon env pull inject the AWS_* env vars; path-style addressing is required.
+peerDeps:
+  - "@aws-sdk/client-s3"
+  - "@aws-sdk/s3-presigned-post"
+  - "@aws-sdk/s3-request-presigner"
+---
+
+## Installation
+
+`@aws-sdk/client-s3`, `@aws-sdk/s3-presigned-post`, and `@aws-sdk/s3-request-presigner` are optional peer dependencies of `files-sdk` - install alongside the SDK so the adapter's imports resolve at runtime.
+
+```package-install
+files-sdk @aws-sdk/client-s3 @aws-sdk/s3-presigned-post @aws-sdk/s3-request-presigner
+```
+
+## Usage
+
+```ts lineNumbers
+import { Files } from "files-sdk";
+import { neon } from "files-sdk/neon";
+
+const files = new Files({
+  adapter: neon({
+    bucket: "images",
+    // endpoint defaults to AWS_ENDPOINT_URL_S3
+    // region defaults to AWS_REGION (then NEON_STORAGE_REGION, then us-east-1)
+    // accessKeyId / secretAccessKey resolve from the AWS credential chain
+    // (the AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY Neon injects)
+  }),
+});
+```
+
+Neon branchable object storage via its S3-compatible API. A thin wrapper around the S3 adapter - errors relabelled, path-style addressing on by default. Declare a bucket in your `neon.ts` policy (`preview.buckets`), then run `neon dev` (or `neon env pull`) to mint a branch credential and inject the standard `AWS_*` variables. Inside a deployed Neon Function the same variables are present, so the adapter works from env alone:
+
+```ts lineNumbers
+const files = new Files({ adapter: neon({ bucket: "images" }) });
+
+await files.upload("avatars/abc.png", file, { contentType: "image/png" });
+const url = await files.url("avatars/abc.png", { expiresIn: 300 });
+```
+
+Path-style addressing is **required**: Neon's wildcard TLS certificate covers a single subdomain level (`*.storage.<suffix>`), which the branch id occupies, so the bucket name must travel in the request path. The adapter sets `forcePathStyle: true` by default - leave it on.
+
+## Options
+
+<AutoTypeTable
+  path="../../packages/files-sdk/src/neon/index.ts"
+  name="NeonAdapterOptions"
+/>
+
+## Compatibility
+
+| Method            | Status | Notes |
+| ----------------- | :----: | ----- |
+| `upload`          |   ✅   |       |
+| `download`        |   ✅   |       |
+| `delete`          |   ✅   |       |
+| `list`            |   ✅   |       |
+| `search`          |   ✅   |       |
+| `head`            |   ✅   |       |
+| `exists`          |   ✅   |       |
+| `copy`            |   ✅   |       |
+| `url`             |   ✅   |       |
+| `signedUploadUrl` |   ✅   |       |

--- a/apps/web/content/docs/cli/index.mdx
+++ b/apps/web/content/docs/cli/index.mdx
@@ -34,6 +34,7 @@ Pass `--provider <name>` on every call, or set `FILES_SDK_PROVIDER` once. Provid
   <span>netlify-blobs</span>
   <span>supabase</span>
   <span>minio</span>
+  <span>neon</span>
   <span>digitalocean-spaces</span>
   <span>backblaze-b2</span>
   <span>wasabi</span>

--- a/packages/files-sdk/package.json
+++ b/packages/files-sdk/package.json
@@ -114,6 +114,10 @@
       "types": "./dist/minio/index.d.ts",
       "import": "./dist/minio/index.js"
     },
+    "./neon": {
+      "types": "./dist/neon/index.d.ts",
+      "import": "./dist/neon/index.js"
+    },
     "./digitalocean-spaces": {
       "types": "./dist/digitalocean-spaces/index.d.ts",
       "import": "./dist/digitalocean-spaces/index.js"

--- a/packages/files-sdk/src/cli/registry.ts
+++ b/packages/files-sdk/src/cli/registry.ts
@@ -352,6 +352,15 @@ export const PROVIDERS: Record<string, ProviderRegistration> = {
     },
     required: ["--bucket", "--endpoint"],
   },
+  neon: {
+    load: async (opts) => {
+      const { neon } = await import("../neon/index.js");
+      return cast(neon, merge(s3LikeOpts(opts), opts.extra));
+    },
+    notes:
+      "endpoint comes from AWS_ENDPOINT_URL_S3 (injected by `neon dev` / `neon env pull`) or pass --endpoint; credentials resolve from the AWS_* env vars Neon injects",
+    required: ["--bucket"],
+  },
   "netlify-blobs": {
     load: async (opts) => {
       const { netlifyBlobs } = await import("../netlify-blobs/index.js");

--- a/packages/files-sdk/src/neon/index.ts
+++ b/packages/files-sdk/src/neon/index.ts
@@ -33,15 +33,6 @@ export interface NeonAdapterOptions {
    */
   secretAccessKey?: string;
   /**
-   * Use path-style addressing (`https://endpoint/bucket/key`). Defaults to
-   * `true` — Neon object storage **requires** it: the wildcard TLS cert covers
-   * one subdomain level (`*.storage.<suffix>`), which the branch id occupies,
-   * so the bucket name must travel in the request path. Honors
-   * `NEON_STORAGE_FORCE_PATH_STYLE` when the option is unset. There is rarely a
-   * reason to turn this off.
-   */
-  forcePathStyle?: boolean;
-  /**
    * Origin used to build URLs from `url()`. When set, `url(key)` returns
    * `${publicBaseUrl}/${key}` and skips signing — appropriate for a bucket
    * fronted by a CDN or custom domain. When unset, `url()` falls back to a
@@ -60,20 +51,6 @@ export type NeonAdapter = Adapter<S3Client> & {
 };
 
 const NEON_DEFAULT_REGION = "us-east-1";
-
-// `neon dev` / `neon env pull` set NEON_STORAGE_FORCE_PATH_STYLE to "true"
-// today. Mirror `@neondatabase/env`'s parser: default to path-style, and only
-// disable it on an explicit "false".
-const resolveForcePathStyle = (opt: boolean | undefined): boolean => {
-  if (opt !== undefined) {
-    return opt;
-  }
-  const fromEnv = readEnv("NEON_STORAGE_FORCE_PATH_STYLE");
-  if (fromEnv === undefined) {
-    return true;
-  }
-  return fromEnv.trim().toLowerCase() !== "false";
-};
 
 export const neon = (opts: NeonAdapterOptions): NeonAdapter => {
   const endpoint = opts.endpoint ?? readEnv("AWS_ENDPOINT_URL_S3");
@@ -106,7 +83,10 @@ export const neon = (opts: NeonAdapterOptions): NeonAdapter => {
     // users don't see "S3 error" from their Neon adapter.
     defaultProviderMessage: "Neon error",
     endpoint,
-    forcePathStyle: resolveForcePathStyle(opts.forcePathStyle),
+    // Neon object storage requires path-style addressing — the wildcard TLS
+    // cert covers one subdomain level, occupied by the branch id, so the bucket
+    // name must travel in the request path. Always on; not configurable.
+    forcePathStyle: true,
     ...(opts.publicBaseUrl && { publicBaseUrl: opts.publicBaseUrl }),
     region,
   });

--- a/packages/files-sdk/src/neon/index.ts
+++ b/packages/files-sdk/src/neon/index.ts
@@ -1,0 +1,118 @@
+import type { S3Client } from "@aws-sdk/client-s3";
+
+import type { Adapter } from "../index.js";
+import { readEnv } from "../internal/env.js";
+import { FilesError } from "../internal/errors.js";
+import { s3 } from "../s3/index.js";
+
+export interface NeonAdapterOptions {
+  /** Neon object-storage bucket name. The adapter scopes all operations to it. */
+  bucket: string;
+  /**
+   * The branch's S3-compatible endpoint URL. Falls back to
+   * `AWS_ENDPOINT_URL_S3` — the variable `neon dev` / `neon env pull` inject
+   * for the linked branch. Required if that env var isn't set.
+   */
+  endpoint?: string;
+  /**
+   * SigV4 region used for signing. Falls back to `AWS_REGION`, then
+   * `NEON_STORAGE_REGION` (Neon injects the region under both names), then
+   * defaults to `"us-east-1"`. Neon normalizes the region server-side and does
+   * not use it for routing, but the signature requires *some* value.
+   */
+  region?: string;
+  /**
+   * Static access key ID. Skip to use the AWS credential chain, which reads
+   * the `AWS_ACCESS_KEY_ID` that `neon dev` / `neon env pull` inject for the
+   * branch credential.
+   */
+  accessKeyId?: string;
+  /**
+   * Static secret access key. Skip to use the AWS credential chain, which
+   * reads the `AWS_SECRET_ACCESS_KEY` Neon injects for the branch credential.
+   */
+  secretAccessKey?: string;
+  /**
+   * Use path-style addressing (`https://endpoint/bucket/key`). Defaults to
+   * `true` — Neon object storage **requires** it: the wildcard TLS cert covers
+   * one subdomain level (`*.storage.<suffix>`), which the branch id occupies,
+   * so the bucket name must travel in the request path. Honors
+   * `NEON_STORAGE_FORCE_PATH_STYLE` when the option is unset. There is rarely a
+   * reason to turn this off.
+   */
+  forcePathStyle?: boolean;
+  /**
+   * Origin used to build URLs from `url()`. When set, `url(key)` returns
+   * `${publicBaseUrl}/${key}` and skips signing — appropriate for a bucket
+   * fronted by a CDN or custom domain. When unset, `url()` falls back to a
+   * presigned `GetObject` URL (default expiry: 1 hour).
+   */
+  publicBaseUrl?: string;
+  /**
+   * Default expiry, in seconds, for the presigned URLs returned by `url()`
+   * when `publicBaseUrl` is not set. Defaults to 3600 (1 hour).
+   */
+  defaultUrlExpiresIn?: number;
+}
+
+export type NeonAdapter = Adapter<S3Client> & {
+  readonly bucket: string;
+};
+
+const NEON_DEFAULT_REGION = "us-east-1";
+
+// `neon dev` / `neon env pull` set NEON_STORAGE_FORCE_PATH_STYLE to "true"
+// today. Mirror `@neondatabase/env`'s parser: default to path-style, and only
+// disable it on an explicit "false".
+const resolveForcePathStyle = (opt: boolean | undefined): boolean => {
+  if (opt !== undefined) {
+    return opt;
+  }
+  const fromEnv = readEnv("NEON_STORAGE_FORCE_PATH_STYLE");
+  if (fromEnv === undefined) {
+    return true;
+  }
+  return fromEnv.trim().toLowerCase() !== "false";
+};
+
+export const neon = (opts: NeonAdapterOptions): NeonAdapter => {
+  const endpoint = opts.endpoint ?? readEnv("AWS_ENDPOINT_URL_S3");
+  if (!endpoint) {
+    throw new FilesError(
+      "Provider",
+      "neon adapter: missing endpoint. Pass `endpoint` or set AWS_ENDPOINT_URL_S3 (injected by `neon dev` / `neon env pull`)."
+    );
+  }
+
+  const region =
+    opts.region ??
+    readEnv("AWS_REGION") ??
+    readEnv("NEON_STORAGE_REGION") ??
+    NEON_DEFAULT_REGION;
+
+  const inner = s3({
+    bucket: opts.bucket,
+    ...(opts.accessKeyId &&
+      opts.secretAccessKey && {
+        credentials: {
+          accessKeyId: opts.accessKeyId,
+          secretAccessKey: opts.secretAccessKey,
+        },
+      }),
+    ...(opts.defaultUrlExpiresIn !== undefined && {
+      defaultUrlExpiresIn: opts.defaultUrlExpiresIn,
+    }),
+    // Neon is wire-compatible with S3; relabel the default provider message so
+    // users don't see "S3 error" from their Neon adapter.
+    defaultProviderMessage: "Neon error",
+    endpoint,
+    forcePathStyle: resolveForcePathStyle(opts.forcePathStyle),
+    ...(opts.publicBaseUrl && { publicBaseUrl: opts.publicBaseUrl }),
+    region,
+  });
+
+  return {
+    ...inner,
+    name: "neon",
+  };
+};

--- a/packages/files-sdk/src/providers/index.ts
+++ b/packages/files-sdk/src/providers/index.ts
@@ -888,12 +888,6 @@ export const PROVIDERS = {
           readBy: "files-sdk",
           secret: false,
         },
-        {
-          description: "Force path-style addressing (Neon requires it; defaults to true)",
-          key: "NEON_STORAGE_FORCE_PATH_STYLE",
-          readBy: "files-sdk",
-          secret: false,
-        },
       ],
       required: [
         {

--- a/packages/files-sdk/src/providers/index.ts
+++ b/packages/files-sdk/src/providers/index.ts
@@ -854,6 +854,60 @@ export const PROVIDERS = {
     peerDeps: AWS_S3_PEERS,
     slug: "minio",
   },
+  neon: {
+    description:
+      "Neon branchable object storage via the S3-compatible API. `neon dev` / `neon env pull` inject the standard AWS_* env vars for the linked branch; path-style addressing is required.",
+    env: {
+      config: ["bucket"],
+      credentialModes: [
+        {
+          label: "AWS credential chain (Neon injects AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY)",
+          vars: [
+            {
+              description: "Access key ID (the Neon branch credential's token id)",
+              key: "AWS_ACCESS_KEY_ID",
+              readBy: "sdk-chain",
+              secret: true,
+            },
+            {
+              description: "Secret access key (the Neon branch credential secret)",
+              key: "AWS_SECRET_ACCESS_KEY",
+              readBy: "sdk-chain",
+              secret: true,
+            },
+          ],
+        },
+      ],
+      notes:
+        "`neon dev` and `neon env pull` inject every variable below from the linked branch (the credentials resolve through the AWS SDK chain via the standard AWS_* names). Object storage requires path-style addressing, which the adapter enables by default.",
+      optional: [
+        {
+          aliases: ["NEON_STORAGE_REGION"],
+          description: "SigV4 region (Neon injects it under both names; defaults to us-east-1)",
+          key: "AWS_REGION",
+          readBy: "files-sdk",
+          secret: false,
+        },
+        {
+          description: "Force path-style addressing (Neon requires it; defaults to true)",
+          key: "NEON_STORAGE_FORCE_PATH_STYLE",
+          readBy: "files-sdk",
+          secret: false,
+        },
+      ],
+      required: [
+        {
+          description: "The branch's S3-compatible endpoint URL",
+          key: "AWS_ENDPOINT_URL_S3",
+          readBy: "files-sdk",
+          secret: false,
+        },
+      ],
+    },
+    name: "Neon",
+    peerDeps: AWS_S3_PEERS,
+    slug: "neon",
+  },
   "netlify-blobs": {
     description:
       "Netlify Blobs via @netlify/blobs. Auto-detects siteID and token on Netlify runtimes; falls back to env vars elsewhere.",

--- a/packages/files-sdk/src/providers/index.ts
+++ b/packages/files-sdk/src/providers/index.ts
@@ -861,16 +861,19 @@ export const PROVIDERS = {
       config: ["bucket"],
       credentialModes: [
         {
-          label: "AWS credential chain (Neon injects AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY)",
+          label:
+            "AWS credential chain (Neon injects AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY)",
           vars: [
             {
-              description: "Access key ID (the Neon branch credential's token id)",
+              description:
+                "Access key ID (the Neon branch credential's token id)",
               key: "AWS_ACCESS_KEY_ID",
               readBy: "sdk-chain",
               secret: true,
             },
             {
-              description: "Secret access key (the Neon branch credential secret)",
+              description:
+                "Secret access key (the Neon branch credential secret)",
               key: "AWS_SECRET_ACCESS_KEY",
               readBy: "sdk-chain",
               secret: true,
@@ -883,7 +886,8 @@ export const PROVIDERS = {
       optional: [
         {
           aliases: ["NEON_STORAGE_REGION"],
-          description: "SigV4 region (Neon injects it under both names; defaults to us-east-1)",
+          description:
+            "SigV4 region (Neon injects it under both names; defaults to us-east-1)",
           key: "AWS_REGION",
           readBy: "files-sdk",
           secret: false,

--- a/packages/files-sdk/test/cli-registry.test.ts
+++ b/packages/files-sdk/test/cli-registry.test.ts
@@ -123,6 +123,11 @@ const cases: Record<string, Case> = {
     expectedName: "minio",
     opts: { ...baseS3, endpoint: "http://localhost:9000" },
   },
+  neon: {
+    expectedName: "neon",
+    // neon() requires an endpoint (or AWS_ENDPOINT_URL_S3); baseS3 has none.
+    opts: { ...baseS3, endpoint: "https://br.storage.example.neon.tech" },
+  },
   "netlify-blobs": {
     expectedName: "netlify-blobs",
     // Both siteId + token are required for explicit-auth mode; without both

--- a/packages/files-sdk/test/neon.test.ts
+++ b/packages/files-sdk/test/neon.test.ts
@@ -16,7 +16,6 @@ const NEON_ENV_KEYS = [
   "AWS_REGION",
   "AWS_DEFAULT_REGION",
   "NEON_STORAGE_REGION",
-  "NEON_STORAGE_FORCE_PATH_STYLE",
 ] as const;
 
 const ENDPOINT = "https://br-cool-moon-42.storage.example.neon.tech";
@@ -110,29 +109,6 @@ describe("neon adapter", () => {
         secretAccessKey: "SECRET",
       })
     ).toThrow(/endpoint/u);
-  });
-
-  test("NEON_STORAGE_FORCE_PATH_STYLE=false disables path-style", async () => {
-    process.env.NEON_STORAGE_FORCE_PATH_STYLE = "false";
-    const adapter = neon({
-      accessKeyId: "AKID",
-      bucket: "images",
-      endpoint: ENDPOINT,
-      secretAccessKey: "SECRET",
-    });
-    expect(await (adapter.raw as S3Client).config.forcePathStyle).toBe(false);
-  });
-
-  test("explicit forcePathStyle option wins over the env var", async () => {
-    process.env.NEON_STORAGE_FORCE_PATH_STYLE = "false";
-    const adapter = neon({
-      accessKeyId: "AKID",
-      bucket: "images",
-      endpoint: ENDPOINT,
-      forcePathStyle: true,
-      secretAccessKey: "SECRET",
-    });
-    expect(await (adapter.raw as S3Client).config.forcePathStyle).toBe(true);
   });
 
   test("url() returns a presigned GET URL by default", async () => {

--- a/packages/files-sdk/test/neon.test.ts
+++ b/packages/files-sdk/test/neon.test.ts
@@ -28,14 +28,14 @@ describe("neon adapter", () => {
     saved = {};
     for (const key of NEON_ENV_KEYS) {
       saved[key] = process.env[key];
-      delete process.env[key];
+      Reflect.deleteProperty(process.env, key);
     }
   });
 
   afterEach(() => {
     for (const key of NEON_ENV_KEYS) {
       if (saved[key] === undefined) {
-        delete process.env[key];
+        Reflect.deleteProperty(process.env, key);
       } else {
         process.env[key] = saved[key];
       }
@@ -84,7 +84,9 @@ describe("neon adapter", () => {
       endpoint: ENDPOINT,
       secretAccessKey: "SECRET",
     });
-    expect(await (adapter.raw as S3Client).config.region()).toBe("eu-central-1");
+    expect(await (adapter.raw as S3Client).config.region()).toBe(
+      "eu-central-1"
+    );
   });
 
   test("explicit endpoint overrides the env var", async () => {
@@ -190,7 +192,10 @@ describe("neon adapter", () => {
       Provider: "Neon error",
       Unauthorized: "Unauthorized",
     } as const;
-    const err = mapS3Error({ $metadata: { httpStatusCode: 500 } }, neonMessages);
+    const err = mapS3Error(
+      { $metadata: { httpStatusCode: 500 } },
+      neonMessages
+    );
     expect(err.code).toBe("Provider");
     expect(err.message).toBe("Neon error");
   });

--- a/packages/files-sdk/test/neon.test.ts
+++ b/packages/files-sdk/test/neon.test.ts
@@ -1,0 +1,221 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { S3Client } from "@aws-sdk/client-s3";
+import { mockClient } from "aws-sdk-client-mock";
+
+import { Files } from "../src/index.js";
+import { neon } from "../src/neon/index.js";
+
+// Every env var the neon adapter (or the AWS credential chain it relies on)
+// reads. Cleared before each test and restored after, so the suite is
+// hermetic regardless of the AWS_* vars the developer's shell already exports.
+const NEON_ENV_KEYS = [
+  "AWS_ACCESS_KEY_ID",
+  "AWS_SECRET_ACCESS_KEY",
+  "AWS_ENDPOINT_URL_S3",
+  "AWS_REGION",
+  "AWS_DEFAULT_REGION",
+  "NEON_STORAGE_REGION",
+  "NEON_STORAGE_FORCE_PATH_STYLE",
+] as const;
+
+const ENDPOINT = "https://br-cool-moon-42.storage.example.neon.tech";
+const ENDPOINT_HOST = "br-cool-moon-42.storage.example.neon.tech";
+
+describe("neon adapter", () => {
+  let saved: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    saved = {};
+    for (const key of NEON_ENV_KEYS) {
+      saved[key] = process.env[key];
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    for (const key of NEON_ENV_KEYS) {
+      if (saved[key] === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = saved[key];
+      }
+    }
+  });
+
+  test("defaults to path-style addressing and us-east-1, relabels the provider", async () => {
+    const adapter = neon({
+      accessKeyId: "AKID",
+      bucket: "images",
+      endpoint: ENDPOINT,
+      secretAccessKey: "SECRET",
+    });
+    expect(adapter.name).toBe("neon");
+    expect(adapter.bucket).toBe("images");
+    const client = adapter.raw as S3Client;
+    // Neon requires path-style — the adapter turns it on by default.
+    expect(await client.config.forcePathStyle).toBe(true);
+    expect(await client.config.region()).toBe("us-east-1");
+    const endpoint = await client.config.endpoint?.();
+    expect(endpoint?.hostname).toBe(ENDPOINT_HOST);
+    expect(endpoint?.protocol).toBe("https:");
+  });
+
+  test("reads endpoint, region, and credentials from the injected AWS_* env vars", async () => {
+    process.env.AWS_ENDPOINT_URL_S3 = ENDPOINT;
+    process.env.AWS_REGION = "us-east-2";
+    process.env.AWS_ACCESS_KEY_ID = "ENV_KEY";
+    process.env.AWS_SECRET_ACCESS_KEY = "ENV_SECRET";
+
+    const adapter = neon({ bucket: "images" });
+    const client = adapter.raw as S3Client;
+    expect(await client.config.region()).toBe("us-east-2");
+    const endpoint = await client.config.endpoint?.();
+    expect(endpoint?.hostname).toBe(ENDPOINT_HOST);
+    const creds = await client.config.credentials();
+    expect(creds.accessKeyId).toBe("ENV_KEY");
+    expect(creds.secretAccessKey).toBe("ENV_SECRET");
+  });
+
+  test("falls back to NEON_STORAGE_REGION when AWS_REGION is unset", async () => {
+    process.env.NEON_STORAGE_REGION = "eu-central-1";
+    const adapter = neon({
+      accessKeyId: "AKID",
+      bucket: "images",
+      endpoint: ENDPOINT,
+      secretAccessKey: "SECRET",
+    });
+    expect(await (adapter.raw as S3Client).config.region()).toBe("eu-central-1");
+  });
+
+  test("explicit endpoint overrides the env var", async () => {
+    process.env.AWS_ENDPOINT_URL_S3 = ENDPOINT;
+    const adapter = neon({
+      accessKeyId: "AKID",
+      bucket: "images",
+      endpoint: "https://custom.example.com:8443",
+      secretAccessKey: "SECRET",
+    });
+    const client = adapter.raw as S3Client;
+    const endpoint = await client.config.endpoint?.();
+    expect(endpoint?.hostname).toBe("custom.example.com");
+    expect(endpoint?.port).toBe(8443);
+  });
+
+  test("missing endpoint throws at construction", () => {
+    expect(() =>
+      neon({
+        accessKeyId: "AKID",
+        bucket: "images",
+        secretAccessKey: "SECRET",
+      })
+    ).toThrow(/endpoint/u);
+  });
+
+  test("NEON_STORAGE_FORCE_PATH_STYLE=false disables path-style", async () => {
+    process.env.NEON_STORAGE_FORCE_PATH_STYLE = "false";
+    const adapter = neon({
+      accessKeyId: "AKID",
+      bucket: "images",
+      endpoint: ENDPOINT,
+      secretAccessKey: "SECRET",
+    });
+    expect(await (adapter.raw as S3Client).config.forcePathStyle).toBe(false);
+  });
+
+  test("explicit forcePathStyle option wins over the env var", async () => {
+    process.env.NEON_STORAGE_FORCE_PATH_STYLE = "false";
+    const adapter = neon({
+      accessKeyId: "AKID",
+      bucket: "images",
+      endpoint: ENDPOINT,
+      forcePathStyle: true,
+      secretAccessKey: "SECRET",
+    });
+    expect(await (adapter.raw as S3Client).config.forcePathStyle).toBe(true);
+  });
+
+  test("url() returns a presigned GET URL by default", async () => {
+    const adapter = neon({
+      accessKeyId: "AKID",
+      bucket: "images",
+      endpoint: ENDPOINT,
+      secretAccessKey: "SECRET",
+    });
+    const url = await adapter.url("a.txt");
+    expect(url).toContain("X-Amz-Signature=");
+    expect(url).toContain("a.txt");
+    expect(url).toContain("X-Amz-Expires=3600");
+    expect(url).toContain(ENDPOINT_HOST);
+  });
+
+  test("url() returns the publicBaseUrl when configured", async () => {
+    const adapter = neon({
+      accessKeyId: "AKID",
+      bucket: "images",
+      endpoint: ENDPOINT,
+      publicBaseUrl: "https://cdn.example.com",
+      secretAccessKey: "SECRET",
+    });
+    expect(await adapter.url("a.txt")).toBe("https://cdn.example.com/a.txt");
+  });
+
+  test("delegates upload to the underlying S3 client", async () => {
+    const s3Mock = mockClient(S3Client);
+    s3Mock.reset();
+    const { PutObjectCommand } = await import("@aws-sdk/client-s3");
+    s3Mock.on(PutObjectCommand).resolves({ ETag: '"ok"' });
+    const files = new Files({
+      adapter: neon({
+        accessKeyId: "AKID",
+        bucket: "images",
+        endpoint: ENDPOINT,
+        secretAccessKey: "SECRET",
+      }),
+    });
+    const result = await files.upload("a.txt", "hi");
+    expect(result.etag).toBe("ok");
+    s3Mock.reset();
+  });
+
+  test("delegates exists to the underlying S3 client", async () => {
+    const s3Mock = mockClient(S3Client);
+    s3Mock.reset();
+    const { HeadObjectCommand } = await import("@aws-sdk/client-s3");
+    const files = new Files({
+      adapter: neon({
+        accessKeyId: "AKID",
+        bucket: "images",
+        endpoint: ENDPOINT,
+        secretAccessKey: "SECRET",
+      }),
+    });
+
+    s3Mock.on(HeadObjectCommand).resolves({});
+    await expect(files.exists("a.txt")).resolves.toBe(true);
+
+    s3Mock.reset();
+    s3Mock.on(HeadObjectCommand).rejects(
+      Object.assign(new Error("missing"), {
+        $metadata: { httpStatusCode: 404 },
+      })
+    );
+    await expect(files.exists("missing.txt")).resolves.toBe(false);
+    s3Mock.reset();
+  });
+
+  test("default error messages from the inner s3 adapter are relabeled as 'Neon error'", async () => {
+    // Bypass the SDK mock and exercise the error mapper directly: the neon
+    // adapter configures it to use 'Neon error' as the Provider fallback.
+    const { mapS3Error } = await import("../src/s3/index.js");
+    const neonMessages = {
+      Conflict: "Conflict",
+      NotFound: "Not found",
+      Provider: "Neon error",
+      Unauthorized: "Unauthorized",
+    } as const;
+    const err = mapS3Error({ $metadata: { httpStatusCode: 500 } }, neonMessages);
+    expect(err.code).toBe("Provider");
+    expect(err.message).toBe("Neon error");
+  });
+});


### PR DESCRIPTION
## Description

Adds a `neon` adapter at `files-sdk/neon` for [Neon](https://neon.com) branchable object storage. Neon's storage is S3-compatible, so the adapter is a thin wrapper over the existing `s3()` adapter (same pattern as `tigris`, `wasabi`, `digitalocean-spaces`, etc.) with two Neon-specific touches:

- **Path-style addressing, always on.** Neon *requires* it — the wildcard TLS cert covers a single subdomain level (`*.storage.<suffix>`), which the branch id occupies, so the bucket name must travel in the request path. It's hardcoded to `true` and not exposed as an option.
- **Reads the standard `AWS_*` env vars Neon injects.** `neon dev` / `neon env pull` (and deployed Neon Functions) expose `AWS_ENDPOINT_URL_S3`, `AWS_REGION` (also `NEON_STORAGE_REGION`), and `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`. The adapter resolves the endpoint and region from those and lets the AWS credential chain pick up the credentials, so `neon({ bucket: "images" })` works from env alone:

```ts
import { Files } from "files-sdk";
import { neon } from "files-sdk/neon";

const files = new Files({ adapter: neon({ bucket: "images" }) });
await files.upload("avatars/abc.png", file, { contentType: "image/png" });
const url = await files.url("avatars/abc.png", { expiresIn: 300 });
```

Wired into the same places as every other adapter:

- `files-sdk/neon` subpath export in `package.json`
- `PROVIDERS` catalog entry in `src/providers/index.ts` (env spec + peer deps)
- CLI registry entry in `src/cli/registry.ts`
- Docs page at `apps/web/content/docs/adapters/neon.mdx`
- Tests at `test/neon.test.ts`
- Changeset (`minor`)

The `providers.test.ts` drift guard passes locally (catalog ↔ exports ↔ CLI registry ↔ `readEnv` declarations all consistent).

I also verified the adapter end-to-end against a live Neon branch bucket (path-style + `AWS_ENDPOINT_URL_S3` + AWS-chain creds): upload → head → download (content verified) → list (prefix) → copy → presigned `url()` GET (fetched, 200) → `signedUploadUrl()` PUT (fetched) → delete → 404-after-delete all succeed.

## Related Issues

N/A

## Checklist

- [x] I've reviewed my code
- [x] I've written tests
- [x] I've generated a change set file
- [x] I've updated the docs, if necessary

## Additional Notes

The credential model intentionally differs from `tigris`/`wasabi` (which require provider-specific key env vars): Neon injects the **standard** `AWS_*` names, so credentials flow through the AWS SDK's default chain exactly like the base `s3` adapter, while `endpoint` + path-style are the Neon-specific bits.