### PR TITLE
Add first-class NestJS support

### DIFF
--- a/.changeset/nestjs-integration.md
+++ b/.changeset/nestjs-integration.md
@@ -1,0 +1,5 @@
+---
+"files-sdk": minor
+---
+
+Add first-class NestJS support (#95). New `files-sdk/nestjs` subpath exports a dynamic `FilesModule` (`forRoot()` / `forRootAsync()`) that configures the gateway, mounts it at a configurable `path` (default `/api/files`) through Nest's middleware layer, and shares the `Files` instance via DI — `@InjectFiles()` / `FILES` token, with the configured router under `FILES_API`. Works on both the Express adapter (create the app with `bodyParser: false`) and the Fastify adapter (no parser configuration needed — middleware runs before body parsing). `@nestjs/common` is a new optional peer dependency.

--- a/apps/web/docs/ui/index.mdx
+++ b/apps/web/docs/ui/index.mdx
@@ -126,7 +126,7 @@ Next: pick your binding — [React](/docs/ui/client/react), [Vue](/docs/ui/clien
 
 ## Server adapters
 
-The gateway mounts on any of these with a one-line adapter: [Next.js](/docs/ui/server/next), [Hono](/docs/ui/server/hono), [Express](/docs/ui/server/express), [Fastify](/docs/ui/server/fastify), [Koa](/docs/ui/server/koa), [Elysia](/docs/ui/server/elysia), [Nitro](/docs/ui/server/nitro), [SvelteKit](/docs/ui/server/sveltekit), [Astro](/docs/ui/server/astro), [TanStack Start](/docs/ui/server/tanstack-start), [Bun](/docs/ui/server/bun), and [Deno](/docs/ui/server/deno).
+The gateway mounts on any of these with a one-line adapter: [Next.js](/docs/ui/server/next), [Hono](/docs/ui/server/hono), [Express](/docs/ui/server/express), [Fastify](/docs/ui/server/fastify), [Koa](/docs/ui/server/koa), [NestJS](/docs/ui/server/nestjs), [Elysia](/docs/ui/server/elysia), [Nitro](/docs/ui/server/nitro), [SvelteKit](/docs/ui/server/sveltekit), [Astro](/docs/ui/server/astro), [TanStack Start](/docs/ui/server/tanstack-start), [Bun](/docs/ui/server/bun), and [Deno](/docs/ui/server/deno).
 
 ## Prebuilt components
 

--- a/apps/web/docs/ui/server/nestjs.mdx
+++ b/apps/web/docs/ui/server/nestjs.mdx
@@ -1,0 +1,96 @@
+---
+title: NestJS
+description: First-class NestJS integration - a dynamic FilesModule that mounts the gateway, plus InjectFiles() for sharing the Files instance through DI.
+---
+
+`files-sdk/nestjs` wraps the [gateway](/docs/ui/server/gateway) in an idiomatic NestJS module. `FilesModule.forRoot()` (or `forRootAsync()`) configures [`createFilesRouter`](/docs/ui/server/gateway), mounts it at a configurable path via Nest's middleware layer, and exposes the `Files` instance through dependency injection — inject it anywhere with `@InjectFiles()`. Both the Express and Fastify platform adapters are supported.
+
+```ts title="app.module.ts" lineNumbers
+import { Module } from "@nestjs/common";
+import { createFiles } from "files-sdk";
+import { FilesModule } from "files-sdk/nestjs";
+import { s3 } from "files-sdk/s3";
+
+@Module({
+  imports: [
+    FilesModule.forRoot({
+      files: createFiles({ adapter: s3({ bucket: "uploads" }) }),
+      path: "/api/files", // the default
+      allowedOrigins: ["https://app.example.com"],
+      operations: ["upload", "download", "list", "delete", "url"],
+      secret: process.env.FILES_API_SECRET,
+    }),
+  ],
+})
+export class AppModule {}
+```
+
+```ts title="main.ts" lineNumbers
+import { NestFactory } from "@nestjs/core";
+import { AppModule } from "./app.module";
+
+// Express adapter: disable the global body parser (see below).
+const app = await NestFactory.create(AppModule, { bodyParser: false });
+await app.listen(3000);
+```
+
+:::warning
+On the **Express adapter**, Nest registers `body-parser` globally _before_ any consumer middleware, and a parser consumes the raw request stream the gateway needs (for the JSON verbs and the proxy/explicit-key `PUT` upload). Create the app with `bodyParser: false` and re-register parsers scoped to your own routes (e.g. `app.use("/api", express.json())`).
+
+The **Fastify adapter** needs no flag: Nest middleware runs at `onRequest`, before Fastify's content-type parsers, so the stream reaches the gateway untouched.
+:::
+
+## Async configuration
+
+`forRootAsync()` follows the standard Nest pattern — `imports`, `inject`, and a `useFactory` that returns the same options:
+
+```ts title="app.module.ts" lineNumbers
+import { Module } from "@nestjs/common";
+import { ConfigModule, ConfigService } from "@nestjs/config";
+import { createFiles } from "files-sdk";
+import { FilesModule } from "files-sdk/nestjs";
+import { s3 } from "files-sdk/s3";
+
+@Module({
+  imports: [
+    ConfigModule.forRoot(),
+    FilesModule.forRootAsync({
+      inject: [ConfigService],
+      useFactory: (config: ConfigService) => ({
+        files: createFiles({
+          adapter: s3({ bucket: config.getOrThrow("S3_BUCKET") }),
+        }),
+        secret: config.getOrThrow("FILES_API_SECRET"),
+        allowedOrigins: [config.getOrThrow("APP_ORIGIN")],
+        operations: ["upload", "download", "list", "delete", "url"],
+      }),
+    }),
+  ],
+})
+export class AppModule {}
+```
+
+## Injecting the `Files` instance
+
+The module registers globally by default (`global: false` to opt out), so any provider can inject the shared instance without importing `FilesModule`:
+
+```ts title="uploads.service.ts" lineNumbers
+import { Injectable } from "@nestjs/common";
+import type { Files } from "files-sdk";
+import { InjectFiles } from "files-sdk/nestjs";
+
+@Injectable()
+export class UploadsService {
+  constructor(@InjectFiles() private readonly files: Files) {}
+
+  async uploadAvatar(userId: string, file: Blob) {
+    return await this.files.upload(`avatars/${userId}.png`, file, {
+      contentType: file.type,
+    });
+  }
+}
+```
+
+The configured gateway router is also available under the `FILES_API` token for manual wiring or tests.
+
+Options beyond `path` and `global` are the [gateway options](/docs/ui/server/gateway) (minus the per-request `files` factory form — mount [`files-sdk/express`](/docs/ui/server/express) manually for multi-tenant routing), and the endpoint speaks the same protocol as every other binding: point [`useFiles`](/docs/ui/client/react) or [`createFilesClient`](/docs/ui) at your mount path and lock it down with [`authorize`](/docs/ui/server/authorization).

--- a/bun.lock
+++ b/bun.lock
@@ -68,6 +68,10 @@
         "@googleapis/drive": "^20.2.0",
         "@happy-dom/global-registrator": "^20.10.6",
         "@microsoft/microsoft-graph-client": "^3.0.7",
+        "@nestjs/common": "^11.0.0",
+        "@nestjs/core": "^11.0.0",
+        "@nestjs/platform-express": "^11.0.0",
+        "@nestjs/platform-fastify": "^11.0.0",
         "@netlify/blobs": "^10.7.9",
         "@openai/agents": "^0.12.0",
         "@opentelemetry/api": "^1.9.1",
@@ -108,6 +112,8 @@
         "pocketbase": "^0.27.0",
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
+        "reflect-metadata": "^0.2.2",
+        "rxjs": "^7.8.1",
         "ssh2-sftp-client": "^12.1.1",
         "svelte": "^5.56.4",
         "typescript": "^7",
@@ -132,6 +138,7 @@
         "@google-cloud/storage": "^7.19.0",
         "@googleapis/drive": "^20.0.0",
         "@microsoft/microsoft-graph-client": "^3.0.7",
+        "@nestjs/common": "^10.0.0 || ^11.0.0",
         "@netlify/blobs": "^10.7.4",
         "@openai/agents": "^0.11.0",
         "@opentelemetry/api": "^1.9.0",
@@ -179,6 +186,7 @@
         "@google-cloud/storage",
         "@googleapis/drive",
         "@microsoft/microsoft-graph-client",
+        "@nestjs/common",
         "@netlify/blobs",
         "@openai/agents",
         "@opentelemetry/api",
@@ -438,6 +446,8 @@
 
     "@babel/types": ["@babel/types@7.29.7", "", { "dependencies": { "@babel/helper-string-parser": "^7.29.7", "@babel/helper-validator-identifier": "^7.29.7" } }, "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA=="],
 
+    "@borewit/text-codec": ["@borewit/text-codec@0.2.2", "", {}, "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ=="],
+
     "@braintree/sanitize-url": ["@braintree/sanitize-url@7.1.2", "", {}, "sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA=="],
 
     "@bruits/satteri-darwin-arm64": ["@bruits/satteri-darwin-arm64@0.9.5", "", { "os": "darwin", "cpu": "arm64" }, "sha512-iw4nZgx9v30lWo/MTngQqi1pI78KI0DnkSm+lVJGYdmPLgAyDNJigVhpG42/Iq55A6c1Ll8q66ljyyRiQUxwow=="],
@@ -600,9 +610,13 @@
 
     "@fastify/busboy": ["@fastify/busboy@3.2.0", "", {}, "sha512-m9FVDXU3GT2ITSe0UaMA5rU3QkfC/UXtCU8y0gSN/GugTqtVldOBWIB5V6V3sbmenVZUIpU6f+mPEO2+m5iTaA=="],
 
+    "@fastify/cors": ["@fastify/cors@11.2.0", "", { "dependencies": { "fastify-plugin": "^5.0.0", "toad-cache": "^3.7.0" } }, "sha512-LbLHBuSAdGdSFZYTLVA3+Ch2t+sA6nq3Ejc6XLAKiQ6ViS2qFnvicpj0htsx03FyYeLs04HfRNBsz/a8SvbcUw=="],
+
     "@fastify/error": ["@fastify/error@4.2.0", "", {}, "sha512-RSo3sVDXfHskiBZKBPRgnQTtIqpi/7zhJOEmAxCiBcM7d0uwdGdxLlsCaLzGs8v8NnxIRlfG0N51p5yFaOentQ=="],
 
     "@fastify/fast-json-stringify-compiler": ["@fastify/fast-json-stringify-compiler@5.0.3", "", { "dependencies": { "fast-json-stringify": "^6.0.0" } }, "sha512-uik7yYHkLr6fxd8hJSZ8c+xF4WafPK+XzneQDPU+D10r5X19GW8lJcom2YijX2+qtFF1ENJlHXKFM9ouXNJYgQ=="],
+
+    "@fastify/formbody": ["@fastify/formbody@8.0.2", "", { "dependencies": { "fast-querystring": "^1.1.2", "fastify-plugin": "^5.0.0" } }, "sha512-84v5J2KrkXzjgBpYnaNRPqwgMsmY7ZDjuj0YVuMR3NXCJRCgKEZy/taSP1wUYGn0onfxJpLyRGDLa+NMaDJtnA=="],
 
     "@fastify/forwarded": ["@fastify/forwarded@3.0.1", "", {}, "sha512-JqDochHFqXs3C3Ml3gOY58zM7OqO9ENqPo0UqAjAjH8L01fRZqwX9iLeX34//kiJubF7r2ZQHtBRU36vONbLlw=="],
 
@@ -742,6 +756,8 @@
 
     "@js-sdsl/ordered-map": ["@js-sdsl/ordered-map@4.4.2", "", {}, "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw=="],
 
+    "@lukeed/csprng": ["@lukeed/csprng@1.1.0", "", {}, "sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA=="],
+
     "@manypkg/find-root": ["@manypkg/find-root@1.1.0", "", { "dependencies": { "@babel/runtime": "^7.5.5", "@types/node": "^12.7.1", "find-up": "^4.1.0", "fs-extra": "^8.1.0" } }, "sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA=="],
 
     "@manypkg/get-packages": ["@manypkg/get-packages@1.1.3", "", { "dependencies": { "@babel/runtime": "^7.5.5", "@changesets/types": "^4.0.1", "@manypkg/find-root": "^1.1.0", "fs-extra": "^8.1.0", "globby": "^11.0.0", "read-yaml-file": "^1.1.0" } }, "sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A=="],
@@ -787,6 +803,14 @@
     "@msgpackr-extract/msgpackr-extract-win32-x64": ["@msgpackr-extract/msgpackr-extract-win32-x64@3.0.3", "", { "os": "win32", "cpu": "x64" }, "sha512-x0fWaQtYp4E6sktbsdAqnehxDgEc/VwM7uLsRCYWaiGu0ykYdZPiS8zCWdnjHwyiumousxfBm4SO31eXqwEZhQ=="],
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.6", "", { "dependencies": { "@tybys/wasm-util": "^0.10.3" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg=="],
+
+    "@nestjs/common": ["@nestjs/common@11.1.28", "", { "dependencies": { "file-type": "21.3.4", "iterare": "1.2.1", "load-esm": "1.0.3", "tslib": "2.8.1", "uid": "2.0.2" }, "peerDependencies": { "class-transformer": ">=0.4.1", "class-validator": ">=0.13.2", "reflect-metadata": "^0.1.12 || ^0.2.0", "rxjs": "^7.1.0" }, "optionalPeers": ["class-transformer", "class-validator"] }, "sha512-bRImsxibie+AM7xjdwcrm/gr5YeacI65kSBNzTufa1Ib5iwziaY/lqMtRh9THq6pbV4e1HP9aI2ZxGUumnmaoQ=="],
+
+    "@nestjs/core": ["@nestjs/core@11.1.28", "", { "dependencies": { "fast-safe-stringify": "2.1.1", "iterare": "1.2.1", "path-to-regexp": "8.4.2", "tslib": "2.8.1", "uid": "2.0.2" }, "peerDependencies": { "@nestjs/common": "^11.0.0", "@nestjs/microservices": "^11.0.0", "@nestjs/platform-express": "^11.0.0", "@nestjs/websockets": "^11.0.0", "reflect-metadata": "^0.1.12 || ^0.2.0", "rxjs": "^7.1.0" }, "optionalPeers": ["@nestjs/microservices", "@nestjs/platform-express", "@nestjs/websockets"] }, "sha512-06m63xIRj8+l8uOeh/8LnYupGubkyu4f+bPKIadaSui6vK9KpXgoz7HveT1yOVLcEt0M0oCOEW5EuEXZkEmBBQ=="],
+
+    "@nestjs/platform-express": ["@nestjs/platform-express@11.1.28", "", { "dependencies": { "cors": "2.8.6", "express": "5.2.1", "multer": "2.2.0", "path-to-regexp": "8.4.2", "tslib": "2.8.1" }, "peerDependencies": { "@nestjs/common": "^11.0.0", "@nestjs/core": "^11.0.0" } }, "sha512-hU+9Sz4m+onHrR5AmelI59QKmY/Re546bPnygnpqqeQdHDiJpBgjWbL4t6Jr73CBpS60cpyng7WzjgphNB9iwA=="],
+
+    "@nestjs/platform-fastify": ["@nestjs/platform-fastify@11.1.28", "", { "dependencies": { "@fastify/cors": "11.2.0", "@fastify/formbody": "8.0.2", "fast-querystring": "1.1.2", "fastify": "5.10.0", "fastify-plugin": "6.0.0", "find-my-way": "9.6.0", "light-my-request": "6.6.0", "path-to-regexp": "8.4.2", "reusify": "1.1.0", "tslib": "2.8.1" }, "peerDependencies": { "@fastify/static": "^8.0.0 || ^9.0.0", "@fastify/view": "^10.0.0 || ^11.0.0 || ^12.0.0", "@nestjs/common": "^11.0.0", "@nestjs/core": "^11.0.0" }, "optionalPeers": ["@fastify/static", "@fastify/view"] }, "sha512-utUfyxRzZsoFxz1GU3Z0OthHpijB605iqtxwFnk9yKowLrU1t1ZkxMUuad/csemImY6AsuaTpTjCecKbmfl+pQ=="],
 
     "@netlify/blobs": ["@netlify/blobs@10.7.9", "", { "dependencies": { "@netlify/dev-utils": "4.4.6", "@netlify/otel": "^6.0.3", "@netlify/runtime-utils": "2.3.0" } }, "sha512-NEM8aNAMZCCWBWymomMM/fn5wmPGyGE8pendgsSu5mL7UNz+aXqGcHS0MiHWU/osyg+geiZuS+Rx956SVrMM/w=="],
 
@@ -1438,6 +1462,10 @@
 
     "@testing-library/react": ["@testing-library/react@16.3.2", "", { "dependencies": { "@babel/runtime": "^7.12.5" }, "peerDependencies": { "@testing-library/dom": "^10.0.0", "@types/react": "^18.0.0 || ^19.0.0", "@types/react-dom": "^18.0.0 || ^19.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g=="],
 
+    "@tokenizer/inflate": ["@tokenizer/inflate@0.4.1", "", { "dependencies": { "debug": "^4.4.3", "token-types": "^6.1.1" } }, "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA=="],
+
+    "@tokenizer/token": ["@tokenizer/token@0.3.0", "", {}, "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="],
+
     "@tootallnate/once": ["@tootallnate/once@2.0.1", "", {}, "sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ=="],
 
     "@tootallnate/quickjs-emscripten": ["@tootallnate/quickjs-emscripten@0.23.0", "", {}, "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA=="],
@@ -1836,6 +1864,8 @@
 
     "anymatch": ["anymatch@3.1.3", "", { "dependencies": { "normalize-path": "^3.0.0", "picomatch": "^2.0.4" } }, "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw=="],
 
+    "append-field": ["append-field@1.0.0", "", {}, "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw=="],
+
     "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
 
     "aria-hidden": ["aria-hidden@1.2.6", "", { "dependencies": { "tslib": "^2.0.0" } }, "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA=="],
@@ -1927,6 +1957,8 @@
     "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "bundle-name": ["bundle-name@4.1.0", "", { "dependencies": { "run-applescript": "^7.0.0" } }, "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q=="],
+
+    "busboy": ["busboy@1.6.0", "", { "dependencies": { "streamsearch": "^1.1.0" } }, "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA=="],
 
     "byte-length": ["byte-length@1.0.2", "", {}, "sha512-ovBpjmsgd/teRmgcPh23d4gJvxDoXtAzEL9xTfMU8Yc2kqCDb7L9jAG0XHl1nzuGl+h3ebCIF1i62UFyA9V/2Q=="],
 
@@ -2336,6 +2368,8 @@
 
     "fast-querystring": ["fast-querystring@1.1.2", "", { "dependencies": { "fast-decode-uri-component": "^1.0.1" } }, "sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg=="],
 
+    "fast-safe-stringify": ["fast-safe-stringify@2.1.1", "", {}, "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="],
+
     "fast-string-truncated-width": ["fast-string-truncated-width@3.0.3", "", {}, "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g=="],
 
     "fast-string-width": ["fast-string-width@3.0.2", "", { "dependencies": { "fast-string-truncated-width": "^3.0.2" } }, "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg=="],
@@ -2350,6 +2384,8 @@
 
     "fastify": ["fastify@5.10.0", "", { "dependencies": { "@fastify/ajv-compiler": "^4.0.5", "@fastify/error": "^4.0.0", "@fastify/fast-json-stringify-compiler": "^5.0.0", "@fastify/proxy-addr": "^5.0.0", "abstract-logging": "^2.0.1", "avvio": "^9.0.0", "fast-json-stringify": "^7.0.0", "find-my-way": "^9.6.0", "light-my-request": "^6.0.0", "pino": "^9.14.0 || ^10.1.0", "process-warning": "^5.0.0", "rfdc": "^1.3.1", "secure-json-parse": "^4.0.0", "semver": "^7.6.0", "toad-cache": "^3.7.0" } }, "sha512-A9L0ziuWGQHgEEVgF3davQ9vbD93IuX+lo2IsxapQmu5b/Y/ynn9m9K5JHt9dvyJXOFc5iN0Zk5GHEOqnzhWjg=="],
 
+    "fastify-plugin": ["fastify-plugin@6.0.0", "", {}, "sha512-fZOty7z3O7vOliF6d8bHE3wiEh1KcNnKEQensSgTk9C1DvN6nRLS++XVd86v33Hw/8u9Un8A1zDrQ8ujcQDHEg=="],
+
     "fastq": ["fastq@1.20.1", "", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw=="],
 
     "faye-websocket": ["faye-websocket@0.11.4", "", { "dependencies": { "websocket-driver": ">=0.5.1" } }, "sha512-CzbClwlXAuiRQAlUyfqPgvPoNKTckTPGfwZV4ZdAhVcP2lh9KUxJg2b5GkE7XbjKQ3YJnQ9z6D9ntLAlB+tP8g=="],
@@ -2361,6 +2397,8 @@
     "fetchdts": ["fetchdts@0.1.7", "", {}, "sha512-YoZjBdafyLIop9lSxXVI33oLD5kN31q4Td+CasofLLYeLXRFeOsuOw0Uo+XNRi9PZlbfdlN2GmRtm4tCEQ9/KA=="],
 
     "file-entry-cache": ["file-entry-cache@8.0.0", "", { "dependencies": { "flat-cache": "^4.0.0" } }, "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ=="],
+
+    "file-type": ["file-type@21.3.4", "", { "dependencies": { "@tokenizer/inflate": "^0.4.1", "strtok3": "^10.3.4", "token-types": "^6.1.1", "uint8array-extras": "^1.4.0" } }, "sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g=="],
 
     "file-uri-to-path": ["file-uri-to-path@1.0.0", "", {}, "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="],
 
@@ -2610,6 +2648,8 @@
 
     "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
+    "iterare": ["iterare@1.2.1", "", {}, "sha512-RKYVTCjAnRthyJes037NX/IiqeidgN1xc3j1RjFfECFp28A1GVwK9nA+i0rJPaHqSZwygLzRnFlzUuHFoWWy+Q=="],
+
     "jackspeak": ["jackspeak@3.4.3", "", { "dependencies": { "@isaacs/cliui": "^8.0.2" }, "optionalDependencies": { "@pkgjs/parseargs": "^0.11.0" } }, "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw=="],
 
     "jake": ["jake@10.9.4", "", { "dependencies": { "async": "^3.2.6", "filelist": "^1.0.4", "picocolors": "^1.1.1" }, "bin": { "jake": "bin/cli.js" } }, "sha512-wpHYzhxiVQL+IV05BLE2Xn34zW1S223hvjtqk0+gsPrwd/8JNLXJgZZM/iPFsYc1xyphF+6M6EvdE5E9MBGkDA=="],
@@ -2721,6 +2761,8 @@
     "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.32.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q=="],
 
     "limiter": ["limiter@1.1.5", "", {}, "sha512-FWWMIEOxz3GwUI4Ts/IvgVy6LPvoMPgjMdQ185nN6psJyBJ4yOpzqm695/h5umdLJg2vW3GR5iG11MAkR2AzJA=="],
+
+    "load-esm": ["load-esm@1.0.3", "", {}, "sha512-v5xlu8eHD1+6r8EHTg6hfmO97LN8ugKtiXcy5e6oN72iD2r6u0RPfLl6fxM+7Wnh2ZRq15o0russMst44WauPA=="],
 
     "loader-runner": ["loader-runner@4.3.2", "", {}, "sha512-DFEqQ3ihfS9blba08cLfYf1NRAIEm+dDjic073DRDc3/JspI/8wYmtDsHwd3+4hwvdxSK7PGaElfTmm0awWJ4w=="],
 
@@ -2941,6 +2983,8 @@
     "msgpackr-extract": ["msgpackr-extract@3.0.3", "", { "dependencies": { "node-gyp-build-optional-packages": "5.2.2" }, "optionalDependencies": { "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.3", "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.3", "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.3", "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.3", "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.3", "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.3" }, "bin": { "download-msgpackr-prebuilds": "bin/download-prebuilds.js" } }, "sha512-P0efT1C9jIdVRefqjzOQ9Xml57zpOXnIuS+csaB4MdZbTdmGDLo8XhzBG1N7aO11gKDDkJvBLULeFTo46wwreA=="],
 
     "muggle-string": ["muggle-string@0.4.1", "", {}, "sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ=="],
+
+    "multer": ["multer@2.2.0", "", { "dependencies": { "append-field": "^1.0.0", "busboy": "^1.6.0", "concat-stream": "^2.0.0", "type-is": "^1.6.18" } }, "sha512-6rdyFg2kLrMh9Jee7/BMPuV9lEAd7lLW2YUpF9/YxR7njyoUwwQ0ZPh3TaIY50Sw6vlyD2HW3wGOkTS4P79xrQ=="],
 
     "multipasta": ["multipasta@0.2.7", "", {}, "sha512-KPA58d68KgGil15oDqXjkUBEBYc00XvbPj5/X+dyzeo/lWm9Nc25pQRlf1D+gv4OpK7NM0J1odrbu9JNNGvynA=="],
 
@@ -3214,6 +3258,8 @@
 
     "recma-stringify": ["recma-stringify@1.0.0", "", { "dependencies": { "@types/estree": "^1.0.0", "estree-util-to-js": "^2.0.0", "unified": "^11.0.0", "vfile": "^6.0.0" } }, "sha512-cjwII1MdIIVloKvC9ErQ+OgAtwHBmcZ0Bg4ciz78FtbT8In39aAYbaA7zvxQ61xVMSPE8WxhLwLbhif4Js2C+g=="],
 
+    "reflect-metadata": ["reflect-metadata@0.2.2", "", {}, "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q=="],
+
     "regex": ["regex@6.1.0", "", { "dependencies": { "regex-utilities": "^2.3.0" } }, "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg=="],
 
     "regex-recursion": ["regex-recursion@6.0.2", "", { "dependencies": { "regex-utilities": "^2.3.0" } }, "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg=="],
@@ -3291,6 +3337,8 @@
     "run-parallel": ["run-parallel@1.2.0", "", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
 
     "rw": ["rw@1.3.3", "", {}, "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ=="],
+
+    "rxjs": ["rxjs@7.8.2", "", { "dependencies": { "tslib": "^2.1.0" } }, "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA=="],
 
     "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
 
@@ -3402,6 +3450,8 @@
 
     "stream-shift": ["stream-shift@1.0.3", "", {}, "sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ=="],
 
+    "streamsearch": ["streamsearch@1.1.0", "", {}, "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg=="],
+
     "string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "string-width-cjs": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
@@ -3421,6 +3471,8 @@
     "strip-final-newline": ["strip-final-newline@2.0.0", "", {}, "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA=="],
 
     "strnum": ["strnum@2.3.0", "", {}, "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q=="],
+
+    "strtok3": ["strtok3@10.3.5", "", { "dependencies": { "@tokenizer/token": "^0.3.0" } }, "sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA=="],
 
     "stubborn-fs": ["stubborn-fs@2.0.0", "", { "dependencies": { "stubborn-utils": "^1.0.1" } }, "sha512-Y0AvSwDw8y+nlSNFXMm2g6L51rBGdAQT20J3YSOqxC53Lo3bjWRtr2BKcfYoAf352WYpsZSTURrA0tqhfgudPA=="],
 
@@ -3492,6 +3544,8 @@
 
     "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
 
+    "token-types": ["token-types@6.1.2", "", { "dependencies": { "@borewit/text-codec": "^0.2.1", "@tokenizer/token": "^0.3.0", "ieee754": "^1.2.1" } }, "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww=="],
+
     "totalist": ["totalist@3.0.1", "", {}, "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ=="],
 
     "tr46": ["tr46@0.0.3", "", {}, "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="],
@@ -3537,6 +3591,10 @@
     "typescript-auto-import-cache": ["typescript-auto-import-cache@0.3.6", "", { "dependencies": { "semver": "^7.3.8" } }, "sha512-RpuHXrknHdVdK7wv/8ug3Fr0WNsNi5l5aB8MYYuXhq2UH5lnEB1htJ1smhtD5VeCsGr2p8mUDtd83LCQDFVgjQ=="],
 
     "ufo": ["ufo@1.6.4", "", {}, "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA=="],
+
+    "uid": ["uid@2.0.2", "", { "dependencies": { "@lukeed/csprng": "^1.0.0" } }, "sha512-u3xV3X7uzvi5b1MncmZo3i2Aw222Zk1keqLA1YkHldREkAhAqi65wuPfe7lHx8H/Wzy+8CE7S7uS3jekIM5s8g=="],
+
+    "uint8array-extras": ["uint8array-extras@1.5.0", "", {}, "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A=="],
 
     "ultracite": ["ultracite@7.9.3", "", { "dependencies": { "@clack/prompts": "^1.5.1", "@typescript-eslint/utils": "^8.62.1", "commander": "^15.0.0", "cross-spawn": "^7.0.6", "deepmerge": "^4.3.1", "glob": "^13.0.6", "jsonc-parser": "^3.3.1", "nypm": "^0.6.6", "yaml": "^2.9.0", "zod": "^4.4.3" }, "peerDependencies": { "oxfmt": ">=0.1.0", "oxlint": "^1.0.0" }, "optionalPeers": ["oxfmt", "oxlint"], "bin": { "ultracite": "dist/index.js" } }, "sha512-MqF0cn5DNHy/I61+hL4aYPRVye+rrmUqfv1dhwQ0ORfoFngk1O8tTKigF+zpsh/6qA84gkl26KkrtYzoypPiaw=="],
 
@@ -3794,7 +3852,11 @@
 
     "@eslint/config-array/minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
 
+    "@fastify/cors/fastify-plugin": ["fastify-plugin@5.1.0", "", {}, "sha512-FAIDA8eovSt5qcDgcBvDuX/v0Cjz0ohGhENZ/wpc3y+oZCY2afZ9Baqql3g/lC+OHRnciQol4ww7tuthOb9idw=="],
+
     "@fastify/fast-json-stringify-compiler/fast-json-stringify": ["fast-json-stringify@6.4.0", "", { "dependencies": { "@fastify/merge-json-schemas": "^0.2.0", "ajv": "^8.12.0", "ajv-formats": "^3.0.1", "fast-uri": "^3.0.0", "json-schema-ref-resolver": "^3.0.0", "rfdc": "^1.2.0" } }, "sha512-ibRCQ0GZKJIQ+P3Et1h0LhPgp3PMTYk0MH8O+kW3lNYsvmaQww5Nn3f1jf73Q0jR1Yz3a1CDP4/NZD3vOajWJQ=="],
+
+    "@fastify/formbody/fastify-plugin": ["fastify-plugin@5.1.0", "", {}, "sha512-FAIDA8eovSt5qcDgcBvDuX/v0Cjz0ohGhENZ/wpc3y+oZCY2afZ9Baqql3g/lC+OHRnciQol4ww7tuthOb9idw=="],
 
     "@google-cloud/storage/google-auth-library": ["google-auth-library@9.15.1", "", { "dependencies": { "base64-js": "^1.3.0", "ecdsa-sig-formatter": "^1.0.11", "gaxios": "^6.1.1", "gcp-metadata": "^6.1.0", "gtoken": "^7.0.0", "jws": "^4.0.0" } }, "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng=="],
 
@@ -4155,6 +4217,8 @@
     "micromark-util-events-to-acorn/@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
     "micromatch/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
+
+    "multer/type-is": ["type-is@1.6.18", "", { "dependencies": { "media-typer": "0.3.0", "mime-types": "~2.1.24" } }, "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g=="],
 
     "nise/@sinonjs/fake-timers": ["@sinonjs/fake-timers@15.4.0", "", { "dependencies": { "@sinonjs/commons": "^3.0.1" } }, "sha512-DsG+8/LscQIQg68J6Ef3dv10u6nVyetYn923s3/sus5eaGfTo1of5WMZSLf0UJc9KDuKPilPH0UDJCjvNbDNCA=="],
 
@@ -4592,6 +4656,10 @@
 
     "mermaid/katex/commander": ["commander@8.3.0", "", {}, "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="],
 
+    "multer/type-is/media-typer": ["media-typer@0.3.0", "", {}, "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ=="],
+
+    "multer/type-is/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
+
     "protobufjs/@types/node/undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
 
     "read-yaml-file/js-yaml/argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
@@ -4655,6 +4723,8 @@
     "glob/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
     "google-gax/retry-request/teeny-request/http-proxy-agent": ["http-proxy-agent@7.0.2", "", { "dependencies": { "agent-base": "^7.1.0", "debug": "^4.3.4" } }, "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig=="],
+
+    "multer/type-is/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
 
     "rimraf/glob/path-scurry/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 

--- a/packages/files-sdk/package.json
+++ b/packages/files-sdk/package.json
@@ -62,6 +62,10 @@
       "types": "./dist/koa/index.d.ts",
       "import": "./dist/koa/index.js"
     },
+    "./nestjs": {
+      "types": "./dist/nestjs/index.d.ts",
+      "import": "./dist/nestjs/index.js"
+    },
     "./nitro": {
       "types": "./dist/nitro/index.d.ts",
       "import": "./dist/nitro/index.js"
@@ -375,6 +379,10 @@
     "@googleapis/drive": "^20.2.0",
     "@happy-dom/global-registrator": "^20.10.6",
     "@microsoft/microsoft-graph-client": "^3.0.7",
+    "@nestjs/common": "^11.0.0",
+    "@nestjs/core": "^11.0.0",
+    "@nestjs/platform-express": "^11.0.0",
+    "@nestjs/platform-fastify": "^11.0.0",
     "@netlify/blobs": "^10.7.9",
     "@openai/agents": "^0.12.0",
     "@opentelemetry/api": "^1.9.1",
@@ -415,6 +423,8 @@
     "pocketbase": "^0.27.0",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
+    "reflect-metadata": "^0.2.2",
+    "rxjs": "^7.8.1",
     "ssh2-sftp-client": "^12.1.1",
     "svelte": "^5.56.4",
     "typescript": "^7",
@@ -436,6 +446,7 @@
     "@google-cloud/storage": "^7.19.0",
     "@googleapis/drive": "^20.0.0",
     "@microsoft/microsoft-graph-client": "^3.0.7",
+    "@nestjs/common": "^10.0.0 || ^11.0.0",
     "@netlify/blobs": "^10.7.4",
     "@openai/agents": "^0.11.0",
     "@opentelemetry/api": "^1.9.0",
@@ -505,6 +516,9 @@
       "optional": true
     },
     "@microsoft/microsoft-graph-client": {
+      "optional": true
+    },
+    "@nestjs/common": {
       "optional": true
     },
     "@netlify/blobs": {

--- a/packages/files-sdk/src/nestjs/index.ts
+++ b/packages/files-sdk/src/nestjs/index.ts
@@ -1,0 +1,169 @@
+// `files-sdk/nestjs` — first-class NestJS integration (issue #95). A dynamic
+// `FilesModule` configures the gateway (`createFilesRouter`), exposes the
+// `Files` instance through Nest's DI (`FILES` token / `InjectFiles()`), and
+// mounts the endpoint itself via `MiddlewareConsumer` at a configurable path.
+// Mounting as *middleware* (not a controller) matters: under the Fastify
+// adapter, middleware runs before Fastify's content-type parsers, so the raw
+// request stream reaches the gateway untouched with no parser configuration.
+//
+//   @Module({
+//     imports: [
+//       FilesModule.forRoot({
+//         files: createFiles({ adapter: s3({ bucket: "uploads" }) }),
+//         operations: ["upload", "download", "list", "delete", "url"],
+//         path: "/api/files",
+//       }),
+//     ],
+//   })
+//   export class AppModule {}
+//
+//   // main.ts — Express adapter only: Nest registers `body-parser` globally
+//   // BEFORE consumer middleware, and a parsed body never reaches the gateway.
+//   const app = await NestFactory.create(AppModule, { bodyParser: false });
+//
+// IMPORTANT (Express adapter): create the app with `bodyParser: false` and
+// re-register parsers scoped to your own routes, or the gateway's JSON verbs
+// and raw uploads read an already-consumed stream. The Fastify adapter needs
+// no such flag — middleware runs at `onRequest`, ahead of body parsing.
+
+import type { ServerResponse } from "node:http";
+
+import type {
+  DynamicModule,
+  FactoryProvider,
+  MiddlewareConsumer,
+  ModuleMetadata,
+  NestModule,
+  Provider,
+} from "@nestjs/common";
+import { Inject, Module, RequestMethod } from "@nestjs/common";
+
+import type { CreateFilesRouterOptions, FilesApi } from "../api/index.js";
+import { createFilesRouter } from "../api/index.js";
+import type { Files } from "../index.js";
+import { handleNodeRequest } from "../internal/node-http.js";
+import type { NodeLikeRequest } from "../internal/node-http.js";
+
+/** Injection token for the configured `Files` instance — see `InjectFiles()`. */
+export const FILES = Symbol("files-sdk/nestjs:FILES");
+
+/** Injection token for the mounted gateway router — for manual wiring or tests. */
+export const FILES_API = Symbol("files-sdk/nestjs:FILES_API");
+
+/** Internal token carrying the resolved options into providers + `configure`. */
+const FILES_MODULE_OPTIONS = Symbol("files-sdk/nestjs:FILES_MODULE_OPTIONS");
+
+const DEFAULT_PATH = "/api/files";
+
+export interface FilesModuleOptions extends Omit<
+  CreateFilesRouterOptions,
+  "files"
+> {
+  /**
+   * The `Files` instance shared through DI and served by the gateway. The
+   * per-request factory form of `CreateFilesRouterOptions.files` is not
+   * supported here (there is no single instance to provide) — mount
+   * `files-sdk/express` manually for multi-tenant routing.
+   */
+  files: Files;
+  /** Register as a global module so `InjectFiles()` works everywhere without importing `FilesModule`. Default true. */
+  global?: boolean;
+  /** Mount path for the gateway endpoint. Default `"/api/files"`. */
+  path?: string;
+}
+
+export interface FilesModuleAsyncOptions extends Pick<
+  ModuleMetadata,
+  "imports"
+> {
+  /** Same as `FilesModuleOptions.global`; lives here because a `DynamicModule` needs it before the factory runs. Default true. */
+  global?: boolean;
+  inject?: FactoryProvider["inject"];
+  useFactory: (
+    ...args: never[]
+  ) => FilesModuleOptions | Promise<FilesModuleOptions>;
+}
+
+/** Constructor-parameter decorator injecting the configured `Files` instance. */
+export const InjectFiles = (): ReturnType<typeof Inject> => Inject(FILES);
+
+const sharedProviders: Provider[] = [
+  {
+    inject: [FILES_MODULE_OPTIONS],
+    provide: FILES,
+    useFactory: (options: FilesModuleOptions): Files => options.files,
+  },
+  {
+    inject: [FILES_MODULE_OPTIONS],
+    provide: FILES_API,
+    useFactory: (options: FilesModuleOptions): FilesApi =>
+      createFilesRouter(options),
+  },
+];
+
+export class FilesModule implements NestModule {
+  static forRoot(options: FilesModuleOptions): DynamicModule {
+    return {
+      exports: [FILES, FILES_API],
+      global: options.global ?? true,
+      module: FilesModule,
+      providers: [
+        { provide: FILES_MODULE_OPTIONS, useValue: options },
+        ...sharedProviders,
+      ],
+    };
+  }
+
+  static forRootAsync(options: FilesModuleAsyncOptions): DynamicModule {
+    return {
+      exports: [FILES, FILES_API],
+      global: options.global ?? true,
+      imports: options.imports,
+      module: FilesModule,
+      providers: [
+        {
+          inject: options.inject ?? [],
+          provide: FILES_MODULE_OPTIONS,
+          useFactory: options.useFactory,
+        },
+        ...sharedProviders,
+      ],
+    };
+  }
+
+  private readonly options: FilesModuleOptions;
+
+  private readonly api: FilesApi;
+
+  constructor(options: FilesModuleOptions, api: FilesApi) {
+    this.options = options;
+    this.api = api;
+  }
+
+  configure(consumer: MiddlewareConsumer): void {
+    // `next` is deliberately never called — the gateway owns this route
+    // entirely. `handleNodeRequest` never rejects (transport failures answer
+    // 500 internally), so the floated promise cannot surface an unhandled
+    // rejection. Three params keep it a normal middleware for Express/middie
+    // (a 4-arity function would register as an error handler).
+    const middleware = (
+      req: NodeLikeRequest,
+      res: ServerResponse,
+      _next: () => void
+    ): void => {
+      void handleNodeRequest(this.api, req, res);
+    };
+    consumer.apply(middleware).forRoutes({
+      method: RequestMethod.ALL,
+      path: this.options.path ?? DEFAULT_PATH,
+    });
+  }
+}
+
+// The SDK builds without `experimentalDecorators`, so the Nest decorators are
+// applied imperatively — exactly what the decorator syntax compiles to. The
+// explicit `Inject` param metadata also removes the `emitDecoratorMetadata`
+// requirement consumers' compilers would otherwise need to satisfy.
+Module({})(FilesModule);
+Inject(FILES_MODULE_OPTIONS)(FilesModule, undefined, 0);
+Inject(FILES_API)(FilesModule, undefined, 1);

--- a/packages/files-sdk/test/files-nestjs.test.ts
+++ b/packages/files-sdk/test/files-nestjs.test.ts
@@ -1,0 +1,157 @@
+// oxlint-disable unicorn/no-await-expression-member -- asserting `.status` off awaited Responses is the natural shape here.
+// oxlint-disable max-classes-per-file, typescript/no-extraneous-class -- Nest modules are (often empty) marker classes; this file necessarily declares a few.
+import { afterEach, describe, expect, test } from "bun:test";
+import type { Server } from "node:http";
+import type { AddressInfo } from "node:net";
+
+import { Injectable, Module } from "@nestjs/common";
+import type { INestApplication, ModuleMetadata, Type } from "@nestjs/common";
+import { NestFactory } from "@nestjs/core";
+import { FastifyAdapter } from "@nestjs/platform-fastify";
+
+import type { FilesApi } from "../src/api/index.js";
+import { createFiles } from "../src/index.js";
+import type { Files } from "../src/index.js";
+import { memory } from "../src/memory/index.js";
+import {
+  FILES,
+  FILES_API,
+  FilesModule,
+  InjectFiles,
+} from "../src/nestjs/index.js";
+
+// Drive the module through real Nest apps on both platform adapters, so the
+// MiddlewareConsumer mount, the DI providers, and the raw-body path are all
+// exercised end-to-end. The SDK (and this test) compiles without
+// `experimentalDecorators`, so Nest decorators are applied imperatively —
+// exactly what the decorator syntax compiles to.
+
+/** A `@Module(metadata) class {}` without decorator syntax. */
+const moduleWith = (metadata: ModuleMetadata): Type => {
+  class DynamicTestModule {}
+  Module(metadata)(DynamicTestModule);
+  return DynamicTestModule;
+};
+
+/** A service holding an `@InjectFiles()` constructor parameter. */
+class UploadsService {
+  readonly files: Files;
+
+  constructor(files: Files) {
+    this.files = files;
+  }
+}
+Injectable()(UploadsService);
+InjectFiles()(UploadsService, undefined, 0);
+
+let app: INestApplication | undefined;
+
+const baseUrlOf = (instance: INestApplication): string => {
+  const addr = (instance.getHttpServer() as Server).address() as AddressInfo;
+  return `http://127.0.0.1:${addr.port}`;
+};
+
+const bootExpress = async (root: Type): Promise<string> => {
+  // `bodyParser: false` — Nest's global body-parser would consume the raw
+  // stream before the consumer middleware runs (see the binding's docs).
+  app = await NestFactory.create(root, { bodyParser: false, logger: false });
+  await app.listen(0, "127.0.0.1");
+  return baseUrlOf(app);
+};
+
+const bootFastify = async (root: Type): Promise<string> => {
+  // No content-type parser workaround here on purpose: middleware runs at
+  // `onRequest`, before Fastify's body parsing, so the stream stays intact.
+  app = await NestFactory.create(root, new FastifyAdapter(), { logger: false });
+  await app.listen(0, "127.0.0.1");
+  return baseUrlOf(app);
+};
+
+const capabilities = (url: string): Promise<Response> =>
+  fetch(url, {
+    body: JSON.stringify({ op: "capabilities" }),
+    headers: { "content-type": "application/json" },
+    method: "POST",
+  });
+
+afterEach(async () => {
+  await app?.close();
+  app = undefined;
+});
+
+describe("files-sdk/nestjs", () => {
+  test("forRoot mounts the gateway at the default path and exposes DI (Express adapter)", async () => {
+    const files = createFiles({ adapter: memory() });
+    // A sibling module with no imports: the default `global: true` must make
+    // `InjectFiles()` resolve without importing `FilesModule`.
+    const servicesModule = moduleWith({ providers: [UploadsService] });
+    const root = moduleWith({
+      imports: [
+        FilesModule.forRoot({
+          files,
+          operations: ["capabilities"],
+          secret: "test-secret",
+        }),
+        servicesModule,
+      ],
+    });
+    const base = await bootExpress(root);
+
+    const res = await capabilities(`${base}/api/files`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { capabilities: { delimiter: boolean } };
+    expect(typeof body.capabilities.delimiter).toBe("boolean");
+
+    expect(app?.get(UploadsService).files).toBe(files);
+    expect(app?.get<Files>(FILES)).toBe(files);
+    expect(typeof app?.get<FilesApi>(FILES_API).handle).toBe("function");
+  });
+
+  test("forRootAsync resolves options from injected providers and mounts at a custom path", async () => {
+    const files = createFiles({ adapter: memory() });
+    const CONFIG = Symbol("test-config");
+    const configModule = moduleWith({
+      exports: [CONFIG],
+      providers: [{ provide: CONFIG, useValue: { mount: "/files" } }],
+    });
+    const root = moduleWith({
+      imports: [
+        FilesModule.forRootAsync({
+          global: false,
+          imports: [configModule],
+          inject: [CONFIG],
+          useFactory: (config: { mount: string }) => ({
+            files,
+            operations: ["capabilities"],
+            path: config.mount,
+            secret: "test-secret",
+          }),
+        }),
+      ],
+    });
+    const base = await bootExpress(root);
+
+    expect((await capabilities(`${base}/files`)).status).toBe(200);
+    // Nothing answers at the default path once a custom one is configured.
+    expect((await capabilities(`${base}/api/files`)).status).toBe(404);
+    expect(app?.get<Files>(FILES)).toBe(files);
+  });
+
+  test("serves under the Fastify adapter with no body-parser configuration", async () => {
+    const root = moduleWith({
+      imports: [
+        FilesModule.forRoot({
+          files: createFiles({ adapter: memory() }),
+          operations: ["capabilities"],
+          secret: "test-secret",
+        }),
+      ],
+    });
+    const base = await bootFastify(root);
+
+    const res = await capabilities(`${base}/api/files`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { capabilities: { delimiter: boolean } };
+    expect(typeof body.capabilities.delimiter).toBe("boolean");
+  });
+});

--- a/packages/files-sdk/test/providers.test.ts
+++ b/packages/files-sdk/test/providers.test.ts
@@ -41,6 +41,7 @@ const NON_PROVIDER_EXPORTS = new Set([
   "./fastify",
   "./hono",
   "./koa",
+  "./nestjs",
   "./next",
   "./nitro",
   "./openai",


### PR DESCRIPTION
Closes #95.

New `files-sdk/nestjs` subpath: a dynamic `FilesModule` that wraps the existing gateway (`createFilesRouter`) in an idiomatic NestJS module.

## What's included

- `FilesModule.forRoot()` / `forRootAsync()` (standard `imports` / `inject` / `useFactory` pattern) taking the gateway options plus `path` (default `/api/files`) and `global` (default `true`)
- `@InjectFiles()` decorator and `FILES` provider token exposing the configured `Files` instance through DI; the configured router is also available under `FILES_API`
- Automatic route mounting via `MiddlewareConsumer` — works on both the Express and Fastify platform adapters
- Docs page (`/docs/ui/server/nestjs`) covering setup, async config, DI, and the raw-body requirements; NestJS added to the server-adapters list
- `@nestjs/common` as a new optional peer dependency (`^10 || ^11`)

## Design notes

- The SDK builds without `experimentalDecorators`, so the Nest decorators are applied imperatively (`Module({})(FilesModule)`, explicit `Inject` param metadata) — exactly what the decorator syntax compiles to. Side benefit: consumers don't need `emitDecoratorMetadata`.
- Mounting as middleware (not a controller) means the Fastify adapter needs zero parser configuration — middleware runs at `onRequest`, before Fastify's content-type parsers, so the raw stream reaches the gateway untouched.
- On the Express adapter, Nest registers `body-parser` before consumer middleware, so apps must create with `NestFactory.create(AppModule, { bodyParser: false })`. This is inherent to Nest's middleware ordering and is documented prominently in the docs page and the module's own docblock.
- `files` is instance-only (the per-request factory form of `CreateFilesRouterOptions.files` has no singleton to provide through DI) — multi-tenant setups can mount `files-sdk/express` manually, as documented.

## Tests

`test/files-nestjs.test.ts` boots real Nest apps end-to-end on both platform adapters: default-path mount + DI resolution (including `InjectFiles()` from a sibling module via the global default) on Express, `forRootAsync` with injected config + custom path, and the Fastify adapter with no body-parser workarounds. 100% line/func coverage on the new module; full suite 3070 pass / 0 fail.