### PR TITLE
Expose the provider-aware runtime loader

### DIFF
--- a/.changeset/calm-files-load.md
+++ b/.changeset/calm-files-load.md
@@ -1,0 +1,5 @@
+---
+"files-sdk": minor
+---
+
+Expose the lazy provider-aware `loadFiles` runtime loader through `files-sdk/loader`.

--- a/apps/web/docs/providers.mdx
+++ b/apps/web/docs/providers.mdx
@@ -87,3 +87,21 @@ An **`EnvVar`** is a single variable, tagged with any `aliases`, whether it is a
 - **`getProvider(slug)`** - look up one provider; returns `undefined` for unknown slugs.
 - **`listEnvVars(slug)`** - every env var a provider references, flattened across `required`, all credential modes, and `optional`, de-duplicated by key.
 - **`getSecretEnvVars(slug)`** - the subset of `listEnvVars` flagged as secrets.
+
+## Runtime provider selection
+
+Where `files-sdk/providers` describes providers, `files-sdk/loader` constructs one. Node.js tools that pick a provider at runtime - backup CLIs, migration scripts, configuration-driven services - can use the lazy `loadFiles` loader instead of maintaining their own adapter registry:
+
+```ts lineNumbers
+import { loadFiles } from "files-sdk/loader";
+
+const { files, provider } = await loadFiles({
+  bucket: "uploads",
+  retries: 3,
+  timeout: 10_000,
+});
+```
+
+The provider comes from the `provider` option or, when omitted, the `FILES_SDK_PROVIDER` environment variable (for example, `r2`). Credentials still come from each adapter's usual environment-variable conventions - the same ones this catalog documents - and only the selected adapter is imported, so optional peer SDKs for other providers never load.
+
+`loadFiles` accepts the flat option set the [CLI](/docs/cli) exposes as flags: provider config such as `bucket`, `region`, `endpoint`, or `root`, plus instance-level `prefix`, `timeout`, and `retries`. Anything beyond the typed shortcuts can be passed through `configJson`, which reaches the adapter as its extra constructor options.

--- a/packages/files-sdk/README.md
+++ b/packages/files-sdk/README.md
@@ -45,6 +45,25 @@ const exists = await files.exists("avatars/abc.png");
 
 Swap the adapter import (`files-sdk/r2`, `files-sdk/gcs`, `files-sdk/azure`, …) and the rest of your code stays the same.
 
+### Runtime provider selection
+
+Node.js tools that choose a provider at runtime can use the lazy loader instead
+of maintaining their own adapter registry:
+
+```ts
+import { loadFiles } from "files-sdk/loader";
+
+const { files, provider } = await loadFiles({
+  bucket: "uploads",
+  retries: 3,
+  timeout: 10_000,
+});
+```
+
+Set `FILES_SDK_PROVIDER` (for example, `r2`) or pass `provider` directly.
+Provider credentials continue to come from each adapter's environment-variable
+conventions, and only the selected adapter is imported.
+
 ## File handles
 
 Use `files.file(key)` when your application code works with the same object repeatedly:

