### PR TITLE
fix: Report stored content types from R2 binding list()

### DIFF
--- a/.changeset/r2-binding-list-metadata.md
+++ b/.changeset/r2-binding-list-metadata.md
@@ -1,0 +1,5 @@
+---
+"files-sdk": patch
+---
+
+Request `httpMetadata` and `customMetadata` when listing through the R2 Workers binding, so list() reports the stored content type and metadata instead of `application/octet-stream` and `undefined`. Completes #116 for the binding path (#128 covered the S3/HTTP paths), and with exact stored values rather than extension inference, since the binding API offers them.

--- a/packages/files-sdk/src/r2/index.ts
+++ b/packages/files-sdk/src/r2/index.ts
@@ -434,6 +434,11 @@ const r2FromBinding = (opts: R2BindingOptions): R2Adapter => {
           ...(options?.limit !== undefined && { limit: options.limit }),
           ...(options?.cursor && { cursor: options.cursor }),
           ...(options?.delimiter && { delimiter: options.delimiter }),
+          // R2 omits httpMetadata/customMetadata from list() results unless
+          // explicitly requested, which would leave every item's `type` at
+          // the octet-stream default. Requesting them makes list() report
+          // the stored content type and metadata, matching head().
+          include: ["httpMetadata", "customMetadata"],
         });
       } catch (error) {
         throw mapR2Error(error);

--- a/packages/files-sdk/test/r2.test.ts
+++ b/packages/files-sdk/test/r2.test.ts
@@ -385,9 +385,24 @@ const fakeBinding = () => {
       limit?: number;
       cursor?: string;
       delimiter?: string;
+      include?: ("httpMetadata" | "customMetadata")[];
     }) {
       const prefix = opts?.prefix ?? "";
       const matched = [...map.entries()].filter(([k]) => k.startsWith(prefix));
+      // Like the real R2 binding, only expose the metadata fields the caller
+      // asked for via `include` — list() omits both by default.
+      const project = (entry: [string, BindingEntry]) => {
+        const obj = toBindingObject(entry);
+        return {
+          ...obj,
+          customMetadata: opts?.include?.includes("customMetadata")
+            ? obj.customMetadata
+            : undefined,
+          httpMetadata: opts?.include?.includes("httpMetadata")
+            ? obj.httpMetadata
+            : undefined,
+        };
+      };
       if (opts?.delimiter) {
         const delim = opts.delimiter;
         const objects: ReturnType<typeof toBindingObject>[] = [];
@@ -396,7 +411,7 @@ const fakeBinding = () => {
           const rest = entry[0].slice(prefix.length);
           const idx = rest.indexOf(delim);
           if (idx === -1) {
-            objects.push(toBindingObject(entry));
+            objects.push(project(entry));
           } else {
             delimited.add(prefix + rest.slice(0, idx + delim.length));
           }
@@ -408,7 +423,7 @@ const fakeBinding = () => {
           truncated: false,
         });
       }
-      const objects = matched.map(toBindingObject);
+      const objects = matched.map(project);
       return Promise.resolve({
         cursor: undefined,
         delimitedPrefixes: [],
@@ -794,6 +809,21 @@ describe("r2 adapter — Workers binding path", () => {
       "a/1.txt",
       "a/2.txt",
     ]);
+  });
+
+  test("binding list reports the stored content type and custom metadata, matching head()", async () => {
+    const { bucket } = fakeBinding();
+    const files = new Files({ adapter: r2({ binding: bucket as never }) });
+    await files.upload("m/report.csv", "a,b", {
+      contentType: "text/csv",
+      metadata: { source: "test" },
+    });
+    const out = await files.list({ prefix: "m/" });
+    expect(out.items).toHaveLength(1);
+    expect(out.items[0]?.type).toBe("text/csv");
+    expect(out.items[0]?.metadata).toEqual({ source: "test" });
+    const head = await files.head("m/report.csv");
+    expect(out.items[0]?.type).toBe(head.type);
   });
 
   test("binding list with a delimiter returns delimitedPrefixes", async () => {


### PR DESCRIPTION
## What

The R2 Workers-binding list() now passes `include: ["httpMetadata", "customMetadata"]`, so listed items report their stored content type and custom metadata — matching what head() returns — instead of `application/octet-stream` and `undefined`.

## Why

This completes #116 for the binding path. #128 fixed the same symptom on the S3/HTTP paths by inferring the type from the key, but the binding path was untouched — and unlike ListObjectsV2, the R2 binding API *can* return the actual stored metadata; it just omits both fields unless the caller opts in via `include`. So the binding path gets exact stored values rather than extension inference, plus `metadata` population as a bonus.

## Notes

- The test fake previously always returned `httpMetadata`/`customMetadata` from list(), which masked this — it now mimics the real binding and only exposes the fields requested via `include`.
- We (uploads.sh) have been running this as a pnpm patch in production; upstreaming so we can drop the patch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * R2 binding file listings now return stored HTTP metadata, including exact content types.
  * Custom metadata is now included in listing results when available.
  * Metadata is consistently returned for both delimiter-based and standard listings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->