### PR TITLE
feat: Add an endpoint override to the r2 adapter

### DIFF
--- a/.changeset/r2-endpoint-override.md
+++ b/.changeset/r2-endpoint-override.md
@@ -2,4 +2,4 @@
 "files-sdk": patch
 ---
 
-Add an optional `endpoint` to the r2 adapter (`R2HttpOptions` and hybrid-mode `R2BindingOptions`), falling back to the default `https://<accountId>.r2.cloudflarestorage.com`. Jurisdiction buckets (`eu`, `fedramp`) live on their own hostnames and were previously unreachable through the r2 adapter; the override also lets tests point the adapter at S3-compatible stand-ins like MinIO or LocalStack.
+Add an optional `endpoint` to the r2 adapter (`R2HttpOptions` and hybrid-mode `R2BindingOptions`), falling back to the default `https://<accountId>.r2.cloudflarestorage.com`. Jurisdiction buckets (`eu`, `fedramp`) live on their own hostnames and were previously unreachable through the r2 adapter; the override also lets tests point the adapter at S3-compatible stand-ins like MinIO or LocalStack. When `endpoint` is set, `accountId` becomes optional — it only ever feeds the default hostname.

--- a/.changeset/r2-endpoint-override.md
+++ b/.changeset/r2-endpoint-override.md
@@ -1,0 +1,5 @@
+---
+"files-sdk": patch
+---
+
+Add an optional `endpoint` to the r2 adapter (`R2HttpOptions` and hybrid-mode `R2BindingOptions`), falling back to the default `https://<accountId>.r2.cloudflarestorage.com`. Jurisdiction buckets (`eu`, `fedramp`) live on their own hostnames and were previously unreachable through the r2 adapter; the override also lets tests point the adapter at S3-compatible stand-ins like MinIO or LocalStack.