--- a/packages/files-sdk/README.md
+++ b/packages/files-sdk/README.md
@@ -47,8 +47,7 @@ Swap the adapter import (`files-sdk/r2`, `files-sdk/gcs`, `files-sdk/azure`, …
 
 ### Runtime provider selection
 
-Node.js tools that choose a provider at runtime can use the lazy loader instead
-of maintaining their own adapter registry:
+Node.js tools that choose a provider at runtime can use the lazy loader instead of maintaining their own adapter registry:
 
 ```ts
 import { loadFiles } from "files-sdk/loader";
@@ -61,8 +60,7 @@ const { files, provider } = await loadFiles({
 ```
 
 Set `FILES_SDK_PROVIDER` (for example, `r2`) or pass `provider` directly.
-Provider credentials continue to come from each adapter's environment-variable
-conventions, and only the selected adapter is imported.
+Provider credentials continue to come from each adapter's environment-variable conventions, and only the selected adapter is imported.
 
 ## File handles
 

--- a/packages/files-sdk/README.md
+++ b/packages/files-sdk/README.md
@@ -59,8 +59,7 @@ const { files, provider } = await loadFiles({
 });
 ```
 
-Set `FILES_SDK_PROVIDER` (for example, `r2`) or pass `provider` directly.
-Provider credentials continue to come from each adapter's environment-variable conventions, and only the selected adapter is imported.
+Set `FILES_SDK_PROVIDER` (for example, `r2`) or pass `provider` directly. Provider credentials continue to come from each adapter's environment-variable conventions, and only the selected adapter is imported.
 
 ## File handles
 

--- a/packages/files-sdk/package.json
+++ b/packages/files-sdk/package.json
@@ -349,6 +349,10 @@
     "./providers": {
       "types": "./dist/providers/index.d.ts",
       "import": "./dist/providers/index.js"
+    },
+    "./loader": {
+      "types": "./dist/loader/index.d.ts",
+      "import": "./dist/loader/index.js"
     }
   },
   "scripts": {

--- a/packages/files-sdk/src/cli/loader.ts
+++ b/packages/files-sdk/src/cli/loader.ts
@@ -4,6 +4,15 @@ import { FilesError } from "../internal/errors.js";
 import { PROVIDER_NAMES, PROVIDERS } from "./registry.js";
 import type { ProviderOpts } from "./registry.js";
 
+/**
+ * Flat runtime configuration shared by every provider — one optional field per
+ * CLI shortcut flag, plus a `configJson` passthrough blob.
+ *
+ * NOTE: this type (and {@link LoadResult} / {@link loadFiles}) is re-exported
+ * as public API through the `files-sdk/loader` subpath. Renaming or removing a
+ * field here is a breaking change for package consumers, not just a CLI flag
+ * tweak.
+ */
 export interface GlobalCliOptions {
   provider?: string;
   /**
@@ -97,6 +106,10 @@ const toProviderOpts = (opts: GlobalCliOptions): ProviderOpts => ({
   urlBaseUrl: opts.urlBaseUrl,
 });
 
+/**
+ * The constructed client and resolved provider slug. Public API via
+ * `files-sdk/loader` (see the note on {@link GlobalCliOptions}).
+ */
 export interface LoadResult {
   files: Files;
   provider: string;

--- a/packages/files-sdk/src/loader/index.ts
+++ b/packages/files-sdk/src/loader/index.ts
@@ -1,0 +1,22 @@
+import { loadFiles as loadFilesInternal } from "../cli/loader.js";
+import type { GlobalCliOptions, LoadResult } from "../cli/loader.js";
+
+/**
+ * Runtime configuration accepted by {@link loadFiles}.
+ *
+ * Provider-specific credentials continue to come from each adapter's
+ * environment-variable conventions. Set `provider` explicitly or use
+ * `FILES_SDK_PROVIDER`.
+ */
+export type LoadFilesOptions = GlobalCliOptions;
+
+/** The configured client and selected provider returned by {@link loadFiles}. */
+export type LoadFilesResult = LoadResult;
+
+/**
+ * Construct a {@link import("../index.js").Files} client from a provider name
+ * and flat runtime configuration while preserving lazy provider imports.
+ */
+export const loadFiles = (
+  options: LoadFilesOptions
+): Promise<LoadFilesResult> => loadFilesInternal(options);

--- a/packages/files-sdk/test/build-output.test.ts
+++ b/packages/files-sdk/test/build-output.test.ts
@@ -18,6 +18,7 @@ const COLD_BUILD_TIMEOUT_MS = 120_000;
 const pkgRoot = path.resolve(import.meta.dirname, "..");
 const distDir = path.resolve(pkgRoot, "dist");
 const cliBundle = path.resolve(distDir, "cli/index.js");
+const loaderBundle = path.resolve(distDir, "loader/index.js");
 
 const optionalPeers = Object.entries(pkg.peerDependenciesMeta ?? {})
   .filter(([, meta]) => (meta as { optional?: boolean }).optional)
@@ -83,7 +84,7 @@ test(
 );
 
 const ensureBuilt = () => {
-  if (!existsSync(cliBundle)) {
+  if (!(existsSync(cliBundle) && existsSync(loaderBundle))) {
     const proc = Bun.spawnSync(["bun", "scripts/build.ts"], {
       cwd: pkgRoot,
       stderr: "pipe",
@@ -94,6 +95,24 @@ const ensureBuilt = () => {
     }
   }
 };
+
+test(
+  "public loader exports loadFiles without eager optional peer imports",
+  async () => {
+    ensureBuilt();
+    const mod = (await import(loaderBundle)) as Record<string, unknown>;
+    expect(typeof mod.loadFiles).toBe("function");
+
+    const externals = staticExternals(loaderBundle);
+    const offenders = optionalPeers.filter((peer) =>
+      [...externals].some(
+        (specifier) => specifier === peer || specifier.startsWith(`${peer}/`)
+      )
+    );
+    expect(offenders).toEqual([]);
+  },
+  COLD_BUILD_TIMEOUT_MS
+);
 
 test(
   "react bundle is a `use client` module importing only react",

--- a/packages/files-sdk/test/build-output.test.ts
+++ b/packages/files-sdk/test/build-output.test.ts
@@ -52,6 +52,16 @@ const staticExternals = (entry: string): Set<string> => {
   return externals;
 };
 
+/** Optional peers reachable from `bundle` via static imports — must be []. */
+const offendingOptionalPeers = (bundle: string): string[] => {
+  const externals = staticExternals(bundle);
+  return optionalPeers.filter((peer) =>
+    [...externals].some(
+      (specifier) => specifier === peer || specifier.startsWith(`${peer}/`)
+    )
+  );
+};
+
 test(
   "CLI bundle never statically imports an optional peer dependency (#67)",
   () => {
@@ -72,13 +82,7 @@ test(
     // Sanity: an empty list would make the assertion below pass vacuously.
     expect(optionalPeers.length).toBeGreaterThan(0);
 
-    const externals = staticExternals(cliBundle);
-    const offenders = optionalPeers.filter((peer) =>
-      [...externals].some(
-        (specifier) => specifier === peer || specifier.startsWith(`${peer}/`)
-      )
-    );
-    expect(offenders).toEqual([]);
+    expect(offendingOptionalPeers(cliBundle)).toEqual([]);
   },
   COLD_BUILD_TIMEOUT_MS
 );
@@ -103,13 +107,7 @@ test(
     const mod = (await import(loaderBundle)) as Record<string, unknown>;
     expect(typeof mod.loadFiles).toBe("function");
 
-    const externals = staticExternals(loaderBundle);
-    const offenders = optionalPeers.filter((peer) =>
-      [...externals].some(
-        (specifier) => specifier === peer || specifier.startsWith(`${peer}/`)
-      )
-    );
-    expect(offenders).toEqual([]);
+    expect(offendingOptionalPeers(loaderBundle)).toEqual([]);
   },
   COLD_BUILD_TIMEOUT_MS
 );

--- a/packages/files-sdk/test/loader.test.ts
+++ b/packages/files-sdk/test/loader.test.ts
@@ -1,0 +1,45 @@
+import { afterAll, describe, expect, test } from "bun:test";
+import * as fsp from "node:fs/promises";
+import * as os from "node:os";
+import path from "node:path";
+
+import { Files } from "../src/index.js";
+import { FilesError } from "../src/internal/errors.js";
+import { loadFiles } from "../src/loader/index.js";
+import type { LoadFilesOptions, LoadFilesResult } from "../src/loader/index.js";
+
+// Behavior is covered in depth by cli-loader.test.ts against the underlying
+// implementation; this suite pins the public `files-sdk/loader` surface — the
+// wrapper resolves at the source level and its type aliases stay assignable.
+
+const tmpDirs: string[] = [];
+const makeRoot = async (): Promise<string> => {
+  const dir = await fsp.mkdtemp(path.join(os.tmpdir(), "files-sdk-loader-"));
+  tmpDirs.push(dir);
+  return dir;
+};
+afterAll(async () => {
+  await Promise.all(
+    tmpDirs.map((d) => fsp.rm(d, { force: true, recursive: true }))
+  );
+});
+
+describe("loader loadFiles (public subpath)", () => {
+  test("constructs a working Files instance via the fs provider", async () => {
+    const root = await makeRoot();
+    const options: LoadFilesOptions = { provider: "fs", root };
+    const result: LoadFilesResult = await loadFiles(options);
+    expect(result.provider).toBe("fs");
+    expect(result.files).toBeInstanceOf(Files);
+
+    await result.files.upload("hello.txt", "hi", { contentType: "text/plain" });
+    const contents = await fsp.readFile(path.join(root, "hello.txt"), "utf-8");
+    expect(contents).toBe("hi");
+  });
+
+  test("rejects unknown providers with FilesError", async () => {
+    await expect(loadFiles({ provider: "nope" })).rejects.toBeInstanceOf(
+      FilesError
+    );
+  });
+});

--- a/packages/files-sdk/test/providers.test.ts
+++ b/packages/files-sdk/test/providers.test.ts
@@ -41,6 +41,7 @@ const NON_PROVIDER_EXPORTS = new Set([
   "./fastify",
   "./hono",
   "./koa",
+  "./loader",
   "./nestjs",
   "./next",
   "./nitro",


### PR DESCRIPTION
## What changed

- expose the existing lazy provider-aware loader as `files-sdk/loader`
- add public `LoadFilesOptions` and `LoadFilesResult` types
- document runtime provider selection through `FILES_SDK_PROVIDER`
- verify the new bundle exports `loadFiles` without eagerly importing optional provider SDKs
- add a minor changeset

## Why

The Files SDK CLI already has the runtime behavior embedders need: select a provider from an option or `FILES_SDK_PROVIDER`, pass flat provider configuration such as `bucket`, let the selected adapter read its normal credential environment variables, and lazily import only that adapter.

That loader currently lives under `src/cli/loader.ts` and is not available through the package exports. Tools therefore have to duplicate the provider registry or depend on an internal source path.

AgentPond is one concrete use case. Its OpenTelemetry exporter receives a statically configured `Files` instance in application code, while its CLI later needs to reconstruct the same client from a persistent AgentPond environment to list and download the exported spans:

```ts
import { loadFiles } from "files-sdk/loader";

const { files } = await loadFiles({
  bucket: "agentpond",
  retries: 3,
  timeout: 10_000,
});
```

With `FILES_SDK_PROVIDER=r2` and the existing `R2_*` credentials, AgentPond can use that client for `agentpond sync` without carrying a second provider registry. The same pattern applies to backup tools, migration CLIs, framework integrations, and configuration-driven services.

## Developer impact

This is additive. Existing CLI behavior and adapter entrypoints are unchanged. Runtime consumers get a supported import path while retaining the CLI loader's lazy-import behavior.

## Validation

- upstream Validate workflow:
  - formatting and lint checks
  - type checks
  - SDK builds on Bun and Node.js 20, 22, and 24
  - tests on Bun and Node.js 20, 22, and 24
  - web build
- `bun test packages/files-sdk/test/cli-loader.test.ts packages/files-sdk/test/providers.test.ts` — 67 passing locally
- filesystem-adapter runtime smoke test through the new public entrypoint
- production-style Bun build and static scan confirming no eager optional peer imports
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a public `files-sdk/loader` entry point exposing `loadFiles` for lazy, runtime provider selection.
  * Provider can be chosen via options or the `FILES_SDK_PROVIDER` environment variable.

* **Documentation**
  * Documented runtime provider selection, including a TypeScript example and how credential configuration follows the selected adapter.

* **Tests**
  * Extended build and runtime coverage for the loader entry point.
  * Added checks that unknown providers reject with a `FilesError` and that only the selected provider is used.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->