### PR TITLE
Infer content type from the key when listing S3-compatible buckets

### DIFF
--- a/.changeset/s3-list-infers-content-type.md
+++ b/.changeset/s3-list-infers-content-type.md
@@ -1,0 +1,5 @@
+---
+"files-sdk": patch
+---
+
+Infer the content type from the key when listing S3-compatible buckets, instead of reporting every object as `application/octet-stream`.

--- a/packages/files-sdk/src/internal/s3-fetch.ts
+++ b/packages/files-sdk/src/internal/s3-fetch.ts
@@ -37,6 +37,7 @@ import {
   resolveUrlStrategy,
 } from "./core.js";
 import { FilesError } from "./errors.js";
+import { inferTypeFromName } from "./mime.js";
 import type { StoredFileMeta } from "./stored-file.js";
 import { createStoredFile } from "./stored-file.js";
 
@@ -470,7 +471,10 @@ export const s3FetchAdapter = (opts: S3FetchAdapterOptions): S3FetchAdapter => {
         }
         items.push(
           createStoredFile(
-            { ...entry, type: DEFAULT_CONTENT_TYPE },
+            // A list response carries no `Content-Type`, so approximate it from
+            // the key rather than labelling every object as a binary blob.
+            // Unknown extensions still fall back to `DEFAULT_CONTENT_TYPE`.
+            { ...entry, type: inferTypeFromName(entry.key) },
             { factory: () => fetchBytes(entry.key), kind: "lazy" }
           )
         );

--- a/packages/files-sdk/src/s3/core.ts
+++ b/packages/files-sdk/src/s3/core.ts
@@ -30,6 +30,7 @@ import {
 import { readEnv } from "../internal/env.js";
 import { FilesError } from "../internal/errors.js";
 import type { ProviderFilesErrorCode } from "../internal/errors.js";
+import { inferTypeFromName } from "../internal/mime.js";
 import { createStoredFile } from "../internal/stored-file.js";
 
 /**
@@ -757,7 +758,11 @@ export const createS3Adapter = (
               key: objKey,
               lastModified: obj.LastModified?.getTime(),
               size: Number(obj.Size ?? 0),
-              type: DEFAULT_CONTENT_TYPE,
+              // `ListObjectsV2` carries no `Content-Type`, so approximate it
+              // from the key rather than labelling every object as a binary
+              // blob. Unknown extensions still fall back to
+              // `DEFAULT_CONTENT_TYPE`.
+              type: inferTypeFromName(objKey),
             },
             {
               factory: async () => {

--- a/packages/files-sdk/test/s3-fetch.test.ts
+++ b/packages/files-sdk/test/s3-fetch.test.ts
@@ -271,6 +271,21 @@ describe("s3-fetch core — list", () => {
     expect(result.prefixes).toBeUndefined();
   });
 
+  test("list infers the content type from the key", async () => {
+    const { adapter } = withFake();
+    await adapter.upload("docs/report.csv", "a,b");
+    await adapter.upload("docs/photo.png", "x");
+    await adapter.upload("docs/blob", "y");
+    const result = await adapter.list({ prefix: "docs/" });
+    const types = Object.fromEntries(
+      result.items.map((item) => [item.key, item.type])
+    );
+    expect(types["docs/report.csv"]).toBe("text/csv; charset=utf-8");
+    expect(types["docs/photo.png"]).toBe("image/png");
+    // No extension to go on, so the generic fallback still applies
+    expect(types["docs/blob"]).toBe("application/octet-stream");
+  });
+
   test("list items expose a lazy body", async () => {
     const { adapter } = withFake();
     await adapter.upload("lazy.txt", "lazy body");

--- a/packages/files-sdk/test/s3.test.ts
+++ b/packages/files-sdk/test/s3.test.ts
@@ -422,6 +422,27 @@ describe("s3 adapter", () => {
     expect(input.MaxKeys).toBe(10);
   });
 
+  test("list infers the content type from the key", async () => {
+    s3Mock.on(ListObjectsV2Command).resolves({
+      Contents: [
+        { ETag: '"1"', Key: "a/report.csv", LastModified: new Date(), Size: 1 },
+        { ETag: '"2"', Key: "a/photo.png", LastModified: new Date(), Size: 2 },
+        { ETag: '"3"', Key: "a/blob", LastModified: new Date(), Size: 3 },
+      ],
+      IsTruncated: false,
+    });
+    const files = new Files({
+      adapter: s3({ bucket: "test-bucket", region: "us-east-1" }),
+    });
+    const out = await files.list({ prefix: "a/" });
+    expect(out.items.map((i) => i.type)).toEqual([
+      "text/csv; charset=utf-8",
+      "image/png",
+      // No extension to go on, so the generic fallback still applies
+      "application/octet-stream",
+    ]);
+  });
+
   test("list passes Delimiter and maps CommonPrefixes to prefixes", async () => {
     s3Mock.on(ListObjectsV2Command).resolves({
       CommonPrefixes: [{ Prefix: "a/b/" }, { Prefix: "a/c/" }, {}],


### PR DESCRIPTION
Closes #116

### What was happening

An S3 list response carries no `Content-Type` per object, so both list implementations hardcoded the generic fallback:

```ts
// src/internal/s3-fetch.ts
{ ...entry, type: DEFAULT_CONTENT_TYPE }

// src/s3/core.ts
type: DEFAULT_CONTENT_TYPE,
```

A CSV uploaded as `text/csv` therefore came back correctly from `head()` but as `application/octet-stream` from `list()`, which reads like the object was stored with the wrong type.

### The change

Both list paths now approximate the type from the key with the existing `inferTypeFromName` helper. That helper is already used for exactly this situation, backends whose protocol stores no content type, in the FTP, SFTP, Box and CLI adapters, and its own comment describes the purpose as avoiding `application/octet-stream` for everything. So this follows a convention already in the codebase rather than adding a new one.

Unknown extensions still return `application/octet-stream`, so nothing that was already correct changes and there is no behavioural regression for callers relying on the fallback.

### Scope

This fixes the whole S3-compatible family in one place. `src/s3/core.ts` backs around twenty adapters (Wasabi, MinIO, DigitalOcean Spaces, Backblaze, Tigris, Scaleway, Vultr, Alibaba, Tencent, Yandex, IBM COS, Akamai, Hetzner, Exoscale, Oracle, iDrive, Filebase, Neon, Archil, OVH), and `src/internal/s3-fetch.ts` backs the R2 HTTP adapter that the issue reports against.

The R2 workers binding is deliberately untouched. It reads a real `httpMetadata.contentType` from the binding, so it was already correct.

### On the alternatives in the issue

The issue floated returning `undefined`, documenting the fallback, or an opt-in `includeMetadata` that issues a `head()` per object. Inferring from the key seemed the best fit because it is non-breaking (`type` stays a `string`), costs no extra requests, and matches what the SDK already does elsewhere. An opt-in hydrating flag would still be a reasonable follow-up for callers who need an authoritative value, and I am happy to look at that separately if you want it.

### Tests

A test in each of `s3.test.ts` and `s3-fetch.test.ts` covers a known extension, a second known extension, and an extensionless key that still falls back. Both fail on `main` and pass with this change.

Full suite is green at 3159 passed and 14 skipped, and the pre-commit gauntlet (`ultracite check`, `turbo run types`, `test:coverage`, `build`) passes. Changeset included.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * S3 file listings now accurately infer content types from file extensions, including CSV and PNG files.
  * Files without recognized extensions continue to use a generic binary content type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->