### PR TITLE
React Native / Expo compatibility for files-sdk/client

### DIFF
--- a/.changeset/react-native-client.md
+++ b/.changeset/react-native-client.md
@@ -1,0 +1,5 @@
+---
+"files-sdk": patch
+---
+
+React Native / Expo compatibility for `files-sdk/client` and the framework hooks. `download()` now falls back to buffering via `arrayBuffer()` on runtimes whose `fetch` never exposes `Response.body` (React Native), instead of returning an empty stream. Byte-body uploads fall back to sending raw bytes when the runtime's `Blob` cannot be constructed from `ArrayBuffer` parts, and the transports accept them directly. Adds a React Native docs page under UI → Client.

--- a/.changeset/react-native-client.md
+++ b/.changeset/react-native-client.md
@@ -1,5 +1,5 @@
 ---
-"files-sdk": patch
+"files-sdk": minor
 ---
 
 React Native / Expo compatibility for `files-sdk/client` and the framework hooks. `download()` now falls back to buffering via `arrayBuffer()` on runtimes whose `fetch` never exposes `Response.body` (React Native), instead of returning an empty stream. Byte-body uploads fall back to sending raw bytes when the runtime's `Blob` cannot be constructed from `ArrayBuffer` parts, and the transports accept them directly. Adds a React Native docs page under UI → Client.

--- a/.changeset/react-native-client.md
+++ b/.changeset/react-native-client.md
@@ -2,4 +2,4 @@
 "files-sdk": minor
 ---
 
-React Native / Expo compatibility for `files-sdk/client` and the framework hooks. `download()` now falls back to buffering via `arrayBuffer()` on runtimes whose `fetch` never exposes `Response.body` (React Native), instead of returning an empty stream. Byte-body uploads fall back to sending raw bytes when the runtime's `Blob` cannot be constructed from `ArrayBuffer` parts, and the transports accept them directly. Adds a React Native docs page under UI → Client.
+React Native / Expo support for `files-sdk/client` and the framework hooks. `upload()` now accepts a `NativeFileRef` (`{ uri, name, type, size }` — the shape Expo pickers return): presigned-POST targets stream the descriptor through React Native's `FormData`, and every other path resolves the `uri` to a Blob automatically. `download()` falls back to buffering via `arrayBuffer()` on runtimes whose `fetch` never exposes `Response.body` (React Native), instead of returning an empty stream. Byte-body uploads fall back to sending raw bytes when the runtime's `Blob` cannot be constructed from `ArrayBuffer` parts. Adds a React Native docs page under UI → Client.