--- a/bun.lock
+++ b/bun.lock
@@ -44,7 +44,7 @@
     },
     "packages/files-sdk": {
       "name": "files-sdk",
-      "version": "2.2.2",
+      "version": "2.2.3",
       "bin": {
         "files": "./dist/cli/index.js",
       },

--- a/packages/files-sdk/src/r2/index.ts
+++ b/packages/files-sdk/src/r2/index.ts
@@ -68,6 +68,14 @@ export interface R2HttpOptions {
    */
   defaultUrlExpiresIn?: number;
   /**
+   * Override the S3 API endpoint. Defaults to
+   * `https://<accountId>.r2.cloudflarestorage.com`. Set it for jurisdiction
+   * buckets, which live on their own hostnames (e.g.
+   * `https://<accountId>.eu.r2.cloudflarestorage.com`), or to point the
+   * adapter at an S3-compatible stand-in (MinIO, LocalStack) in tests.
+   */
+  endpoint?: string;
+  /**
    * Which HTTP engine backs the adapter.
    *
    * - `"aws-sdk"` (default): `@aws-sdk/client-s3` — the full surface,
@@ -126,6 +134,13 @@ export interface R2BindingOptions {
    * signing (hybrid mode without `publicBaseUrl`). Defaults to 3600.
    */
   defaultUrlExpiresIn?: number;
+  /**
+   * Hybrid mode: override the S3 API endpoint used for signing. Defaults to
+   * `https://<accountId>.r2.cloudflarestorage.com`. Set it for jurisdiction
+   * buckets, which live on their own hostnames (e.g.
+   * `https://<accountId>.eu.r2.cloudflarestorage.com`).
+   */
+  endpoint?: string;
 }
 
 export type R2AdapterOptions = R2BindingOptions | R2HttpOptions;
@@ -319,7 +334,9 @@ const r2FromBinding = (opts: R2BindingOptions): R2Adapter => {
       ? s3FetchAdapter({
           accessKeyId: opts.accessKeyId,
           bucket: httpBucket,
-          endpoint: `https://${opts.accountId}.r2.cloudflarestorage.com`,
+          endpoint:
+            opts.endpoint ??
+            `https://${opts.accountId}.r2.cloudflarestorage.com`,
           forcePathStyle: true,
           name: "r2-hybrid-signer",
           providerLabel: "R2 error",
@@ -585,7 +602,8 @@ const r2FromHttp = (opts: R2HttpOptions): R2Adapter => {
       ...(opts.defaultUrlExpiresIn !== undefined && {
         defaultUrlExpiresIn: opts.defaultUrlExpiresIn,
       }),
-      endpoint: `https://${accountId}.r2.cloudflarestorage.com`,
+      endpoint:
+        opts.endpoint ?? `https://${accountId}.r2.cloudflarestorage.com`,
       ...(opts.fetch && { fetch: opts.fetch }),
       forcePathStyle: true,
       name: "r2-http-fetch",
@@ -617,7 +635,7 @@ const r2FromHttp = (opts: R2HttpOptions): R2Adapter => {
     ...(opts.defaultUrlExpiresIn !== undefined && {
       defaultUrlExpiresIn: opts.defaultUrlExpiresIn,
     }),
-    endpoint: `https://${accountId}.r2.cloudflarestorage.com`,
+    endpoint: opts.endpoint ?? `https://${accountId}.r2.cloudflarestorage.com`,
     forcePathStyle: true,
     ...(opts.publicBaseUrl && { publicBaseUrl: opts.publicBaseUrl }),
     region: "auto",

--- a/packages/files-sdk/src/r2/index.ts
+++ b/packages/files-sdk/src/r2/index.ts
@@ -42,7 +42,8 @@ export interface R2HttpOptions {
   bucket: string;
   /**
    * Cloudflare account ID. Falls back to `R2_ACCOUNT_ID` env var; required
-   * if no env var is set.
+   * if no env var is set — unless an explicit `endpoint` is passed, which
+   * makes `accountId` unnecessary.
    */
   accountId?: string;
   /**
@@ -73,6 +74,7 @@ export interface R2HttpOptions {
    * buckets, which live on their own hostnames (e.g.
    * `https://<accountId>.eu.r2.cloudflarestorage.com`), or to point the
    * adapter at an S3-compatible stand-in (MinIO, LocalStack) in tests.
+   * When set, `accountId` is not required.
    */
   endpoint?: string;
   /**
@@ -122,7 +124,8 @@ export interface R2BindingOptions {
    * needed) instead of throwing. Reads and writes still go through the
    * binding so they stay intra-Worker (no egress fees). Useful for Workers
    * that need browser-facing presigned URLs without giving up the binding's
-   * I/O performance.
+   * I/O performance. An explicit `endpoint` can stand in for `accountId`,
+   * which only feeds the default signing hostname.
    */
   accountId?: string;
   /** Hybrid mode: R2 access key ID. See `accountId`. */
@@ -138,7 +141,8 @@ export interface R2BindingOptions {
    * Hybrid mode: override the S3 API endpoint used for signing. Defaults to
    * `https://<accountId>.r2.cloudflarestorage.com`. Set it for jurisdiction
    * buckets, which live on their own hostnames (e.g.
-   * `https://<accountId>.eu.r2.cloudflarestorage.com`).
+   * `https://<accountId>.eu.r2.cloudflarestorage.com`). When set,
+   * `accountId` is not required for hybrid signing.
    */
   endpoint?: string;
 }
@@ -328,15 +332,20 @@ const r2FromBinding = (opts: R2BindingOptions): R2Adapter => {
   // go through the binding — only signing delegates. Pure Web Crypto, so a
   // hybrid Worker needs no `@aws-sdk/*` packages at all.
   const httpBucket = (opts as Partial<R2HttpOptions>).bucket;
+  // An explicit `endpoint` stands in for `accountId`, which only ever feeds
+  // the default signing hostname.
+  const signerEndpoint =
+    opts.endpoint ??
+    (opts.accountId
+      ? `https://${opts.accountId}.r2.cloudflarestorage.com`
+      : undefined);
   const hybrid =
     // oxlint-disable-next-line sonarjs/expression-complexity -- the inline && chain is what narrows each opt to a non-undefined string inside the branch; extracting the guard loses that narrowing
-    opts.accountId && opts.accessKeyId && opts.secretAccessKey && httpBucket
+    signerEndpoint && opts.accessKeyId && opts.secretAccessKey && httpBucket
       ? s3FetchAdapter({
           accessKeyId: opts.accessKeyId,
           bucket: httpBucket,
-          endpoint:
-            opts.endpoint ??
-            `https://${opts.accountId}.r2.cloudflarestorage.com`,
+          endpoint: signerEndpoint,
           forcePathStyle: true,
           name: "r2-hybrid-signer",
           providerLabel: "R2 error",
@@ -348,7 +357,7 @@ const r2FromBinding = (opts: R2BindingOptions): R2Adapter => {
     if (!hybrid) {
       throw new FilesError(
         "Provider",
-        "r2 binding: signing requires either `publicBaseUrl` (for url()) or HTTP credentials (`accountId`, `accessKeyId`, `secretAccessKey`, `bucket`) for presigned URLs. See https://developers.cloudflare.com/r2/api/s3/tokens/."
+        "r2 binding: signing requires either `publicBaseUrl` (for url()) or HTTP credentials (`accountId` or `endpoint`, plus `accessKeyId`, `secretAccessKey`, `bucket`) for presigned URLs. See https://developers.cloudflare.com/r2/api/s3/tokens/."
       );
     }
     return hybrid;
@@ -579,10 +588,15 @@ const r2FromHttp = (opts: R2HttpOptions): R2Adapter => {
   const secretAccessKey =
     opts.secretAccessKey ?? readEnv("R2_SECRET_ACCESS_KEY");
 
-  if (!accountId) {
+  // `accountId` only ever feeds the default endpoint, so an explicit
+  // `endpoint` makes it unnecessary (e.g. MinIO/LocalStack stand-ins).
+  const endpoint =
+    opts.endpoint ??
+    (accountId ? `https://${accountId}.r2.cloudflarestorage.com` : undefined);
+  if (!endpoint) {
     throw new FilesError(
       "Provider",
-      "r2 adapter: missing accountId. Pass `accountId` or set R2_ACCOUNT_ID."
+      "r2 adapter: missing accountId. Pass `accountId`, set R2_ACCOUNT_ID, or pass an explicit `endpoint`."
     );
   }
   if (!(accessKeyId && secretAccessKey)) {
@@ -602,8 +616,7 @@ const r2FromHttp = (opts: R2HttpOptions): R2Adapter => {
       ...(opts.defaultUrlExpiresIn !== undefined && {
         defaultUrlExpiresIn: opts.defaultUrlExpiresIn,
       }),
-      endpoint:
-        opts.endpoint ?? `https://${accountId}.r2.cloudflarestorage.com`,
+      endpoint,
       ...(opts.fetch && { fetch: opts.fetch }),
       forcePathStyle: true,
       name: "r2-http-fetch",
@@ -635,7 +648,7 @@ const r2FromHttp = (opts: R2HttpOptions): R2Adapter => {
     ...(opts.defaultUrlExpiresIn !== undefined && {
       defaultUrlExpiresIn: opts.defaultUrlExpiresIn,
     }),
-    endpoint: opts.endpoint ?? `https://${accountId}.r2.cloudflarestorage.com`,
+    endpoint,
     forcePathStyle: true,
     ...(opts.publicBaseUrl && { publicBaseUrl: opts.publicBaseUrl }),
     region: "auto",

--- a/packages/files-sdk/test/r2.test.ts
+++ b/packages/files-sdk/test/r2.test.ts
@@ -68,6 +68,27 @@ describe("r2 adapter — HTTP path", () => {
     expect(endpoint?.hostname).toBe("acct.eu.r2.cloudflarestorage.com");
   });
 
+  test("endpoint override makes accountId optional (S3-compatible stand-ins)", async () => {
+    const oldId = process.env.R2_ACCOUNT_ID;
+    delete process.env.R2_ACCOUNT_ID;
+    try {
+      const adapter = r2({
+        accessKeyId: "AKID",
+        bucket: "uploads",
+        endpoint: "http://localhost:9000",
+        secretAccessKey: "SECRET",
+      });
+      await adapter.head("touch").catch(() => {});
+      const client = adapter.raw as S3Client;
+      const endpoint = await client.config.endpoint?.();
+      expect(endpoint?.hostname).toBe("localhost");
+    } finally {
+      if (oldId) {
+        process.env.R2_ACCOUNT_ID = oldId;
+      }
+    }
+  });
+
   test("missing credentials throws at construction even with accountId set", () => {
     const oldKey = process.env.R2_ACCESS_KEY_ID;
     const oldSecret = process.env.R2_SECRET_ACCESS_KEY;
@@ -682,6 +703,23 @@ describe("r2 adapter — Workers binding path", () => {
       adapter: r2({
         accessKeyId: "K",
         accountId: "ACCT",
+        binding: bucket as never,
+        bucket: "uploads",
+        endpoint: "https://acct.eu.r2.cloudflarestorage.com",
+        secretAccessKey: "S",
+      }),
+    });
+    await files.upload("a.txt", "via-binding");
+    const url = await files.url("a.txt", { expiresIn: 60 });
+    expect(url).toContain("acct.eu.r2.cloudflarestorage.com");
+    expect(url).toContain("X-Amz-Signature=");
+  });
+
+  test("hybrid: endpoint override stands in for accountId", async () => {
+    const { bucket } = fakeBinding();
+    const files = new Files({
+      adapter: r2({
+        accessKeyId: "K",
         binding: bucket as never,
         bucket: "uploads",
         endpoint: "https://acct.eu.r2.cloudflarestorage.com",

--- a/packages/files-sdk/test/r2.test.ts
+++ b/packages/files-sdk/test/r2.test.ts
@@ -54,6 +54,20 @@ describe("r2 adapter — HTTP path", () => {
     expect(endpoint?.hostname).toBe("acct.r2.cloudflarestorage.com");
   });
 
+  test("endpoint override replaces the default R2 hostname (jurisdiction buckets)", async () => {
+    const adapter = r2({
+      accessKeyId: "AKID",
+      accountId: "ACCT",
+      bucket: "uploads",
+      endpoint: "https://acct.eu.r2.cloudflarestorage.com",
+      secretAccessKey: "SECRET",
+    });
+    await adapter.head("touch").catch(() => {});
+    const client = adapter.raw as S3Client;
+    const endpoint = await client.config.endpoint?.();
+    expect(endpoint?.hostname).toBe("acct.eu.r2.cloudflarestorage.com");
+  });
+
   test("missing credentials throws at construction even with accountId set", () => {
     const oldKey = process.env.R2_ACCESS_KEY_ID;
     const oldSecret = process.env.R2_SECRET_ACCESS_KEY;
@@ -662,6 +676,24 @@ describe("r2 adapter — Workers binding path", () => {
     expect(url).toContain("a.txt");
   });
 
+  test("hybrid: endpoint override is honored by the signing fallback", async () => {
+    const { bucket } = fakeBinding();
+    const files = new Files({
+      adapter: r2({
+        accessKeyId: "K",
+        accountId: "ACCT",
+        binding: bucket as never,
+        bucket: "uploads",
+        endpoint: "https://acct.eu.r2.cloudflarestorage.com",
+        secretAccessKey: "S",
+      }),
+    });
+    await files.upload("a.txt", "via-binding");
+    const url = await files.url("a.txt", { expiresIn: 60 });
+    expect(url).toContain("acct.eu.r2.cloudflarestorage.com");
+    expect(url).toContain("X-Amz-Signature=");
+  });
+
   test("hybrid: responseContentDisposition forces signing through publicBaseUrl", async () => {
     const { bucket } = fakeBinding();
     const files = new Files({
@@ -1202,6 +1234,25 @@ describe('r2 adapter — HTTP path with client: "fetch"', () => {
     expect(url).toContain("X-Amz-Signature=");
     expect(url).toContain("X-Amz-Expires=3600");
     expect(url).toContain("acct.r2.cloudflarestorage.com/uploads/a.txt");
+  });
+
+  test("endpoint override routes fetch-client requests and url() to the custom host", async () => {
+    const fake = makeFakeS3();
+    const adapter = r2({
+      accessKeyId: "K",
+      accountId: "ACCT",
+      bucket: "uploads",
+      client: "fetch",
+      endpoint: "https://acct.eu.r2.cloudflarestorage.com",
+      fetch: fake.fetchImpl,
+      secretAccessKey: "S",
+    });
+    const files = new Files({ adapter });
+    await files.upload("hello.txt", "hi");
+    const put = fake.requests[0] as Request;
+    expect(new URL(put.url).hostname).toBe("acct.eu.r2.cloudflarestorage.com");
+    const url = await files.url("hello.txt");
+    expect(url).toContain("acct.eu.r2.cloudflarestorage.com/uploads/hello.txt");
   });
 
   test("publicBaseUrl is honored by url()", async () => {


### PR DESCRIPTION
## What

Adds an optional `endpoint` to the r2 adapter — on `R2HttpOptions` and on `R2BindingOptions` (hybrid signing mode) — falling back to the current default `https://<accountId>.r2.cloudflarestorage.com` at all three construction sites (aws-sdk client, fetch client, hybrid signer).

## Why

The r2 wrapper delegates to the s3 machinery, which already accepts `endpoint` publicly — the wrapper just seals that knob shut by hardcoding the hostname. That makes two real cases unreachable:

- **Jurisdiction buckets.** R2 buckets created with a jurisdiction (`eu`, `fedramp`) live on their own hostnames (`https://<accountId>.eu.r2.cloudflarestorage.com`); the r2 adapter can't talk to them at all today, which locks out GDPR/FedRAMP-constrained users.
- **S3-compatible stand-ins.** Pointing the r2 code path at MinIO/LocalStack in CI, or at an S3-speaking proxy/gateway.

## Notes

- Fully backwards compatible — omitted `endpoint` behaves exactly as before.
- We (uploads.sh) have been running this as a pnpm patch in production to support jurisdiction buckets as BYO storage; upstreaming so we can drop the patch.
- Tests cover all three sites: aws-sdk client config, fetch-client request/presign hosts, and the hybrid binding signing fallback.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional custom endpoint configuration for R2 connections.
  * Supports jurisdiction-specific R2 hostnames and S3-compatible services.
  * `accountId` is optional when a custom endpoint is provided.
  * Custom endpoints work consistently across HTTP, hybrid binding, signing, and generated URLs.
  * Existing configurations continue using the standard R2 endpoint by default.

* **Documentation**
  * Added release documentation for the endpoint override option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->