### PR TITLE
Refresh Vercel Blob runtime credentials

### DIFF
--- a/.changeset/refresh-vercel-credentials.md
+++ b/.changeset/refresh-vercel-credentials.md
@@ -1,0 +1,5 @@
+---
+"files-sdk": patch
+---
+
+Refresh environment-provided Vercel Blob credentials for every operation.

--- a/packages/files-sdk/src/vercel-blob/index.ts
+++ b/packages/files-sdk/src/vercel-blob/index.ts
@@ -257,10 +257,12 @@ export const vercelBlob = (
   config: VercelBlobAdapterOptions = {}
 ): VercelBlobAdapter => {
   const explicitToken = config.token;
+  const explicitOidcToken = config.oidcToken;
+  const explicitStoreId = config.storeId;
   const resolveAuth = (): BlobAuthOptions => {
     const envToken = readEnv("BLOB_READ_WRITE_TOKEN");
-    const oidcToken = config.oidcToken ?? readEnv("VERCEL_OIDC_TOKEN");
-    const resolvedStoreId = config.storeId ?? readEnv("BLOB_STORE_ID");
+    const oidcToken = explicitOidcToken ?? readEnv("VERCEL_OIDC_TOKEN");
+    const resolvedStoreId = explicitStoreId ?? readEnv("BLOB_STORE_ID");
 
     // Mirrors the upstream SDK's resolution order:
     //   1. explicit `token` (RW or client token) — wins over OIDC
@@ -272,7 +274,7 @@ export const vercelBlob = (
     if (oidcToken && resolvedStoreId) {
       return { oidcToken, storeId: resolvedStoreId };
     }
-    if (config.oidcToken) {
+    if (explicitOidcToken) {
       // An explicit `oidcToken` option (vs one picked up from the env) is an
       // unambiguous request for OIDC. With no resolvable `storeId`, don't fall
       // through to `BLOB_READ_WRITE_TOKEN` — that would silently swap the auth
@@ -294,7 +296,7 @@ export const vercelBlob = (
 
   // Preserve construction-time validation while resolving implicit
   // environment credentials again for every provider operation.
-  const initialAuth = resolveAuth();
+  resolveAuth();
 
   const access = config.access ?? "public";
   const addRandomSuffix = config.addRandomSuffix ?? false;
@@ -334,21 +336,21 @@ export const vercelBlob = (
     };
   };
 
-  // Prefer the explicit storeId (option or `BLOB_STORE_ID` env) since it
-  // works for OIDC and any future credential shape. Fall back to deriving
-  // from a read-write token (the only credential shape that embeds the
-  // storeId) so existing setups keep their no-round-trip URL fast path.
-  let storeId: string | undefined;
-  const initialStoreId = config.storeId ?? initialAuth.storeId;
-  if (initialStoreId) {
-    storeId = normalizeExplicitStoreId(initialStoreId);
-  }
-  if (!storeId) {
-    const rwToken = initialAuth.token;
-    if (rwToken) {
-      storeId = deriveStoreIdFromToken(rwToken);
+  // Prefer a storeId resolved from the current auth snapshot since it works
+  // for OIDC and any future credential shape. Fall back to deriving it from
+  // a read-write token (the only credential shape that embeds the storeId)
+  // so existing setups keep their no-round-trip URL fast path.
+  const resolveStoreId = (): string | undefined => {
+    const auth = resolveAuth();
+    const resolvedStoreId = explicitStoreId ?? auth.storeId;
+    if (resolvedStoreId) {
+      const normalizedStoreId = normalizeExplicitStoreId(resolvedStoreId);
+      if (normalizedStoreId) {
+        return normalizedStoreId;
+      }
     }
-  }
+    return auth.token ? deriveStoreIdFromToken(auth.token) : undefined;
+  };
 
   const headRaw = async (key: string, signal?: AbortSignal) => {
     try {
@@ -758,11 +760,14 @@ export const vercelBlob = (
       // Fast path: with a known storeId and predictable keys, derive the
       // URL without an API call. `addRandomSuffix: true` makes the actual
       // pathname unknowable in advance, so we have to head() in that case.
-      if (storeId && !addRandomSuffix) {
-        return joinPublicUrl(
-          `https://${storeId}.public.blob.vercel-storage.com`,
-          key
-        );
+      if (!addRandomSuffix) {
+        const storeId = resolveStoreId();
+        if (storeId) {
+          return joinPublicUrl(
+            `https://${storeId}.public.blob.vercel-storage.com`,
+            key
+          );
+        }
       }
       const result = await headRaw(key, urlOpts?.signal);
       if (!result.url) {

--- a/packages/files-sdk/src/vercel-blob/index.ts
+++ b/packages/files-sdk/src/vercel-blob/index.ts
@@ -28,6 +28,8 @@ import { createStoredFile } from "../internal/stored-file.js";
 export interface VercelBlobAdapterOptions {
   /**
    * Long-lived read-write token. Defaults to `process.env.BLOB_READ_WRITE_TOKEN`.
+   * Environment-provided credentials are resolved for each operation so
+   * changes made after adapter construction are honored.
    *
    * Takes priority over OIDC even when both are present (mirrors the
    * upstream `@vercel/blob` resolution order). For code running on
@@ -37,7 +39,8 @@ export interface VercelBlobAdapterOptions {
   /**
    * Vercel OIDC token. Defaults to `process.env.VERCEL_OIDC_TOKEN`, which
    * Vercel populates automatically on every deployment when a Blob store
-   * is connected to the project.
+   * is connected to the project. Environment-provided credentials are
+   * resolved for each operation so rotated OIDC tokens stay current.
    *
    * OIDC tokens are short-lived and auto-rotated, so they remove the risk
    * that a long-lived `BLOB_READ_WRITE_TOKEN` leaks from your codebase
@@ -243,8 +246,7 @@ const normalizeExplicitStoreId = (id: string): string | undefined => {
 };
 
 // Credentials passed to every `@vercel/blob` call. Mirrors `BlobCommandOptions`
-// (the upstream interface shared across put/get/head/del/copy/list) so a
-// single resolved object can be spread into every call site.
+// (the upstream interface shared across put/get/head/del/copy/list).
 interface BlobAuthOptions {
   token?: string;
   oidcToken?: string;
@@ -255,41 +257,44 @@ export const vercelBlob = (
   config: VercelBlobAdapterOptions = {}
 ): VercelBlobAdapter => {
   const explicitToken = config.token;
-  const envToken = readEnv("BLOB_READ_WRITE_TOKEN");
-  const oidcToken = config.oidcToken ?? readEnv("VERCEL_OIDC_TOKEN");
-  const explicitStoreId = config.storeId ?? readEnv("BLOB_STORE_ID");
+  const resolveAuth = (): BlobAuthOptions => {
+    const envToken = readEnv("BLOB_READ_WRITE_TOKEN");
+    const oidcToken = config.oidcToken ?? readEnv("VERCEL_OIDC_TOKEN");
+    const resolvedStoreId = config.storeId ?? readEnv("BLOB_STORE_ID");
 
-  // Mirrors the upstream SDK's resolution order:
-  //   1. explicit `token` (RW or client token) — wins over OIDC
-  //   2. OIDC pair (`oidcToken` + `storeId`, either option or env)
-  //   3. `BLOB_READ_WRITE_TOKEN` env
-  // Anything else is a construction-time error so OIDC misconfigurations
-  // (e.g. only one of the two env vars set) surface immediately rather
-  // than silently falling back to anonymous calls.
-  const auth: BlobAuthOptions = {};
-  if (explicitToken) {
-    auth.token = explicitToken;
-  } else if (oidcToken && explicitStoreId) {
-    auth.oidcToken = oidcToken;
-    auth.storeId = explicitStoreId;
-  } else if (config.oidcToken) {
-    // An explicit `oidcToken` option (vs one picked up from the env) is an
-    // unambiguous request for OIDC. With no resolvable `storeId`, don't fall
-    // through to `BLOB_READ_WRITE_TOKEN` — that would silently swap the auth
-    // scheme out from under the caller. Upstream `resolveBlobAuth` throws here
-    // too, ahead of its own read-write-token fallback.
-    throw new FilesError(
-      "Provider",
-      "vercelBlob adapter: `oidcToken` was passed but no `storeId` was found. Pass `storeId` or set BLOB_STORE_ID to use OIDC."
-    );
-  } else if (envToken) {
-    auth.token = envToken;
-  } else {
+    // Mirrors the upstream SDK's resolution order:
+    //   1. explicit `token` (RW or client token) — wins over OIDC
+    //   2. OIDC pair (`oidcToken` + `storeId`, either option or env)
+    //   3. `BLOB_READ_WRITE_TOKEN` env
+    if (explicitToken) {
+      return { token: explicitToken };
+    }
+    if (oidcToken && resolvedStoreId) {
+      return { oidcToken, storeId: resolvedStoreId };
+    }
+    if (config.oidcToken) {
+      // An explicit `oidcToken` option (vs one picked up from the env) is an
+      // unambiguous request for OIDC. With no resolvable `storeId`, don't fall
+      // through to `BLOB_READ_WRITE_TOKEN` — that would silently swap the auth
+      // scheme out from under the caller. Upstream `resolveBlobAuth` throws here
+      // too, ahead of its own read-write-token fallback.
+      throw new FilesError(
+        "Provider",
+        "vercelBlob adapter: `oidcToken` was passed but no `storeId` was found. Pass `storeId` or set BLOB_STORE_ID to use OIDC."
+      );
+    }
+    if (envToken) {
+      return { token: envToken };
+    }
     throw new FilesError(
       "Provider",
       "vercelBlob adapter: missing credentials. Pass `token`, or `oidcToken` + `storeId`, or set BLOB_READ_WRITE_TOKEN, or set both VERCEL_OIDC_TOKEN and BLOB_STORE_ID."
     );
-  }
+  };
+
+  // Preserve construction-time validation while resolving implicit
+  // environment credentials again for every provider operation.
+  const initialAuth = resolveAuth();
 
   const access = config.access ?? "public";
   const addRandomSuffix = config.addRandomSuffix ?? false;
@@ -313,7 +318,7 @@ export const vercelBlob = (
     const abortSignal = withTimeoutSignal(signal, downloadTimeoutMs);
     const got = await blob.get(key, {
       access: "private",
-      ...auth,
+      ...resolveAuth(),
       ...(abortSignal && { abortSignal }),
     });
     if (!got || got.statusCode !== 200) {
@@ -334,11 +339,12 @@ export const vercelBlob = (
   // from a read-write token (the only credential shape that embeds the
   // storeId) so existing setups keep their no-round-trip URL fast path.
   let storeId: string | undefined;
-  if (explicitStoreId) {
-    storeId = normalizeExplicitStoreId(explicitStoreId);
+  const initialStoreId = config.storeId ?? initialAuth.storeId;
+  if (initialStoreId) {
+    storeId = normalizeExplicitStoreId(initialStoreId);
   }
   if (!storeId) {
-    const rwToken = explicitToken ?? envToken;
+    const rwToken = initialAuth.token;
     if (rwToken) {
       storeId = deriveStoreIdFromToken(rwToken);
     }
@@ -348,7 +354,7 @@ export const vercelBlob = (
     try {
       return await blob.head(key, {
         ...(signal && { abortSignal: signal }),
-        ...auth,
+        ...resolveAuth(),
       });
     } catch (error) {
       throw mapBlobError(error);
@@ -365,7 +371,7 @@ export const vercelBlob = (
           ...(operationOpts?.signal && {
             abortSignal: operationOpts.signal,
           }),
-          ...auth,
+          ...resolveAuth(),
         });
       } catch (error) {
         throw mapBlobError(error);
@@ -377,7 +383,7 @@ export const vercelBlob = (
           ...(operationOpts?.signal && {
             abortSignal: operationOpts.signal,
           }),
-          ...auth,
+          ...resolveAuth(),
         });
       } catch (error) {
         throw mapBlobError(error);
@@ -487,7 +493,7 @@ export const vercelBlob = (
         }
         const result = await blob.list({
           ...(options?.signal && { abortSignal: options.signal }),
-          ...auth,
+          ...resolveAuth(),
           ...(options?.prefix && { prefix: options.prefix }),
           ...(options?.limit !== undefined && { limit: options.limit }),
           ...(options?.cursor && { cursor: options.cursor }),
@@ -574,7 +580,7 @@ export const vercelBlob = (
             const created = await blob.createMultipartUpload(key, {
               access,
               addRandomSuffix,
-              ...auth,
+              ...resolveAuth(),
               contentType: meta.contentType,
             });
             session = {
@@ -604,7 +610,7 @@ export const vercelBlob = (
                 access,
                 key: active.storageKey,
                 uploadId: active.uploadId,
-                ...auth,
+                ...resolveAuth(),
               }
             );
             return {
@@ -642,7 +648,7 @@ export const vercelBlob = (
                 key: active.storageKey,
                 partNumber,
                 uploadId: active.uploadId,
-                ...auth,
+                ...resolveAuth(),
                 ...(signal && { abortSignal: signal }),
               }
             );
@@ -686,7 +692,7 @@ export const vercelBlob = (
           addRandomSuffix,
           allowOverwrite,
           ...(options?.signal && { abortSignal: options.signal }),
-          ...auth,
+          ...resolveAuth(),
           ...(options?.contentType && { contentType: options.contentType }),
           ...(options?.cacheControl && {
             cacheControlMaxAge: parseCacheControlMaxAge(options.cacheControl),
@@ -706,7 +712,7 @@ export const vercelBlob = (
         if (size === undefined) {
           const { size: headSize, uploadedAt } = await blob.head(result.url, {
             ...(options?.signal && { abortSignal: options.signal }),
-            ...auth,
+            ...resolveAuth(),
           });
           size = headSize;
           lastModified = uploadedAt?.getTime() ?? lastModified;

--- a/packages/files-sdk/src/vercel-blob/index.ts
+++ b/packages/files-sdk/src/vercel-blob/index.ts
@@ -336,13 +336,15 @@ export const vercelBlob = (
     };
   };
 
-  // Prefer a storeId resolved from the current auth snapshot since it works
-  // for OIDC and any future credential shape. Fall back to deriving it from
-  // a read-write token (the only credential shape that embeds the storeId)
-  // so existing setups keep their no-round-trip URL fast path.
+  // Prefer the explicit storeId (option or `BLOB_STORE_ID` env, whatever the
+  // active auth scheme) since it works for OIDC and any future credential
+  // shape. Fall back to deriving it from a read-write token (the only
+  // credential shape that embeds the storeId) so existing setups keep their
+  // no-round-trip URL fast path.
   const resolveStoreId = (): string | undefined => {
     const auth = resolveAuth();
-    const resolvedStoreId = explicitStoreId ?? auth.storeId;
+    const resolvedStoreId =
+      explicitStoreId ?? auth.storeId ?? readEnv("BLOB_STORE_ID");
     if (resolvedStoreId) {
       const normalizedStoreId = normalizeExplicitStoreId(resolvedStoreId);
       if (normalizedStoreId) {

--- a/packages/files-sdk/test/vercel-blob.test.ts
+++ b/packages/files-sdk/test/vercel-blob.test.ts
@@ -437,6 +437,20 @@ describe("vercel-blob adapter", () => {
     process.env.BLOB_READ_WRITE_TOKEN = "test-token";
   });
 
+  test("url re-resolves a rotated environment read-write token", async () => {
+    process.env.BLOB_READ_WRITE_TOKEN = "vercel_blob_rw_initialstore_random";
+    const files = new Files({ adapter: vercelBlob() });
+
+    process.env.BLOB_READ_WRITE_TOKEN = "vercel_blob_rw_rotatedstore_random";
+    headMock.mockClear();
+    const url = await files.url("a.txt");
+
+    expect(url).toBe(
+      "https://rotatedstore.public.blob.vercel-storage.com/a.txt"
+    );
+    expect(headMock).not.toHaveBeenCalled();
+  });
+
   test("url encodes special characters in the key on the storeId fast path", async () => {
     process.env.BLOB_READ_WRITE_TOKEN = "vercel_blob_rw_abc123store_random";
     const files = new Files({ adapter: vercelBlob() });
@@ -1137,6 +1151,44 @@ describe("vercel-blob adapter", () => {
       const url = await files.url("a.txt");
       expect(url).toBe(
         "https://abc123store.public.blob.vercel-storage.com/a.txt"
+      );
+      expect(headMock).not.toHaveBeenCalled();
+    });
+
+    test("url re-resolves a rotated BLOB_STORE_ID", async () => {
+      delete process.env.BLOB_READ_WRITE_TOKEN;
+      process.env.VERCEL_OIDC_TOKEN = "oidc-token";
+      process.env.BLOB_STORE_ID = "initialstore";
+      const files = new Files({ adapter: vercelBlob() });
+
+      process.env.BLOB_STORE_ID = "rotatedstore";
+      headMock.mockClear();
+      const url = await files.url("a.txt");
+
+      expect(url).toBe(
+        "https://rotatedstore.public.blob.vercel-storage.com/a.txt"
+      );
+      expect(headMock).not.toHaveBeenCalled();
+    });
+
+    test("url keeps an explicitly configured storeId fixed", async () => {
+      delete process.env.BLOB_READ_WRITE_TOKEN;
+      process.env.VERCEL_OIDC_TOKEN = "environment-oidc";
+      process.env.BLOB_STORE_ID = "environmentstore";
+      const files = new Files({
+        adapter: vercelBlob({
+          oidcToken: "explicit-oidc",
+          storeId: "explicitstore",
+        }),
+      });
+
+      process.env.VERCEL_OIDC_TOKEN = "rotated-environment-oidc";
+      process.env.BLOB_STORE_ID = "rotatedstore";
+      headMock.mockClear();
+      const url = await files.url("a.txt");
+
+      expect(url).toBe(
+        "https://explicitstore.public.blob.vercel-storage.com/a.txt"
       );
       expect(headMock).not.toHaveBeenCalled();
     });

--- a/packages/files-sdk/test/vercel-blob.test.ts
+++ b/packages/files-sdk/test/vercel-blob.test.ts
@@ -1001,6 +1001,25 @@ describe("vercel-blob adapter", () => {
       expect(opts.storeId).toBe("abc123store");
     });
 
+    test("re-resolves rotating OIDC credentials for each operation", async () => {
+      delete process.env.BLOB_READ_WRITE_TOKEN;
+      process.env.VERCEL_OIDC_TOKEN = "oidc-before-rotation";
+      process.env.BLOB_STORE_ID = "abc123store";
+      const files = new Files({ adapter: vercelBlob() });
+
+      process.env.VERCEL_OIDC_TOKEN = "oidc-after-rotation";
+      await files.upload("a.txt", "hello");
+
+      const [firstCall] = putMock.mock.calls;
+      if (!firstCall) {
+        throw new Error("expected put to have been called");
+      }
+      const opts = firstCall[2] as AuthOpts;
+      expect(opts.token).toBeUndefined();
+      expect(opts.oidcToken).toBe("oidc-after-rotation");
+      expect(opts.storeId).toBe("abc123store");
+    });
+
     test("explicit oidcToken without storeId throws — no silent RW-token fallback", () => {
       // A caller who explicitly passes `oidcToken` is asking for OIDC. With
       // no resolvable storeId, the adapter must not quietly fall back to the

--- a/packages/files-sdk/test/vercel-blob.test.ts
+++ b/packages/files-sdk/test/vercel-blob.test.ts
@@ -1155,6 +1155,21 @@ describe("vercel-blob adapter", () => {
       expect(headMock).not.toHaveBeenCalled();
     });
 
+    test("url fast path prefers BLOB_STORE_ID over the RW token's embedded storeId", async () => {
+      // `BLOB_STORE_ID` is the explicit override for any auth scheme — it
+      // must win over (and not require) a derivable RW token, matching the
+      // pre-existing precedence.
+      process.env.BLOB_READ_WRITE_TOKEN = "vercel_blob_rw_tokenstore1_random";
+      process.env.BLOB_STORE_ID = "envstore123";
+      const files = new Files({ adapter: vercelBlob() });
+      headMock.mockClear();
+      const url = await files.url("a.txt");
+      expect(url).toBe(
+        "https://envstore123.public.blob.vercel-storage.com/a.txt"
+      );
+      expect(headMock).not.toHaveBeenCalled();
+    });
+
     test("url re-resolves a rotated BLOB_STORE_ID", async () => {
       delete process.env.BLOB_READ_WRITE_TOKEN;
       process.env.VERCEL_OIDC_TOKEN = "oidc-token";


### PR DESCRIPTION
## What changed

- resolve environment-provided Vercel Blob credentials for every provider operation
- retain construction-time validation and the existing credential precedence
- keep explicitly supplied tokens and OIDC credentials fixed

## Why

The adapter previously captured `VERCEL_OIDC_TOKEN` when it was constructed and reused that value for its lifetime. Vercel OIDC credentials are short-lived and rotate, so a long-lived `Files` instance could continue forwarding an expired token after the environment value changed.

## Impact

This is a patch-level runtime fix with no new option or public API. Explicit credentials behave as before. Implicit `BLOB_READ_WRITE_TOKEN`, `VERCEL_OIDC_TOKEN`, and `BLOB_STORE_ID` values are refreshed at operation time.

## Validation

- `bun test packages/files-sdk/test/vercel-blob.test.ts`
- `bun run types --filter files-sdk`
- `bun run check`
- `bun run build --filter files-sdk`
- pre-commit full typecheck and test coverage: 3,151 passed, 14 skipped, 0 failed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Vercel Blob adapter to re-resolve environment-provided credentials and store ID for every operation, so rotated tokens take effect immediately without recreating the adapter.
  * Improved public URL generation to use the latest resolved store ID, including OIDC and `BLOB_STORE_ID` fallback behavior, while keeping explicitly configured `storeId` stable.
* **Tests**
  * Added regression coverage verifying URL and blob operations use rotated tokens/store ID after adapter creation, including OIDC updates and explicit `storeId` precedence.
* **Chores**
  * Added a patch changeset for the `files-sdk` package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->