--- a/apps/web/docs/ui/client/react-native.mdx
+++ b/apps/web/docs/ui/client/react-native.mdx
@@ -14,7 +14,7 @@ const files = useFiles({
 
 ## Uploading from a picker
 
-`expo-document-picker` / `expo-image-picker` hand you a local `uri`; fetch it to get a Blob the client can send:
+Pass the picker asset straight to `upload` as a `NativeFileRef` — the `{ uri, name, type }` shape `expo-document-picker` / `expo-image-picker` already return:
 
 ```tsx lineNumbers
 import * as DocumentPicker from "expo-document-picker";
@@ -24,14 +24,17 @@ const pick = async () => {
   if (result.canceled) {
     return;
   }
-  const blob = await fetch(result.assets[0].uri).then((r) => r.blob());
-  const { key } = await files.upload(blob, {
-    onProgress: (p) => setProgress(p.fraction), // 0 → 1
-  });
+  const { uri, name, mimeType, size } = result.assets[0];
+  const { key } = await files.upload(
+    { uri, name, type: mimeType, size },
+    { onProgress: (p) => setProgress(p.fraction) } // 0 → 1
+  );
 };
 ```
 
-Progress is real: React Native ships `XMLHttpRequest` with upload progress events, so the default transport reports byte-level progress exactly as in the browser. Byte bodies also work — `files.upload(key, bytes)` detects that React Native's `Blob` cannot wrap an `ArrayBuffer` and sends the bytes raw instead.
+The client picks the right wire form per target: a presigned **POST** target appends the descriptor to React Native's `FormData`, which streams it from disk without buffering; every other path (presigned PUT, the through-the-gateway upload) resolves the `uri` to a Blob first. Explicit keys work the same way — `files.upload("avatars/me.png", { uri, type: mimeType })`.
+
+Progress is real: React Native ships `XMLHttpRequest` with upload progress events, so the default transport reports byte-level progress exactly as in the browser. Blob bodies (`fetch(uri).then((r) => r.blob())`) still work, and byte bodies do too — `files.upload(key, bytes)` detects that React Native's `Blob` cannot wrap an `ArrayBuffer` and sends the bytes raw instead.
 
 ## Downloading
 
@@ -59,5 +62,5 @@ await FileSystem.downloadAsync(
 
 - `StoredFile.stream()` needs a `ReadableStream` polyfill (Hermes has none) — prefer `blob()` / `arrayBuffer()`.
 - `StoredFile.text()` relies on `TextDecoder`, present on recent Hermes; polyfill it on older runtimes.
-- Presigned **POST** upload targets don't work: React Native's `FormData` cannot carry a Blob part. Presigned **PUT** targets — the common case, including every S3-family adapter and UploadThing — work fine, as does the default through-the-gateway path.
+- Presigned **POST** upload targets (S3-family adapters with a `maxUploadSize` gateway cap) require a `NativeFileRef` body — React Native's `FormData` cannot carry a Blob part, but it streams a descriptor natively. Presigned **PUT** targets and the through-the-gateway path accept any body form.
 - The [UI components](/docs/ui/components) are React DOM + Tailwind, so they are web-only; the hook state (`uploads`, `progress`, `error`) maps directly onto your native components instead.

--- a/apps/web/docs/ui/client/react-native.mdx
+++ b/apps/web/docs/ui/client/react-native.mdx
@@ -1,0 +1,63 @@
+---
+title: React Native
+description: The same useFiles hook in React Native / Expo — absolute endpoint, picker-to-Blob uploads with real progress, buffered downloads.
+---
+
+`files-sdk/react` has no DOM dependency, so `useFiles` works in React Native and Expo as-is — same verbs, same progress and error state, talking to the same [gateway](/docs/ui/server/gateway) your web app uses. Two platform differences matter: the endpoint must be absolute, and upload bodies come from the picker as Blobs.
+
+```tsx lineNumbers
+const files = useFiles({
+  endpoint: "https://app.example.com/api/files", // React Native fetch needs an absolute URL
+  headers: () => ({ authorization: `Bearer ${token}` }), // your auth token
+});
+```
+
+## Uploading from a picker
+
+`expo-document-picker` / `expo-image-picker` hand you a local `uri`; fetch it to get a Blob the client can send:
+
+```tsx lineNumbers
+import * as DocumentPicker from "expo-document-picker";
+
+const pick = async () => {
+  const result = await DocumentPicker.getDocumentAsync();
+  if (result.canceled) {
+    return;
+  }
+  const blob = await fetch(result.assets[0].uri).then((r) => r.blob());
+  const { key } = await files.upload(blob, {
+    onProgress: (p) => setProgress(p.fraction), // 0 → 1
+  });
+};
+```
+
+Progress is real: React Native ships `XMLHttpRequest` with upload progress events, so the default transport reports byte-level progress exactly as in the browser. Byte bodies also work — `files.upload(key, bytes)` detects that React Native's `Blob` cannot wrap an `ArrayBuffer` and sends the bytes raw instead.
+
+## Downloading
+
+React Native's `fetch` has no response streaming, so `download()` transparently buffers the body — `blob()` and `arrayBuffer()` behave exactly as on the web:
+
+```tsx lineNumbers
+const file = await files.download("report.pdf");
+const bytes = await file.arrayBuffer();
+```
+
+For displaying or saving media, skip the byte round-trip and use a signed URL:
+
+```tsx lineNumbers
+import * as FileSystem from "expo-file-system";
+
+<Image source={{ uri: avatarUrl }} />; // from await files.url("avatar.png")
+
+await FileSystem.downloadAsync(
+  await files.url("report.pdf"),
+  FileSystem.documentDirectory + "report.pdf"
+);
+```
+
+## Caveats
+
+- `StoredFile.stream()` needs a `ReadableStream` polyfill (Hermes has none) — prefer `blob()` / `arrayBuffer()`.
+- `StoredFile.text()` relies on `TextDecoder`, present on recent Hermes; polyfill it on older runtimes.
+- Presigned **POST** upload targets don't work: React Native's `FormData` cannot carry a Blob part. Presigned **PUT** targets — the common case, including every S3-family adapter and UploadThing — work fine, as does the default through-the-gateway path.
+- The [UI components](/docs/ui/components) are React DOM + Tailwind, so they are web-only; the hook state (`uploads`, `progress`, `error`) maps directly onto your native components instead.

--- a/packages/files-sdk/src/client/download-decode.ts
+++ b/packages/files-sdk/src/client/download-decode.ts
@@ -2,8 +2,10 @@
 // returns, reusing `createStoredFile` so `blob()/text()/arrayBuffer()/stream()`
 // behave identically (including the single-consumption guard). The body is a
 // streaming `BodySource` over `Response.body` — a large download isn't buffered
-// unless an accessor asks for the bytes. Metadata with no HTTP-header home
-// (`key`, `metadata`) rides in the base64 `X-Files-Meta` header.
+// unless an accessor asks for the bytes. On runtimes whose fetch never exposes
+// `Response.body` (React Native), it falls back to a lazy `arrayBuffer()`
+// buffer instead. Metadata with no HTTP-header home (`key`, `metadata`) rides
+// in the base64 `X-Files-Meta` header.
 
 import type { StoredFile } from "../index.js";
 import { createStoredFile } from "../internal/stored-file.js";
@@ -34,6 +36,7 @@ export const decodeDownload = (
   const meta = decodeMeta(res.headers.get("x-files-meta"));
   const lengthHeader = res.headers.get("content-length");
   const size = lengthHeader === null ? 0 : Number(lengthHeader);
+  const { body } = res;
   return createStoredFile(
     {
       etag: res.headers.get("etag") ?? meta.etag,
@@ -43,6 +46,11 @@ export const decodeDownload = (
       size,
       type: res.headers.get("content-type") ?? "application/octet-stream",
     },
-    { factory: () => res.body ?? new ReadableStream(), kind: "stream" }
+    body
+      ? { factory: () => body, kind: "stream" }
+      : {
+          factory: async () => new Uint8Array(await res.arrayBuffer()),
+          kind: "lazy",
+        }
   );
 };

--- a/packages/files-sdk/src/client/files-client.ts
+++ b/packages/files-sdk/src/client/files-client.ts
@@ -33,6 +33,7 @@ import type {
   FilesClient,
   FilesClientConfig,
   ListCallOptions,
+  NativeFileRef,
   SearchCallOptions,
   SignUploadCallOptions,
   TrashedFile,
@@ -42,6 +43,7 @@ import type {
   UploadOutcome,
   UrlCallOptions,
 } from "./types.js";
+import { isNativeFileRef } from "./types.js";
 
 const DEFAULT_ENDPOINT = "/api/files";
 const DEFAULT_CONCURRENCY = 4;
@@ -107,7 +109,12 @@ const asBytes = (
         body.byteLength
       );
 
-const toBody = (body: UploadBody, contentType?: string): NormalizedBody => {
+// Refs are excluded: every caller resolves a `NativeFileRef` to a Blob before
+// normalizing (raw request bodies always need real bytes).
+const toBody = (
+  body: Exclude<UploadBody, NativeFileRef>,
+  contentType?: string
+): NormalizedBody => {
   if (body instanceof Blob) {
     return fromBlob(
       contentType && body.type !== contentType
@@ -143,6 +150,20 @@ export const createFilesClient = (
   const transport = config.transport ?? defaultTransport(fetchImpl);
   const concurrency = config.concurrency ?? DEFAULT_CONCURRENCY;
   const sep = endpoint.includes("?") ? "&" : "?";
+
+  // Read a React Native picker asset into a Blob — needed whenever the bytes
+  // themselves must be sent (raw PUT bodies); only the presigned-POST path can
+  // stream the descriptor via RN's FormData without touching the bytes.
+  const resolveRef = async (ref: NativeFileRef): Promise<Blob> => {
+    const res = await fetchImpl(ref.uri);
+    if (!res.ok) {
+      throw new FilesError(
+        "Provider",
+        `could not read upload source ${ref.uri} (${res.status})`
+      );
+    }
+    return res.blob();
+  };
 
   const resolveHeaders = async (): Promise<Record<string, string>> => {
     const raw =
@@ -238,7 +259,7 @@ export const createFilesClient = (
 
   const sendToTarget = async (
     target: PresignedUpload["target"],
-    body: Blob,
+    body: Blob | NativeFileRef,
     signal: AbortSignal | undefined,
     onProgress?: (loaded: number, total: number) => void
   ): Promise<void> => {
@@ -258,12 +279,12 @@ export const createFilesClient = (
   };
 
   const uploadKeyless = async (
-    file: Blob,
+    file: Blob | NativeFileRef,
     opts?: UploadCallOptions
   ): Promise<UploadOutcome> => {
     const info = {
       name: fileName(file),
-      size: file.size,
+      size: file.size ?? 0,
       type: file.type || "application/octet-stream",
     };
     const presign = await post<{ uploads: PresignedUpload[] }>(
@@ -280,13 +301,20 @@ export const createFilesClient = (
     }
     const { id, key, target } = first;
 
+    // A descriptor can ride RN's FormData only on a POST target; a raw PUT
+    // needs the actual bytes, so resolve the uri to a Blob first.
+    const body =
+      isNativeFileRef(file) && target.method === "PUT"
+        ? await resolveRef(file)
+        : file;
+
     const state = initialState(file);
     state.status = "uploading";
     state.key = key;
     const states: FileUploadState[] = [state];
-    await sendToTarget(target, file, opts?.signal, (loaded, total) => {
+    await sendToTarget(target, body, opts?.signal, (loaded, total) => {
       state.loaded = loaded;
-      state.total = total || file.size;
+      state.total = total || state.size;
       state.progress = state.total ? loaded / state.total : 0;
       opts?.onProgress?.(aggregate(states), states);
     });
@@ -318,7 +346,11 @@ export const createFilesClient = (
     body: UploadBody,
     opts?: UploadCallOptions
   ): Promise<UploadOutcome> => {
-    const norm = toBody(body, opts?.contentType);
+    // The through-endpoint is a raw PUT, so a picker ref becomes a Blob here;
+    // its declared type fills in when no explicit contentType is given.
+    const norm = isNativeFileRef(body)
+      ? toBody(await resolveRef(body), opts?.contentType ?? body.type)
+      : toBody(body, opts?.contentType);
     const result = await transport({
       body: norm.body,
       headers: {
@@ -633,7 +665,7 @@ export const createFilesClient = (
     },
 
     upload: ((
-      a: Blob | string | UploadManyClientItem[],
+      a: Blob | NativeFileRef | string | UploadManyClientItem[],
       b?: UploadBody | UploadCallOptions | BulkCallOptions,
       c?: UploadCallOptions
     ) => {

--- a/packages/files-sdk/src/client/files-client.ts
+++ b/packages/files-sdk/src/client/files-client.ts
@@ -84,16 +84,46 @@ const withErrors = <T extends object>(base: T, errors?: WireBulkError[]): T => {
   return revived ? { ...base, errors: revived } : base;
 };
 
-const toBlob = (body: UploadBody, contentType?: string): Blob => {
+interface NormalizedBody {
+  body: Blob | Uint8Array;
+  size: number;
+  type: string;
+}
+
+const fromBlob = (blob: Blob): NormalizedBody => ({
+  body: blob,
+  size: blob.size,
+  type: blob.type,
+});
+
+const asBytes = (body: ArrayBuffer | ArrayBufferView): Uint8Array =>
+  body instanceof ArrayBuffer
+    ? new Uint8Array(body)
+    : new Uint8Array(body.buffer, body.byteOffset, body.byteLength);
+
+const toBody = (body: UploadBody, contentType?: string): NormalizedBody => {
   if (body instanceof Blob) {
-    return contentType && body.type !== contentType
-      ? new Blob([body], { type: contentType })
-      : body;
+    return fromBlob(
+      contentType && body.type !== contentType
+        ? new Blob([body], { type: contentType })
+        : body
+    );
   }
-  return new Blob(
-    [body as BlobPart],
-    contentType ? { type: contentType } : undefined
-  );
+  if (typeof body === "string") {
+    return fromBlob(
+      new Blob([body], contentType ? { type: contentType } : undefined)
+    );
+  }
+  const bytes = asBytes(body);
+  try {
+    return fromBlob(
+      new Blob([bytes as BlobPart], contentType ? { type: contentType } : undefined)
+    );
+  } catch {
+    // React Native's Blob cannot be constructed from ArrayBuffer parts; the
+    // transports accept raw bytes, so pass them through instead.
+    return { body: bytes, size: bytes.byteLength, type: contentType ?? "" };
+  }
 };
 
 export const createFilesClient = (
@@ -279,21 +309,21 @@ export const createFilesClient = (
     body: UploadBody,
     opts?: UploadCallOptions
   ): Promise<UploadOutcome> => {
-    const blob = toBlob(body, opts?.contentType);
+    const norm = toBody(body, opts?.contentType);
     const result = await transport({
-      body: blob,
+      body: norm.body,
       headers: {
-        "content-type": blob.type || "application/octet-stream",
+        "content-type": norm.type || "application/octet-stream",
         ...(await resolveHeaders()),
       },
       method: "PUT",
       onProgress: opts?.onProgress
         ? (loaded, total) => {
-            const state = initialState(blob);
+            const state = initialState(norm.body);
             state.key = key;
             state.status = "uploading";
             state.loaded = loaded;
-            state.total = total || blob.size;
+            state.total = total || norm.size;
             state.progress = state.total ? loaded / state.total : 0;
             opts.onProgress?.(aggregate([state]), [state]);
           }

--- a/packages/files-sdk/src/client/files-client.ts
+++ b/packages/files-sdk/src/client/files-client.ts
@@ -85,7 +85,7 @@ const withErrors = <T extends object>(base: T, errors?: WireBulkError[]): T => {
 };
 
 interface NormalizedBody {
-  body: Blob | Uint8Array;
+  body: Blob | Uint8Array<ArrayBuffer>;
   size: number;
   type: string;
 }
@@ -96,10 +96,16 @@ const fromBlob = (blob: Blob): NormalizedBody => ({
   type: blob.type,
 });
 
-const asBytes = (body: ArrayBuffer | ArrayBufferView): Uint8Array =>
+const asBytes = (
+  body: ArrayBuffer | ArrayBufferView
+): Uint8Array<ArrayBuffer> =>
   body instanceof ArrayBuffer
     ? new Uint8Array(body)
-    : new Uint8Array(body.buffer, body.byteOffset, body.byteLength);
+    : new Uint8Array(
+        body.buffer as ArrayBuffer,
+        body.byteOffset,
+        body.byteLength
+      );
 
 const toBody = (body: UploadBody, contentType?: string): NormalizedBody => {
   if (body instanceof Blob) {
@@ -117,7 +123,10 @@ const toBody = (body: UploadBody, contentType?: string): NormalizedBody => {
   const bytes = asBytes(body);
   try {
     return fromBlob(
-      new Blob([bytes as BlobPart], contentType ? { type: contentType } : undefined)
+      new Blob(
+        [bytes as BlobPart],
+        contentType ? { type: contentType } : undefined
+      )
     );
   } catch {
     // React Native's Blob cannot be constructed from ArrayBuffer parts; the

--- a/packages/files-sdk/src/client/progress.ts
+++ b/packages/files-sdk/src/client/progress.ts
@@ -11,8 +11,14 @@ export type FileUploadStatus =
   | "error"
   | "aborted";
 
+/**
+ * The body a `FileUploadState` tracks. `Uint8Array` appears only on runtimes
+ * whose `Blob` cannot wrap raw bytes (React Native).
+ */
+export type UploadStateBody = Blob | Uint8Array;
+
 export interface FileUploadState {
-  file: Blob;
+  file: UploadStateBody;
   name: string;
   size: number;
   type: string;
@@ -44,16 +50,19 @@ export const aggregate = (
   return { fraction: total === 0 ? 0 : loaded / total, loaded, total };
 };
 
-export const fileName = (file: Blob): string =>
+export const fileName = (file: UploadStateBody): string =>
   file instanceof File ? file.name : "blob";
 
-export const initialState = (file: Blob): FileUploadState => ({
-  file,
-  loaded: 0,
-  name: fileName(file),
-  progress: 0,
-  size: file.size,
-  status: "pending",
-  total: file.size,
-  type: file.type || "application/octet-stream",
-});
+export const initialState = (file: UploadStateBody): FileUploadState => {
+  const size = file instanceof Blob ? file.size : file.byteLength;
+  return {
+    file,
+    loaded: 0,
+    name: fileName(file),
+    progress: 0,
+    size,
+    status: "pending",
+    total: size,
+    type: (file instanceof Blob && file.type) || "application/octet-stream",
+  };
+};

--- a/packages/files-sdk/src/client/progress.ts
+++ b/packages/files-sdk/src/client/progress.ts
@@ -3,6 +3,8 @@
 // straight byte-sum reduce so a multi-file upload reports one bar.
 
 import type { FilesError } from "../internal/errors.js";
+import type { NativeFileRef } from "./types.js";
+import { isNativeFileRef } from "./types.js";
 
 export type FileUploadStatus =
   | "pending"
@@ -12,10 +14,11 @@ export type FileUploadStatus =
   | "aborted";
 
 /**
- * The body a `FileUploadState` tracks. `Uint8Array` appears only on runtimes
- * whose `Blob` cannot wrap raw bytes (React Native).
+ * The body a `FileUploadState` tracks. `Uint8Array` and `NativeFileRef`
+ * appear only in React Native — the former on runtimes whose `Blob` cannot
+ * wrap raw bytes, the latter for picker-asset uploads.
  */
-export type UploadStateBody = Blob | Uint8Array;
+export type UploadStateBody = Blob | Uint8Array | NativeFileRef;
 
 export interface FileUploadState {
   file: UploadStateBody;
@@ -50,11 +53,33 @@ export const aggregate = (
   return { fraction: total === 0 ? 0 : loaded / total, loaded, total };
 };
 
-export const fileName = (file: UploadStateBody): string =>
-  file instanceof File ? file.name : "blob";
+const refName = (ref: NativeFileRef): string => {
+  if (ref.name) {
+    return ref.name;
+  }
+  const base = ref.uri.split("?")[0]?.split("/").pop();
+  return base || "blob";
+};
+
+export const fileName = (file: UploadStateBody): string => {
+  if (file instanceof File) {
+    return file.name;
+  }
+  return isNativeFileRef(file) ? refName(file) : "blob";
+};
+
+const sizeAndType = (file: UploadStateBody): { size: number; type: string } => {
+  if (file instanceof Blob) {
+    return { size: file.size, type: file.type };
+  }
+  if (isNativeFileRef(file)) {
+    return { size: file.size ?? 0, type: file.type ?? "" };
+  }
+  return { size: file.byteLength, type: "" };
+};
 
 export const initialState = (file: UploadStateBody): FileUploadState => {
-  const size = file instanceof Blob ? file.size : file.byteLength;
+  const { size, type } = sizeAndType(file);
   return {
     file,
     loaded: 0,
@@ -63,6 +88,6 @@ export const initialState = (file: UploadStateBody): FileUploadState => {
     size,
     status: "pending",
     total: size,
-    type: (file instanceof Blob && file.type) || "application/octet-stream",
+    type: type || "application/octet-stream",
   };
 };

--- a/packages/files-sdk/src/client/transport.ts
+++ b/packages/files-sdk/src/client/transport.ts
@@ -7,6 +7,10 @@
 
 import { FilesError } from "../internal/errors.js";
 import { abortError } from "../internal/retry.js";
+import type { NativeFileRef } from "./types.js";
+import { isNativeFileRef } from "./types.js";
+
+export type SendBody = Blob | Uint8Array<ArrayBuffer> | NativeFileRef;
 
 export interface SendRequest {
   url: string;
@@ -17,8 +21,10 @@ export interface SendRequest {
   /**
    * `Uint8Array` appears only on runtimes whose `Blob` cannot wrap raw bytes
    * (React Native); both XHR and fetch accept it as a request body directly.
+   * A `NativeFileRef` appears only on the presigned-POST path in React
+   * Native, whose `FormData` streams the descriptor from disk.
    */
-  body: Blob | Uint8Array<ArrayBuffer> | null;
+  body: SendBody | null;
   signal?: AbortSignal;
   onProgress?: (loaded: number, total: number) => void;
 }
@@ -30,14 +36,38 @@ export interface SendResult {
 
 export type Transport = (req: SendRequest) => Promise<SendResult>;
 
-const bodySize = (body: Blob | Uint8Array<ArrayBuffer>): number =>
-  body instanceof Blob ? body.size : body.byteLength;
+const bodySize = (body: SendBody): number => {
+  if (body instanceof Blob) {
+    return body.size;
+  }
+  return isNativeFileRef(body) ? (body.size ?? 0) : body.byteLength;
+};
 
-// The multipart `file` part must be a Blob. A raw-byte body only exists on
-// runtimes whose Blob rejects byte parts (React Native), where presigned-POST
-// multipart is unusable anyway — the wrap below throws there, accurately.
-const asFilePart = (body: Blob | Uint8Array<ArrayBuffer>): Blob =>
-  body instanceof Blob ? body : new Blob([body as BlobPart]);
+// The multipart `file` part: Blobs pass through; a NativeFileRef is handed to
+// FormData untouched (React Native streams it from disk — the cast covers the
+// web type, where refs never appear); raw bytes get wrapped — they only exist
+// on runtimes whose Blob rejects byte parts (React Native), where the wrap
+// throws, accurately.
+const asFilePart = (body: SendBody): Blob => {
+  if (body instanceof Blob || isNativeFileRef(body)) {
+    return body as Blob;
+  }
+  return new Blob([body as BlobPart]);
+};
+
+// A raw (non-multipart) request body. A NativeFileRef here is a client bug —
+// `files-client` resolves refs to Blobs for every non-POST-fields path.
+const asRawBody = (
+  body: SendBody | null
+): Blob | Uint8Array<ArrayBuffer> | null => {
+  if (isNativeFileRef(body)) {
+    throw new FilesError(
+      "Provider",
+      "a NativeFileRef body requires a presigned-POST target; resolve it to a Blob first"
+    );
+  }
+  return body;
+};
 
 const buildBody = (req: SendRequest): XMLHttpRequestBodyInit | null => {
   if (req.method === "POST" && req.fields) {
@@ -50,7 +80,7 @@ const buildBody = (req: SendRequest): XMLHttpRequestBodyInit | null => {
     }
     return form;
   }
-  return req.body;
+  return asRawBody(req.body);
 };
 
 export const xhrTransport: Transport = (req) =>
@@ -106,7 +136,7 @@ export const fetchTransport =
       }
       body = form;
     } else {
-      ({ body } = req);
+      body = asRawBody(req.body);
     }
     const res = await fetchImpl(req.url, {
       body,

--- a/packages/files-sdk/src/client/transport.ts
+++ b/packages/files-sdk/src/client/transport.ts
@@ -18,7 +18,7 @@ export interface SendRequest {
    * `Uint8Array` appears only on runtimes whose `Blob` cannot wrap raw bytes
    * (React Native); both XHR and fetch accept it as a request body directly.
    */
-  body: Blob | Uint8Array | null;
+  body: Blob | Uint8Array<ArrayBuffer> | null;
   signal?: AbortSignal;
   onProgress?: (loaded: number, total: number) => void;
 }
@@ -30,13 +30,13 @@ export interface SendResult {
 
 export type Transport = (req: SendRequest) => Promise<SendResult>;
 
-const bodySize = (body: Blob | Uint8Array): number =>
+const bodySize = (body: Blob | Uint8Array<ArrayBuffer>): number =>
   body instanceof Blob ? body.size : body.byteLength;
 
 // The multipart `file` part must be a Blob. A raw-byte body only exists on
 // runtimes whose Blob rejects byte parts (React Native), where presigned-POST
 // multipart is unusable anyway — the wrap below throws there, accurately.
-const asFilePart = (body: Blob | Uint8Array): Blob =>
+const asFilePart = (body: Blob | Uint8Array<ArrayBuffer>): Blob =>
   body instanceof Blob ? body : new Blob([body as BlobPart]);
 
 const buildBody = (req: SendRequest): XMLHttpRequestBodyInit | null => {

--- a/packages/files-sdk/src/client/transport.ts
+++ b/packages/files-sdk/src/client/transport.ts
@@ -14,7 +14,11 @@ export interface SendRequest {
   headers?: Record<string, string>;
   /** Presigned-POST form fields, appended in order before the file. */
   fields?: Record<string, string>;
-  body: Blob | null;
+  /**
+   * `Uint8Array` appears only on runtimes whose `Blob` cannot wrap raw bytes
+   * (React Native); both XHR and fetch accept it as a request body directly.
+   */
+  body: Blob | Uint8Array | null;
   signal?: AbortSignal;
   onProgress?: (loaded: number, total: number) => void;
 }
@@ -26,6 +30,15 @@ export interface SendResult {
 
 export type Transport = (req: SendRequest) => Promise<SendResult>;
 
+const bodySize = (body: Blob | Uint8Array): number =>
+  body instanceof Blob ? body.size : body.byteLength;
+
+// The multipart `file` part must be a Blob. A raw-byte body only exists on
+// runtimes whose Blob rejects byte parts (React Native), where presigned-POST
+// multipart is unusable anyway — the wrap below throws there, accurately.
+const asFilePart = (body: Blob | Uint8Array): Blob =>
+  body instanceof Blob ? body : new Blob([body as BlobPart]);
+
 const buildBody = (req: SendRequest): XMLHttpRequestBodyInit | null => {
   if (req.method === "POST" && req.fields) {
     const form = new FormData();
@@ -33,7 +46,7 @@ const buildBody = (req: SendRequest): XMLHttpRequestBodyInit | null => {
       form.append(key, value);
     }
     if (req.body) {
-      form.append("file", req.body);
+      form.append("file", asFilePart(req.body));
     }
     return form;
   }
@@ -80,7 +93,7 @@ export const xhrTransport: Transport = (req) =>
 export const fetchTransport =
   (fetchImpl: typeof fetch): Transport =>
   async (req) => {
-    const total = req.body?.size ?? 0;
+    const total = req.body ? bodySize(req.body) : 0;
     req.onProgress?.(0, total);
     let body: BodyInit | null;
     if (req.method === "POST" && req.fields) {
@@ -89,7 +102,7 @@ export const fetchTransport =
         form.append(key, value);
       }
       if (req.body) {
-        form.append("file", req.body);
+        form.append("file", asFilePart(req.body));
       }
       body = form;
     } else {

--- a/packages/files-sdk/src/client/types.ts
+++ b/packages/files-sdk/src/client/types.ts
@@ -91,7 +91,34 @@ export interface UploadOutcome {
   lastModified?: number;
 }
 
-export type UploadBody = Blob | ArrayBuffer | ArrayBufferView | string;
+/**
+ * A React Native file reference — the `{ uri, name, type }` shape Expo's
+ * pickers return and React Native's `FormData` streams from disk. Pass one
+ * anywhere an upload body goes; on a presigned-POST target it rides the form
+ * untouched (native streaming), on every other path the client resolves the
+ * `uri` to a Blob first. Only meaningful in React Native — on the web, pass a
+ * `Blob`/`File` instead.
+ */
+export interface NativeFileRef {
+  uri: string;
+  name?: string;
+  type?: string;
+  /** Bytes, when the picker reports it; informs presign info and progress totals. */
+  size?: number;
+}
+
+export const isNativeFileRef = (body: unknown): body is NativeFileRef =>
+  typeof body === "object" &&
+  body !== null &&
+  !(body instanceof Blob) &&
+  typeof (body as NativeFileRef).uri === "string";
+
+export type UploadBody =
+  | Blob
+  | ArrayBuffer
+  | ArrayBufferView
+  | string
+  | NativeFileRef;
 
 export interface UploadManyClientItem {
   key: string;
@@ -124,7 +151,10 @@ export interface TrashedFile {
 
 export interface FilesClient {
   upload: {
-    (file: Blob, opts?: UploadCallOptions): Promise<UploadOutcome>;
+    (
+      file: Blob | NativeFileRef,
+      opts?: UploadCallOptions
+    ): Promise<UploadOutcome>;
     (
       key: string,
       body: UploadBody,

--- a/packages/files-sdk/test/files-client-edge.test.ts
+++ b/packages/files-sdk/test/files-client-edge.test.ts
@@ -4,8 +4,11 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { decodeDownload } from "../src/client/download-decode.js";
 import { createFilesClient } from "../src/client/index.js";
 import type { FileUploadState } from "../src/client/progress.js";
+import { fileName, initialState } from "../src/client/progress.js";
 import type { SendRequest, Transport } from "../src/client/transport.js";
 import { fetchTransport, xhrTransport } from "../src/client/transport.js";
+import type { NativeFileRef } from "../src/client/types.js";
+import { isNativeFileRef } from "../src/client/types.js";
 
 const ENDPOINT = "https://app.test/api/files";
 
@@ -407,5 +410,231 @@ describe("xhrTransport failure + abort", () => {
     });
     controller.abort(new Error("stop"));
     expect(promise).rejects.toMatchObject({ aborted: true });
+  });
+});
+
+describe("native file refs", () => {
+  const REF_URI = "file:///docs/photo.png";
+
+  // Serves the picker uri as bytes and everything else as the gateway.
+  const refAwareFetch = (
+    uploads: unknown,
+    posts: unknown[] = []
+  ): typeof fetch =>
+    ((input: RequestInfo | URL, init?: RequestInit) => {
+      if (String(input).startsWith("file://")) {
+        return Promise.resolve(
+          new Response(new Blob(["native bytes!"], { type: "image/png" }))
+        );
+      }
+      const payload = JSON.parse(String(init?.body)) as { op: string };
+      posts.push(payload);
+      const body =
+        payload.op === "presign"
+          ? { uploads }
+          : { files: [{ key: "k", size: 13, type: "image/png" }] };
+      return Promise.resolve(Response.json(body, { status: 200 }));
+    }) as unknown as typeof fetch;
+
+  const okTransport =
+    (capture: (req: SendRequest) => void): Transport =>
+    (req) => {
+      capture(req);
+      req.onProgress?.(0, 0);
+      return Promise.resolve({ status: 200, text: "{}" });
+    };
+
+  test("isNativeFileRef accepts only uri-carrying plain objects", () => {
+    expect(isNativeFileRef({ uri: "file:///x" })).toBe(true);
+    expect(isNativeFileRef(null)).toBe(false);
+    expect(isNativeFileRef("file:///x")).toBe(false);
+    expect(isNativeFileRef(new Blob(["x"]))).toBe(false);
+    expect(isNativeFileRef({ name: "no-uri" })).toBe(false);
+  });
+
+  test("keyless ref upload resolves to a Blob for a PUT target", async () => {
+    const posts: { op: string; files?: { name: string; size: number }[] }[] =
+      [];
+    let sent: SendRequest | undefined;
+    const client = createFilesClient({
+      endpoint: ENDPOINT,
+      fetchImpl: refAwareFetch(
+        [{ id: "t", key: "k", target: { method: "PUT", url: "https://s/up" } }],
+        posts
+      ),
+      transport: okTransport((req) => {
+        sent = req;
+      }),
+    });
+    const out = await client.upload({ type: "image/png", uri: REF_URI });
+    expect(out.key).toBe("k");
+    expect(sent?.body).toBeInstanceOf(Blob);
+    // presign info derives the name from the uri and defaults size to 0
+    expect(posts[0]?.files?.[0]?.name).toBe("photo.png");
+    expect(posts[0]?.files?.[0]?.size).toBe(0);
+  });
+
+  test("keyless ref upload rides the form untouched on a POST target", async () => {
+    const ref: NativeFileRef = {
+      name: "pic.png",
+      size: 5,
+      type: "image/png",
+      uri: REF_URI,
+    };
+    let sent: SendRequest | undefined;
+    const client = createFilesClient({
+      endpoint: ENDPOINT,
+      fetchImpl: refAwareFetch([
+        {
+          id: "t",
+          key: "k",
+          target: {
+            fields: { acl: "private" },
+            method: "POST",
+            url: "https://s/up",
+          },
+        },
+      ]),
+      transport: okTransport((req) => {
+        sent = req;
+      }),
+    });
+    const states: FileUploadState[] = [];
+    await client.upload(ref, {
+      onProgress: (_agg, perFile) => states.push(...perFile),
+    });
+    expect(sent?.body).toBe(ref);
+    expect(sent?.fields).toEqual({ acl: "private" });
+    expect(states[0]?.name).toBe("pic.png");
+    expect(states[0]?.size).toBe(5);
+  });
+
+  test("explicit ref upload resolves bytes and uses the ref's type", async () => {
+    let sent: SendRequest | undefined;
+    const client = createFilesClient({
+      endpoint: ENDPOINT,
+      fetchImpl: refAwareFetch([]),
+      transport: (req) => {
+        sent = req;
+        return Promise.resolve({
+          status: 200,
+          text: JSON.stringify({
+            file: { key: "k", size: 13, type: "image/png" },
+          }),
+        });
+      },
+    });
+    const out = await client.upload("k", { type: "image/png", uri: REF_URI });
+    expect(out.size).toBe(13);
+    expect(sent?.body).toBeInstanceOf(Blob);
+    expect(sent?.headers?.["content-type"]).toBe("image/png");
+  });
+
+  test("explicit contentType overrides the ref's type", async () => {
+    let sent: SendRequest | undefined;
+    const client = createFilesClient({
+      endpoint: ENDPOINT,
+      fetchImpl: refAwareFetch([]),
+      transport: (req) => {
+        sent = req;
+        return Promise.resolve({
+          status: 200,
+          text: JSON.stringify({
+            file: { key: "k", size: 13, type: "image/webp" },
+          }),
+        });
+      },
+    });
+    await client.upload(
+      "k",
+      { type: "image/png", uri: REF_URI },
+      {
+        contentType: "image/webp",
+      }
+    );
+    expect(sent?.headers?.["content-type"]).toBe("image/webp");
+  });
+
+  test("an unreadable ref uri rejects with a Provider error", () => {
+    const failing = ((input: RequestInfo | URL) =>
+      Promise.resolve(
+        String(input).startsWith("file://")
+          ? new Response(null, { status: 404 })
+          : new Response("{}", { status: 200 })
+      )) as unknown as typeof fetch;
+    const client = createFilesClient({
+      endpoint: ENDPOINT,
+      fetchImpl: failing,
+    });
+    expect(client.upload("k", { uri: "file:///gone.png" })).rejects.toThrow(
+      /could not read upload source/u
+    );
+  });
+
+  test("a raw-body transport path rejects an unresolved ref", () => {
+    const transport = fetchTransport(okStub);
+    expect(
+      transport({ body: { uri: REF_URI }, method: "PUT", url: "https://s/up" })
+    ).rejects.toThrow(/requires a presigned-POST target/u);
+  });
+
+  test("fetchTransport appends a ref to the form and reports its size", async () => {
+    const RealFormData = globalThis.FormData;
+    const parts: [string, unknown][] = [];
+    globalThis.FormData = class {
+      append(key: string, value: unknown) {
+        parts.push([key, value]);
+      }
+    } as unknown as typeof FormData;
+    try {
+      const ref: NativeFileRef = { size: 5, uri: REF_URI };
+      const totals: number[] = [];
+      const transport = fetchTransport(okStub);
+      await transport({
+        body: ref,
+        fields: { key: "k" },
+        method: "POST",
+        onProgress: (_loaded, total) => totals.push(total),
+        url: "https://s/up",
+      });
+      expect(totals).toEqual([5, 5]);
+      expect(parts).toEqual([
+        ["key", "k"],
+        ["file", ref],
+      ]);
+    } finally {
+      globalThis.FormData = RealFormData;
+    }
+  });
+
+  test("fetchTransport tolerates a null body", async () => {
+    const totals: number[] = [];
+    const transport = fetchTransport(okStub);
+    await transport({
+      body: null,
+      method: "PUT",
+      onProgress: (_loaded, total) => totals.push(total),
+      url: "https://s/up",
+    });
+    expect(totals).toEqual([0, 0]);
+  });
+
+  test("progress helpers understand refs", () => {
+    const named = initialState({
+      name: "n.png",
+      size: 7,
+      type: "image/png",
+      uri: REF_URI,
+    });
+    expect(named.name).toBe("n.png");
+    expect(named.size).toBe(7);
+    expect(named.type).toBe("image/png");
+
+    const bare = initialState({ uri: "file:///a/b.pdf" });
+    expect(bare.name).toBe("b.pdf");
+    expect(bare.size).toBe(0);
+    expect(bare.type).toBe("application/octet-stream");
+
+    expect(fileName({ uri: "file:///dir/?query" })).toBe("blob");
   });
 });

--- a/packages/files-sdk/test/files-client-edge.test.ts
+++ b/packages/files-sdk/test/files-client-edge.test.ts
@@ -3,8 +3,9 @@ import { afterEach, describe, expect, test } from "bun:test";
 
 import { decodeDownload } from "../src/client/download-decode.js";
 import { createFilesClient } from "../src/client/index.js";
-import type { Transport } from "../src/client/transport.js";
-import { xhrTransport } from "../src/client/transport.js";
+import type { FileUploadState } from "../src/client/progress.js";
+import type { SendRequest, Transport } from "../src/client/transport.js";
+import { fetchTransport, xhrTransport } from "../src/client/transport.js";
 
 const ENDPOINT = "https://app.test/api/files";
 
@@ -194,6 +195,153 @@ describe("download edge paths", () => {
     const file = decodeDownload(res, "fallback-key");
     expect(file.key).toBe("fallback-key");
     expect(file.size).toBe(5);
+  });
+
+  test("decodeDownload buffers via arrayBuffer when Response.body is missing", async () => {
+    // React Native's fetch never exposes `Response.body`.
+    const data = new TextEncoder().encode("hello");
+    const res = {
+      arrayBuffer: () => Promise.resolve(data.buffer),
+      body: null,
+      headers: new Headers({
+        "content-length": "5",
+        "content-type": "text/plain",
+      }),
+    } as unknown as Response;
+    const file = decodeDownload(res, "k");
+    expect(file.size).toBe(5);
+    expect(await file.text()).toBe("hello");
+  });
+});
+
+describe("react-native fallbacks", () => {
+  const RealBlob = globalThis.Blob;
+  afterEach(() => {
+    globalThis.Blob = RealBlob;
+  });
+
+  // Mimic React Native's Blob, which rejects ArrayBuffer/TypedArray parts.
+  const installByteRejectingBlob = () => {
+    globalThis.Blob = class extends RealBlob {
+      constructor(parts?: BlobPart[], opts?: BlobPropertyBag) {
+        if (
+          parts?.some((p) => p instanceof ArrayBuffer || ArrayBuffer.isView(p))
+        ) {
+          throw new Error(
+            "Creating blobs from 'ArrayBuffer' and 'ArrayBufferView' are not supported"
+          );
+        }
+        super(parts, opts);
+      }
+    };
+  };
+
+  const captureTransport =
+    (onSend: (req: SendRequest) => void, size: number): Transport =>
+    (req) => {
+      onSend(req);
+      req.onProgress?.(size, size);
+      return Promise.resolve({
+        status: 200,
+        text: JSON.stringify({
+          file: { key: "k", size, type: "application/octet-stream" },
+        }),
+      });
+    };
+
+  test("byte upload falls back to raw bytes when Blob rejects buffer parts", async () => {
+    installByteRejectingBlob();
+    let sent: SendRequest | undefined;
+    const states: FileUploadState[] = [];
+    const client = createFilesClient({
+      endpoint: ENDPOINT,
+      fetchImpl: okStub,
+      transport: captureTransport((req) => {
+        sent = req;
+      }, 3),
+    });
+    const out = await client.upload("k", new Uint8Array([1, 2, 3]), {
+      contentType: "application/x-thing",
+      onProgress: (_agg, perFile) => states.push(...perFile),
+    });
+    expect(out.key).toBe("k");
+    expect(sent?.body).toBeInstanceOf(Uint8Array);
+    expect(sent?.headers?.["content-type"]).toBe("application/x-thing");
+    expect(states[0]?.size).toBe(3);
+    expect(states[0]?.name).toBe("blob");
+    expect(states[0]?.progress).toBe(1);
+  });
+
+  test("byte fallback without contentType defaults the header", async () => {
+    installByteRejectingBlob();
+    let sent: SendRequest | undefined;
+    const client = createFilesClient({
+      endpoint: ENDPOINT,
+      fetchImpl: okStub,
+      transport: captureTransport((req) => {
+        sent = req;
+      }, 2),
+    });
+    await client.upload("k", new ArrayBuffer(2));
+    expect(sent?.body).toBeInstanceOf(Uint8Array);
+    expect(sent?.headers?.["content-type"]).toBe("application/octet-stream");
+  });
+
+  test("fetchTransport reports byte-body size", async () => {
+    const totals: number[] = [];
+    const transport = fetchTransport(
+      fetchReturning(() => new Response("{}", { status: 200 }))
+    );
+    await transport({
+      body: new Uint8Array(4),
+      method: "PUT",
+      onProgress: (_loaded, total) => totals.push(total),
+      url: "https://s/up",
+    });
+    expect(totals).toEqual([4, 4]);
+  });
+
+  test("presigned POST wraps a raw-byte body into a Blob form part", async () => {
+    let sentBody: FormData | undefined;
+    const Capture = class {
+      private readonly handlers: Record<string, (() => void)[]> = {};
+      upload = { addEventListener: () => {} };
+      status = 204;
+      responseText = "";
+      open() {
+        /* noop */
+      }
+      setRequestHeader() {
+        /* noop */
+      }
+      addEventListener(type: string, handler: () => void) {
+        (this.handlers[type] ??= []).push(handler);
+      }
+      send(body?: unknown) {
+        sentBody = body as FormData;
+        for (const handler of this.handlers.load ?? []) {
+          handler();
+        }
+      }
+      abort() {
+        /* noop */
+      }
+    };
+    (globalThis as { XMLHttpRequest?: unknown }).XMLHttpRequest = Capture;
+    try {
+      const result = await xhrTransport({
+        body: new Uint8Array([7]),
+        fields: { key: "k" },
+        method: "POST",
+        url: "https://s/up",
+      });
+      expect(result.status).toBe(204);
+      expect(sentBody?.get("file")).toBeInstanceOf(Blob);
+      expect(sentBody?.get("key")).toBe("k");
+    } finally {
+      // @ts-expect-error -- cleanup
+      delete globalThis.XMLHttpRequest;
+    }
   });
 });
 

--- a/packages/files-sdk/test/files-client.test.ts
+++ b/packages/files-sdk/test/files-client.test.ts
@@ -45,12 +45,12 @@ const clientFor = (adapter: Adapter, opts: { headers?: HeadersInit } = {}) => {
   const fetchImpl = ((input: RequestInfo | URL, init?: RequestInit) =>
     router.handle(new Request(input, init))) as typeof fetch;
   const transport: Transport = async (req: SendRequest) => {
-    const total =
-      req.body instanceof Blob ? req.body.size : (req.body?.byteLength ?? 0);
+    const raw = req.body as Blob | Uint8Array<ArrayBuffer> | null;
+    const total = raw instanceof Blob ? raw.size : (raw?.byteLength ?? 0);
     req.onProgress?.(total, total);
     const res = await router.handle(
       new Request(req.url, {
-        body: req.body,
+        body: raw,
         headers: req.headers,
         method: req.method,
       })
@@ -376,7 +376,7 @@ describe("createFilesClient — plugin verbs", () => {
     const transport: Transport = async (req: SendRequest) => {
       const res = await router.handle(
         new Request(req.url, {
-          body: req.body,
+          body: req.body as Blob | Uint8Array<ArrayBuffer> | null,
           headers: req.headers,
           method: req.method,
         })

--- a/packages/files-sdk/test/files-client.test.ts
+++ b/packages/files-sdk/test/files-client.test.ts
@@ -45,7 +45,9 @@ const clientFor = (adapter: Adapter, opts: { headers?: HeadersInit } = {}) => {
   const fetchImpl = ((input: RequestInfo | URL, init?: RequestInit) =>
     router.handle(new Request(input, init))) as typeof fetch;
   const transport: Transport = async (req: SendRequest) => {
-    req.onProgress?.(req.body?.size ?? 0, req.body?.size ?? 0);
+    const total =
+      req.body instanceof Blob ? req.body.size : (req.body?.byteLength ?? 0);
+    req.onProgress?.(total, total);
     const res = await router.handle(
       new Request(req.url, {
         body: req.body,

--- a/packages/files-sdk/test/use-files-svelte-component.test.ts
+++ b/packages/files-sdk/test/use-files-svelte-component.test.ts
@@ -63,7 +63,9 @@ const config = (adapter: Adapter) => {
   const fetchImpl = ((input: RequestInfo | URL, init?: RequestInit) =>
     router.handle(new Request(input, init))) as typeof fetch;
   const transport: Transport = async (req) => {
-    req.onProgress?.(req.body?.size ?? 0, req.body?.size ?? 0);
+    const total =
+      req.body instanceof Blob ? req.body.size : (req.body?.byteLength ?? 0);
+    req.onProgress?.(total, total);
     const res = await router.handle(
       new Request(req.url, {
         body: req.body,

--- a/packages/files-sdk/test/use-files-svelte-component.test.ts
+++ b/packages/files-sdk/test/use-files-svelte-component.test.ts
@@ -63,12 +63,12 @@ const config = (adapter: Adapter) => {
   const fetchImpl = ((input: RequestInfo | URL, init?: RequestInit) =>
     router.handle(new Request(input, init))) as typeof fetch;
   const transport: Transport = async (req) => {
-    const total =
-      req.body instanceof Blob ? req.body.size : (req.body?.byteLength ?? 0);
+    const raw = req.body as Blob | Uint8Array<ArrayBuffer> | null;
+    const total = raw instanceof Blob ? raw.size : (raw?.byteLength ?? 0);
     req.onProgress?.(total, total);
     const res = await router.handle(
       new Request(req.url, {
-        body: req.body,
+        body: raw,
         headers: req.headers,
         method: req.method,
       })

--- a/packages/files-sdk/test/use-files-svelte.test.ts
+++ b/packages/files-sdk/test/use-files-svelte.test.ts
@@ -32,12 +32,12 @@ const config = (adapter: Adapter) => {
   const fetchImpl = ((input: RequestInfo | URL, init?: RequestInit) =>
     router.handle(new Request(input, init))) as typeof fetch;
   const transport: Transport = async (req) => {
-    const total =
-      req.body instanceof Blob ? req.body.size : (req.body?.byteLength ?? 0);
+    const raw = req.body as Blob | Uint8Array<ArrayBuffer> | null;
+    const total = raw instanceof Blob ? raw.size : (raw?.byteLength ?? 0);
     req.onProgress?.(total, total);
     const res = await router.handle(
       new Request(req.url, {
-        body: req.body,
+        body: raw,
         headers: req.headers,
         method: req.method,
       })

--- a/packages/files-sdk/test/use-files-svelte.test.ts
+++ b/packages/files-sdk/test/use-files-svelte.test.ts
@@ -32,7 +32,9 @@ const config = (adapter: Adapter) => {
   const fetchImpl = ((input: RequestInfo | URL, init?: RequestInit) =>
     router.handle(new Request(input, init))) as typeof fetch;
   const transport: Transport = async (req) => {
-    req.onProgress?.(req.body?.size ?? 0, req.body?.size ?? 0);
+    const total =
+      req.body instanceof Blob ? req.body.size : (req.body?.byteLength ?? 0);
+    req.onProgress?.(total, total);
     const res = await router.handle(
       new Request(req.url, {
         body: req.body,

--- a/packages/files-sdk/test/use-files-vue.test.ts
+++ b/packages/files-sdk/test/use-files-vue.test.ts
@@ -34,7 +34,9 @@ const config = (adapter: Adapter) => {
   const fetchImpl = ((input: RequestInfo | URL, init?: RequestInit) =>
     router.handle(new Request(input, init))) as typeof fetch;
   const transport: Transport = async (req) => {
-    req.onProgress?.(req.body?.size ?? 0, req.body?.size ?? 0);
+    const total =
+      req.body instanceof Blob ? req.body.size : (req.body?.byteLength ?? 0);
+    req.onProgress?.(total, total);
     const res = await router.handle(
       new Request(req.url, {
         body: req.body,

--- a/packages/files-sdk/test/use-files-vue.test.ts
+++ b/packages/files-sdk/test/use-files-vue.test.ts
@@ -34,12 +34,12 @@ const config = (adapter: Adapter) => {
   const fetchImpl = ((input: RequestInfo | URL, init?: RequestInit) =>
     router.handle(new Request(input, init))) as typeof fetch;
   const transport: Transport = async (req) => {
-    const total =
-      req.body instanceof Blob ? req.body.size : (req.body?.byteLength ?? 0);
+    const raw = req.body as Blob | Uint8Array<ArrayBuffer> | null;
+    const total = raw instanceof Blob ? raw.size : (raw?.byteLength ?? 0);
     req.onProgress?.(total, total);
     const res = await router.handle(
       new Request(req.url, {
-        body: req.body,
+        body: raw,
         headers: req.headers,
         method: req.method,
       })

--- a/packages/files-sdk/test/use-files.test.ts
+++ b/packages/files-sdk/test/use-files.test.ts
@@ -57,7 +57,9 @@ const config = (adapter: Adapter) => {
   const fetchImpl = ((input: RequestInfo | URL, init?: RequestInit) =>
     router.handle(new Request(input, init))) as typeof fetch;
   const transport: Transport = async (req) => {
-    req.onProgress?.(req.body?.size ?? 0, req.body?.size ?? 0);
+    const total =
+      req.body instanceof Blob ? req.body.size : (req.body?.byteLength ?? 0);
+    req.onProgress?.(total, total);
     const res = await router.handle(
       new Request(req.url, {
         body: req.body,

--- a/packages/files-sdk/test/use-files.test.ts
+++ b/packages/files-sdk/test/use-files.test.ts
@@ -57,12 +57,12 @@ const config = (adapter: Adapter) => {
   const fetchImpl = ((input: RequestInfo | URL, init?: RequestInit) =>
     router.handle(new Request(input, init))) as typeof fetch;
   const transport: Transport = async (req) => {
-    const total =
-      req.body instanceof Blob ? req.body.size : (req.body?.byteLength ?? 0);
+    const raw = req.body as Blob | Uint8Array<ArrayBuffer> | null;
+    const total = raw instanceof Blob ? raw.size : (raw?.byteLength ?? 0);
     req.onProgress?.(total, total);
     const res = await router.handle(
       new Request(req.url, {
-        body: req.body,
+        body: raw,
         headers: req.headers,
         method: req.method,
       })
@@ -91,7 +91,7 @@ const pluginConfig = (files: Files) => {
   const transport: Transport = async (req) => {
     const res = await router.handle(
       new Request(req.url, {
-        body: req.body,
+        body: req.body as Blob | Uint8Array<ArrayBuffer> | null,
         headers: req.headers,
         method: req.method,
       })


### PR DESCRIPTION
Makes `files-sdk/client` (and therefore `files-sdk/react` / vue / svelte) work in React Native and Expo, per the investigation on #79.

- **`NativeFileRef` upload bodies**: `upload()` now accepts the `{ uri, name, type, size }` descriptor Expo pickers return, everywhere a body goes (keyless, explicit key, bulk items). On a presigned-**POST** target the descriptor rides React Native's `FormData` untouched — native streaming from disk, no buffering — which makes S3-family POST policies (`maxUploadSize` setups) work on RN. On every other path (presigned PUT, through-the-gateway) the client resolves the `uri` to a Blob automatically, using the ref's declared `type` when no explicit `contentType` is given.
- **`download()`**: React Native's fetch never exposes `Response.body` (and Hermes has no `ReadableStream`), so `decodeDownload` now falls back to a lazy `arrayBuffer()` buffer instead of returning an empty stream. Web keeps the streaming path.
- **Byte uploads**: React Native's `Blob` can't be constructed from `ArrayBuffer`/`ArrayBufferView` parts. `upload(key, bytes)` now normalizes the body and, when the Blob wrap throws, passes raw bytes straight through — both transports accept them as request bodies. `FileUploadState.file` widens to `Blob | Uint8Array | NativeFileRef` accordingly.
- **Docs**: new UI → Client → React Native page covering the absolute-endpoint requirement, descriptor uploads with real XHR progress, buffered downloads, and the remaining caveats (`stream()`/`text()` polyfills, web-only UI components).

Native UI components are left as a possible follow-up (separate issue if wanted).

Resolves #79
